### PR TITLE
chore: adopt American English spelling across project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ For the full feature status and roadmap see `README.md`.
 
 ## Code
 
+- American English everywhere (javadoc, comments, identifiers): recognize/optimize/finalize/serialize/normalize/behavior/color — never -ise/-isation/-our. Matches the JDK (Object.finalize, Serializable).
 - code is indented with tabs (enforced by checkstyle)
 - always keep the MethodHandles private static final
 - every `MH_` field must have a `/// \`<c prototype>\`` comment on the line immediately above it, copied verbatim from `rocksdb/include/rocksdb/c.h` (strip the `extern ROCKSDB_LIBRARY_API` prefix); no duplicate comment in the `static` block

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngine.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngine.java
@@ -305,7 +305,7 @@ public final class BackupEngine extends NativeObject {
 	/// before restoring.
 	///
 	/// @param dbDir destination directory for the restored database
-	/// @param restoreOptions options controlling the restore behaviour
+	/// @param restoreOptions options controlling the restore behavior
 	public void restoreDbFromLatestBackup(Path dbDir, RestoreOptions restoreOptions) {
 		restoreDbFromLatestBackup(dbDir, dbDir, restoreOptions);
 	}
@@ -314,7 +314,7 @@ public final class BackupEngine extends NativeObject {
 	///
 	/// @param dbDir destination directory for the restored database
 	/// @param walDir destination directory for WAL files
-	/// @param restoreOptions options controlling the restore behaviour
+	/// @param restoreOptions options controlling the restore behavior
 	public void restoreDbFromLatestBackup(Path dbDir, Path walDir, RestoreOptions restoreOptions) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
@@ -331,7 +331,7 @@ public final class BackupEngine extends NativeObject {
 	///
 	/// @param backupId the identifier of the backup to restore
 	/// @param dbDir destination directory for the restored database
-	/// @param restoreOptions options controlling the restore behaviour
+	/// @param restoreOptions options controlling the restore behavior
 	public void restoreDbFromBackup(BackupId backupId, Path dbDir, RestoreOptions restoreOptions) {
 		restoreDbFromBackup(backupId, dbDir, dbDir, restoreOptions);
 	}
@@ -341,7 +341,7 @@ public final class BackupEngine extends NativeObject {
 	/// @param backupId the identifier of the backup to restore
 	/// @param dbDir destination directory for the restored database
 	/// @param walDir destination directory for WAL files
-	/// @param restoreOptions options controlling the restore behaviour
+	/// @param restoreOptions options controlling the restore behavior
 	public void restoreDbFromBackup(BackupId backupId, Path dbDir, Path walDir, RestoreOptions restoreOptions) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
@@ -191,7 +191,7 @@ public final class BlobDB extends NativeObject {
 
 	/// Flushes all memtable data to SST/blob files. Blocks when [FlushOptions#isWait()] is `true`.
 	///
-	/// @param flushOptions options controlling flush behaviour (e.g. wait)
+	/// @param flushOptions options controlling flush behavior (e.g. wait)
 	public void flush(FlushOptions flushOptions) {
 		RocksDB.flush(ptr(), flushOptions);
 	}
@@ -231,7 +231,7 @@ public final class BlobDB extends NativeObject {
 	/// Ingests SST files produced by [SstFileWriter] into the database.
 	///
 	/// @param files paths to SST files to ingest
-	/// @param options options controlling the ingest behaviour
+	/// @param options options controlling the ingest behavior
 	public void ingestExternalFile(List<Path> files, IngestExternalFileOptions options) {
 		if (files.isEmpty()) {
 			return;

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/LogLevel.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/LogLevel.java
@@ -14,7 +14,7 @@ public enum LogLevel {
 	ERROR(3),
 	/// Fatal errors; the DB will likely be unusable after this.
 	FATAL(4),
-	/// Header lines emitted at startup that summarise configuration.
+	/// Header lines emitted at startup that summarize configuration.
 	HEADER(5);
 
 	final int value;

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObject.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObject.java
@@ -13,7 +13,7 @@ public abstract class NativeObject implements AutoCloseable {
 
 	private final AtomicReference<MemorySegment> owningPointer;
 
-	/// Initialises this wrapper with the given native pointer.
+	/// Initializes this wrapper with the given native pointer.
 	///
 	/// @param owningPointer the non-NULL native pointer this object now owns
 	protected NativeObject(MemorySegment owningPointer) {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -299,7 +299,7 @@ public final class ReadWriteDB extends NativeObject {
 
 	/// Blocks until all current compactions finish, subject to the given [WaitForCompactOptions].
 	///
-	/// @param options  options controlling wait behaviour (e.g. abort-on-pause)
+	/// @param options  options controlling wait behavior (e.g. abort-on-pause)
 	/// @throws RocksDBException on I/O error or if [WaitForCompactOptions#isAbortOnPause()] is
 	///                          `true` and background work is paused
 	public void waitForCompact(WaitForCompactOptions options) {
@@ -334,7 +334,7 @@ public final class ReadWriteDB extends NativeObject {
 
 	/// Flushes all memtable data to SST files. Blocks when [FlushOptions#isWait()] is `true`.
 	///
-	/// @param flushOptions options controlling flush behaviour
+	/// @param flushOptions options controlling flush behavior
 	public void flush(FlushOptions flushOptions) {
 		RocksDB.flush(ptr(), flushOptions);
 	}
@@ -765,7 +765,7 @@ public final class ReadWriteDB extends NativeObject {
 	/// Flushes the memtable for `cf` to SST files.
 	///
 	/// @param cf          target column family
-	/// @param flushOptions options controlling flush behaviour
+	/// @param flushOptions options controlling flush behavior
 	public void flush(ColumnFamilyHandle cf, FlushOptions flushOptions) {
 		RocksDB.flushCf(ptr(), flushOptions, cf);
 	}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RestoreOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RestoreOptions.java
@@ -7,7 +7,7 @@ import java.lang.invoke.MethodHandle;
 
 /// FFM wrapper for `rocksdb_restore_options_t`.
 ///
-/// Controls behaviour when restoring a backup via [BackupEngine].
+/// Controls behavior when restoring a backup via [BackupEngine].
 ///
 /// ```
 /// try (var restoreOpts = RestoreOptions.create().setKeepLogFiles(false);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -410,7 +410,7 @@ public final class RocksDB {
 	// -----------------------------------------------------------------------
 
 	/// Opens a read-write database at `path`.
-	/// Use [Options#setCreateIfMissing(boolean)] to control behaviour when
+	/// Use [Options#setCreateIfMissing(boolean)] to control behavior when
 	/// the path does not exist.
 	///
 	/// @param options the database options

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -169,7 +169,7 @@ public final class TransactionDB extends NativeObject {
 	/// Flushes all memtable data to SST files on disk.
 	/// Blocks until the flush completes when [FlushOptions#isWait()] is `true`.
 	///
-	/// @param flushOptions options controlling flush behaviour
+	/// @param flushOptions options controlling flush behavior
 	public void flush(FlushOptions flushOptions) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
@@ -686,7 +686,7 @@ public final class TransactionDB extends NativeObject {
 	/// Flushes the memtable for `cf` to SST files.
 	///
 	/// @param cf           target column family
-	/// @param flushOptions options controlling flush behaviour
+	/// @param flushOptions options controlling flush behavior
 	public void flush(ColumnFamilyHandle cf, FlushOptions flushOptions) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
@@ -485,7 +485,7 @@ public final class TtlDB extends NativeObject {
 	/// Flushes the memtable for `cf` to SST files.
 	///
 	/// @param cf           column family to flush
-	/// @param flushOptions flush options controlling wait behaviour
+	/// @param flushOptions flush options controlling wait behavior
 	public void flush(ColumnFamilyHandle cf, FlushOptions flushOptions) {
 		RocksDB.flushCf(ptr(), flushOptions, cf);
 	}
@@ -567,7 +567,7 @@ public final class TtlDB extends NativeObject {
 
 	/// Flushes all memtable data to SST files. Blocks when [FlushOptions#isWait()] is `true`.
 	///
-	/// @param flushOptions flush options controlling wait behaviour
+	/// @param flushOptions flush options controlling wait behavior
 	public void flush(FlushOptions flushOptions) {
 		RocksDB.flush(ptr(), flushOptions);
 	}
@@ -671,7 +671,7 @@ public final class TtlDB extends NativeObject {
 	/// Ingests SST files produced by [SstFileWriter] into the database.
 	///
 	/// @param files   list of SST file paths to ingest
-	/// @param options ingest options controlling behaviour on conflicts
+	/// @param options ingest options controlling behavior on conflicts
 	public void ingestExternalFile(List<Path> files, IngestExternalFileOptions options) {
 		if (files.isEmpty()) {
 			return;
@@ -691,7 +691,7 @@ public final class TtlDB extends NativeObject {
 	/// Ingests a single SST file with explicit [IngestExternalFileOptions].
 	///
 	/// @param file    SST file path to ingest
-	/// @param options ingest options controlling behaviour on conflicts
+	/// @param options ingest options controlling behavior on conflicts
 	public void ingestExternalFile(Path file, IngestExternalFileOptions options) {
 		ingestExternalFile(List.of(file), options);
 	}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WaitForCompactOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WaitForCompactOptions.java
@@ -6,7 +6,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.time.Duration;
 
-/// Options controlling the behaviour of [ReadWriteDB#waitForCompact].
+/// Options controlling the behavior of [ReadWriteDB#waitForCompact].
 ///
 /// ```
 /// try (WaitForCompactOptions opts = WaitForCompactOptions.create()


### PR DESCRIPTION
## Summary

Adopt American English across the project, per request.

1. **CLAUDE.md** — new code-convention rule: American English everywhere (javadoc, comments, identifiers); never -ise/-isation/-our. Matches the JDK (`Object.finalize`, `Serializable`).
2. **Normalize existing spellings** (javadoc/comments only):
   - `behaviour` → `behavior` — BackupEngine, BlobDB, ReadWriteDB, RestoreOptions, RocksDB, TransactionDB, TtlDB, WaitForCompactOptions
   - `summarise` → `summarize` — LogLevel

## Scope notes

- Scanned all tracked `*.java/*.md/*.yml/*.yaml/*.xml/*.sh/*.txt` (excluding vendored `rocksdb/`).
- False positives guarded (exercise, raise, otherwise, enterprise, disable, etc.) — none touched.
- No public API identifiers renamed; all changes are in javadoc/comments. Nothing to flag for API breakage.
- Other British forms from the checklist (serialise, optimise, colour, analyse, licence, …) were searched for — **none present** in non-vendored sources.

## Verification

- `./mvnw test` — BUILD SUCCESS
- `./mvnw javadoc:javadoc -pl core` — zero warnings
- Checkstyle — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)