### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest   # Apple Silicon (arm64); Zig cross-compiles linux targets


### PR DESCRIPTION
Potential fix for [https://github.com/dfa1/rocksdbffm/security/code-scanning/1](https://github.com/dfa1/rocksdbffm/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege defaults. For this workflow, the minimal and appropriate permission is:

- `contents: read`

This preserves existing functionality (checkout and reading repository content) while preventing unnecessary write scopes on `GITHUB_TOKEN`.  
Edit the workflow near the trigger section (`on:`) and before `jobs:` to keep structure clear and conventional. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
