### PR TITLE
fix: scope iterator segments to the current position

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
@@ -100,6 +100,13 @@ public final class RocksIterator extends NativeObject {
 	private final Arena lenArena;
 	private final MemorySegment lenSegment;
 
+	/// Scopes the segments handed out by [#keySegment()] and [#valueSegment()].
+	/// Created on demand and closed by the next positioning call, so a segment
+	/// used after the iterator moves throws [IllegalStateException] instead of
+	/// silently reading the new position. Callers that never touch the segment
+	/// tier never allocate one.
+	private Arena segmentArena;
+
 	/// Package-private: created via [#create].
 	private RocksIterator(MemorySegment ptr) {
 		super(ptr);
@@ -123,11 +130,39 @@ public final class RocksIterator extends NativeObject {
 	}
 
 	// -----------------------------------------------------------------------
+	// Segment lifetime
+	// -----------------------------------------------------------------------
+
+	/// Invalidates every segment previously returned by [#keySegment()] and
+	/// [#valueSegment()].
+	///
+	/// `rocksdb_iter_key` and `rocksdb_iter_value` hand back a pointer into a
+	/// buffer the iterator reuses in place, so the address does not change when
+	/// the iterator moves — only its contents do. A segment that outlived a move
+	/// would therefore keep reading, and silently report the new position's
+	/// bytes. Closing the scope turns that into an [IllegalStateException].
+	private void invalidateSegments() {
+		if (segmentArena != null) {
+			segmentArena.close();
+			segmentArena = null;
+		}
+	}
+
+	/// Wraps `data` in a segment of `length` bytes scoped to the current position.
+	private MemorySegment scopedToPosition(MemorySegment data, long length) {
+		if (segmentArena == null) {
+			segmentArena = Arena.ofConfined();
+		}
+		return data.reinterpret(length, segmentArena, null);
+	}
+
+	// -----------------------------------------------------------------------
 	// Positioning
 	// -----------------------------------------------------------------------
 
 	/// Positions the iterator at the first key in the database.
 	public void seekToFirst() {
+		invalidateSegments();
 		try {
 			MH_SEEK_TO_FIRST.invokeExact(ptr());
 		} catch (Throwable t) {
@@ -137,6 +172,7 @@ public final class RocksIterator extends NativeObject {
 
 	/// Positions the iterator at the last key in the database.
 	public void seekToLast() {
+		invalidateSegments();
 		try {
 			MH_SEEK_TO_LAST.invokeExact(ptr());
 		} catch (Throwable t) {
@@ -148,6 +184,7 @@ public final class RocksIterator extends NativeObject {
 	///
 	/// @param target the seek target key
 	public void seek(byte[] target) {
+		invalidateSegments();
 		try (Arena arena = Arena.ofConfined()) {
 			MH_SEEK.invokeExact(ptr(), RocksDB.toNative(arena, target), (long) target.length);
 		} catch (Throwable t) {
@@ -159,6 +196,7 @@ public final class RocksIterator extends NativeObject {
 	///
 	/// @param target direct [ByteBuffer] containing the seek target key
 	public void seek(ByteBuffer target) {
+		invalidateSegments();
 		try {
 			MH_SEEK.invokeExact(ptr(), MemorySegment.ofBuffer(target), (long) target.remaining());
 		} catch (Throwable t) {
@@ -170,6 +208,7 @@ public final class RocksIterator extends NativeObject {
 	///
 	/// @param target native segment containing the seek target key
 	public void seek(MemorySegment target) {
+		invalidateSegments();
 		try {
 			MH_SEEK.invokeExact(ptr(), target, target.byteSize());
 		} catch (Throwable t) {
@@ -181,6 +220,7 @@ public final class RocksIterator extends NativeObject {
 	///
 	/// @param target the seek target key
 	public void seekForPrev(byte[] target) {
+		invalidateSegments();
 		try (Arena arena = Arena.ofConfined()) {
 			MH_SEEK_FOR_PREV.invokeExact(ptr(), RocksDB.toNative(arena, target), (long) target.length);
 		} catch (Throwable t) {
@@ -192,6 +232,7 @@ public final class RocksIterator extends NativeObject {
 	///
 	/// @param target direct [ByteBuffer] containing the seek target key
 	public void seekForPrev(ByteBuffer target) {
+		invalidateSegments();
 		try {
 			MH_SEEK_FOR_PREV.invokeExact(ptr(), MemorySegment.ofBuffer(target), (long) target.remaining());
 		} catch (Throwable t) {
@@ -203,6 +244,7 @@ public final class RocksIterator extends NativeObject {
 	///
 	/// @param target native segment containing the seek target key
 	public void seekForPrev(MemorySegment target) {
+		invalidateSegments();
 		try {
 			MH_SEEK_FOR_PREV.invokeExact(ptr(), target, target.byteSize());
 		} catch (Throwable t) {
@@ -212,6 +254,7 @@ public final class RocksIterator extends NativeObject {
 
 	/// Moves to the next key. Only call when [#isValid()] is true.
 	public void next() {
+		invalidateSegments();
 		try {
 			MH_NEXT.invokeExact(ptr());
 		} catch (Throwable t) {
@@ -221,6 +264,7 @@ public final class RocksIterator extends NativeObject {
 
 	/// Moves to the previous key. Only call when [#isValid()] is true.
 	public void prev() {
+		invalidateSegments();
 		try {
 			MH_PREV.invokeExact(ptr());
 		} catch (Throwable t) {
@@ -281,6 +325,7 @@ public final class RocksIterator extends NativeObject {
 	/// Refreshes the iterator to reflect the latest DB state after mutations.
 	/// Repositions to the same key if it still exists.
 	public void refresh() {
+		invalidateSegments();
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MH_REFRESH.invokeExact(ptr(), err);
@@ -295,28 +340,40 @@ public final class RocksIterator extends NativeObject {
 	// -----------------------------------------------------------------------
 
 	/// Returns a zero-copy view of the current key.
-	/// The returned segment is only valid until the next positioning call.
+	///
+	/// The returned segment is scoped to the current position: the next
+	/// positioning call ([#next()], [#seek(byte[])], …) and [#close()] both
+	/// invalidate it, after which any access throws [IllegalStateException].
+	/// Copy the bytes out with [#key()] if you need them to outlive the
+	/// position.
+	///
 	/// Only call when [#isValid()] is true.
 	///
-	/// @return native segment pointing to the current key
+	/// @return native segment pointing to the current key, valid until the iterator moves
 	public MemorySegment keySegment() {
 		try {
 			MemorySegment data = (MemorySegment) MH_KEY.invokeExact(ptr(), lenSegment);
-			return data.reinterpret(lenSegment.get(ValueLayout.JAVA_LONG, 0));
+			return scopedToPosition(data, lenSegment.get(ValueLayout.JAVA_LONG, 0));
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("key failed", t);
 		}
 	}
 
 	/// Returns a zero-copy view of the current value.
-	/// The returned segment is only valid until the next positioning call.
+	///
+	/// The returned segment is scoped to the current position: the next
+	/// positioning call ([#next()], [#seek(byte[])], …) and [#close()] both
+	/// invalidate it, after which any access throws [IllegalStateException].
+	/// Copy the bytes out with [#value()] if you need them to outlive the
+	/// position.
+	///
 	/// Only call when [#isValid()] is true.
 	///
-	/// @return native segment pointing to the current value
+	/// @return native segment pointing to the current value, valid until the iterator moves
 	public MemorySegment valueSegment() {
 		try {
 			MemorySegment data = (MemorySegment) MH_VALUE.invokeExact(ptr(), lenSegment);
-			return data.reinterpret(lenSegment.get(ValueLayout.JAVA_LONG, 0));
+			return scopedToPosition(data, lenSegment.get(ValueLayout.JAVA_LONG, 0));
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("value failed", t);
 		}
@@ -400,6 +457,9 @@ public final class RocksIterator extends NativeObject {
 
 	@Override
 	protected void tryClose(MemorySegment ptr) throws Throwable {
+		// Invalidate before destroying: the segments point into the iterator's
+		// own buffer, which rocksdb_iter_destroy frees.
+		invalidateSegments();
 		MH_DESTROY.invokeExact(ptr);
 		lenArena.close();
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RocksIteratorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RocksIteratorTest.java
@@ -3,12 +3,15 @@ package io.github.dfa1.rocksdbffm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RocksIteratorTest {
 
@@ -217,6 +220,144 @@ class RocksIteratorTest {
 						.isEqualTo("k".getBytes());
 				assertThat(valSeg.toArray(java.lang.foreign.ValueLayout.JAVA_BYTE))
 						.isEqualTo("v".getBytes());
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Segment lifetime
+	//
+	// rocksdb_iter_key/_value return a pointer into a buffer the iterator
+	// reuses in place. The address is stable across moves, so a segment that
+	// outlives its position would silently report the *new* position's bytes
+	// rather than fail. These tests pin the invalidation that prevents that.
+	// -----------------------------------------------------------------------
+
+	@Test
+	void keySegment_isInvalidated_byNext(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("aaaa".getBytes(), "1111".getBytes());
+			db.put("bbbb".getBytes(), "2222".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+				var firstKey = it.keySegment();
+				assertThat(firstKey.toArray(ValueLayout.JAVA_BYTE)).isEqualTo("aaaa".getBytes());
+
+				// When
+				it.next();
+
+				// Then
+				assertThatThrownBy(() -> firstKey.toArray(ValueLayout.JAVA_BYTE))
+						.as("must not silently report the new position's bytes")
+						.isInstanceOf(IllegalStateException.class);
+			}
+		}
+	}
+
+	@Test
+	void valueSegment_isInvalidated_byNext(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("aaaa".getBytes(), "1111".getBytes());
+			db.put("bbbb".getBytes(), "2222".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+				var firstValue = it.valueSegment();
+
+				// When
+				it.next();
+
+				// Then
+				assertThatThrownBy(() -> firstValue.toArray(ValueLayout.JAVA_BYTE))
+						.isInstanceOf(IllegalStateException.class);
+			}
+		}
+	}
+
+	@Test
+	void keySegment_isInvalidated_bySeek(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("aaaa".getBytes(), "1111".getBytes());
+			db.put("bbbb".getBytes(), "2222".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+				var firstKey = it.keySegment();
+
+				// When
+				it.seek("bbbb".getBytes());
+
+				// Then
+				assertThatThrownBy(() -> firstKey.toArray(ValueLayout.JAVA_BYTE))
+						.isInstanceOf(IllegalStateException.class);
+			}
+		}
+	}
+
+	@Test
+	void keySegment_isInvalidated_byIteratorClose(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("aaaa".getBytes(), "1111".getBytes());
+
+			MemorySegment escaped;
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+				escaped = it.keySegment();
+			}
+
+			// When / Then — the iterator's buffer is freed by rocksdb_iter_destroy,
+			// so this must throw rather than read freed memory
+			assertThatThrownBy(() -> escaped.toArray(ValueLayout.JAVA_BYTE))
+					.isInstanceOf(IllegalStateException.class);
+		}
+	}
+
+	@Test
+	void keySegment_collectedAcrossIteration_failsLoudly(@TempDir Path dir) {
+		// Given — the natural-looking idiom that used to silently produce
+		// N references all showing the last key
+		try (var db = RocksDB.open(dir)) {
+			db.put("aaaa".getBytes(), "1111".getBytes());
+			db.put("bbbb".getBytes(), "2222".getBytes());
+			db.put("cccc".getBytes(), "3333".getBytes());
+
+			List<MemorySegment> collected = new ArrayList<>();
+			try (RocksIterator it = db.newIterator()) {
+				for (it.seekToFirst(); it.isValid(); it.next()) {
+					collected.add(it.keySegment());
+				}
+			}
+
+			// When / Then
+			assertThat(collected).hasSize(3);
+			assertThatThrownBy(() -> collected.getFirst().toArray(ValueLayout.JAVA_BYTE))
+					.isInstanceOf(IllegalStateException.class);
+		}
+	}
+
+	@Test
+	void keySegment_staysValid_whileIteratorDoesNotMove(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("aaaa".getBytes(), "1111".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+
+				// When — non-positioning calls must not invalidate
+				var key = it.keySegment();
+				var value = it.valueSegment();
+				boolean valid = it.isValid();
+
+				// Then
+				assertThat(valid).isTrue();
+				assertThat(key.toArray(ValueLayout.JAVA_BYTE)).isEqualTo("aaaa".getBytes());
+				assertThat(value.toArray(ValueLayout.JAVA_BYTE)).isEqualTo("1111".getBytes());
 			}
 		}
 	}


### PR DESCRIPTION
`RocksIterator.keySegment()` / `valueSegment()` returned segments that were never invalidated, so using one after the iterator moved silently returned the **wrong data** rather than failing.

## The bug

Both accessors did `data.reinterpret(len)` on a raw pointer (`RocksIterator.java:302`, `:316`), which produces a **global-scope** segment — no lifetime, no bounds on validity.

That interacts badly with how the C API works: `rocksdb_iter_key`/`_value` return a pointer into a buffer the iterator **reuses in place**. The address is stable across moves; only the contents change. So a stale segment doesn't dangle in a detectable way — it silently re-points at wherever the iterator now is.

Probe against a 3-key DB, before the fix:

```
scope-is-global?          true
before next():            aaaa
after  next():            bbbb     <-- same segment, contents changed
after  next() x2:         cccc
after iterator close():   cccc     <-- use-after-free, no exception
```

Which makes the obvious idiom quietly produce garbage:

```java
for (it.seekToFirst(); it.isValid(); it.next()) {
    keys.add(it.keySegment());   // every element ends up showing the LAST key
}
```

The read after `close()` is a real use-after-free — `rocksdb_iter_destroy` frees that buffer — which survived only because the memory was still mapped.

## The fix

Segments are now scoped to a confined `Arena` created on demand, which every positioning method (`seekToFirst`, `seekToLast`, `seek`×3, `seekForPrev`×3, `next`, `prev`, `refresh`) and `tryClose()` close. Using a segment after a move throws `IllegalStateException`.

This is the safety property FFM gives Java that JNI could not: a segment whose scope is closed *throws* rather than reading freed memory.

Callers who never touch the segment tier never allocate an `Arena` — they pay one null check per positioning call.

## Cost

200k entries, best of 7 runs, wall clock (not JMH — treat as indicative):

| Path | Before | After | |
|:---|---:|---:|:---|
| `keySegment()` + `valueSegment()` | 62 ns/entry | 68 ns/entry | ~+10% |
| `key()` / `value()` (`byte[]`) | 68 ns/entry | 69 ns/entry | noise |

The cost falls only on the tier that had the bug, and buys a loud failure instead of silent corruption.

## Tests

Six new tests in `RocksIteratorTest` pin the behaviour: invalidation by `next()`, by `seek()`, by iterator `close()`, the collect-across-iteration idiom failing loudly, and — importantly — that non-positioning calls like `isValid()` do **not** invalidate.

`./mvnw test` → 363 tests, 0 failures.

## Note

This is phase 2 of the read-path redesign discussed for `getPinned`/`PinnedResult`, landed on its own because it is an independent live bug. It does not change any signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)