### PR TITLE
feat: add getPinned returning a sealed PinnedResult

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,11 @@ For every feature, provide three tiers of access:
 2. **`ByteBuffer` Version:** For compatibility with existing NIO-based clients.
 3. **`byte[]` Version:** Quick access for convenience (explicitly documented as slower).
 
+**On the read path, the tiers describe the *key* only.** The value comes back as a `PinnedResult` from `getPinned` —
+a borrowed `MemorySegment` whose `byteSize()` is the length — not through a caller-supplied destination buffer. The
+older `get(ByteBuffer, ByteBuffer)` / `get(MemorySegment, MemorySegment)` copy-into overloads silently truncate when
+the destination is too small and are on the way out (see issue #47); do not add new ones or extend them to new types.
+
 ## ⚡ FFM Performance & Patterns
 
 ### 1. Centralized Error Handling
@@ -147,6 +152,7 @@ For the full feature status and roadmap see `README.md`.
 | Feature                 | Java source files                                                                                                         |
 |:------------------------|:--------------------------------------------------------------------------------------------------------------------------|
 | DB Open/Close/Put/Get/Delete | `RocksDB.java`                                                                                                       |
+| Pinned reads            | `PinnedResult.java` (sealed: `Found` / `NotFound`), `PinnableSlice.java`; `getPinned` on every DB type + `Transaction`, all key tiers, CF variants |
 | Options                 | `Options.java`, `ReadOptions.java`, `WriteOptions.java`                                                                   |
 | WriteBatch              | `WriteBatch.java`                                                                                                         |
 | Transactions            | `Transaction.java`, `TransactionDB.java`, `TransactionDBOptions.java`, `TransactionOptions.java`                          |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,10 @@ Here the constraint is enforced at compile time — `ReadOnlyDB` simply has no `
 ### Exceptions for all errors
 
 Every operation that can fail throws `RocksDBException` (an unchecked exception). `rocksdbjni` historically returned
-`null`, `-1`, or relied on status objects that callers could silently ignore. Here a failure is always loud.
+`null`, `-1`, or relied on status objects that callers could silently ignore.
+
+The one place this is not yet true is the copy-into read overloads, which inherit rocksdbjni's length-or-`-1` encoding
+and its silent truncation — see [Pinned reads](#pinned-reads-absence-is-a-type-not-a-sentinel) below.
 
 ### Domain primitives instead of raw scalars
 
@@ -174,9 +177,40 @@ Raw numeric types carry no unit information and cannot be validated at construct
 |:---------------------|:-------------------------|:----------------------|
 | Cache / buffer sizes | `long` (bytes, silently) | `MemorySize.ofMB(64)` |
 | Snapshot position    | `long`                   | `SequenceNumber`      |
+| Read outcome         | `int` (length, or `-1`)  | `PinnedResult`        |
 
-Both types are immutable, `Comparable`, and reject invalid values at construction — an illegal value cannot be created
-and therefore cannot be passed anywhere.
+Both scalar types are immutable, `Comparable`, and reject invalid values at construction — an illegal value cannot be
+created and therefore cannot be passed anywhere.
+
+### Pinned reads: absence is a type, not a sentinel
+
+`getPinned` borrows the value straight from the block cache and reports absence as a case of its return type:
+
+```java
+try (PinnedResult result = db.getPinned(key)) {
+    switch (result) {
+        case PinnedResult.Found found -> consume(found.value());  // MemorySegment
+        case PinnedResult.NotFound ignored -> handleMiss();
+    }
+}
+```
+
+Three properties fall out of the shape:
+
+- **The length is intrinsic.** `found.value()` is a `MemorySegment` whose `byteSize()` *is* the value length. There is
+  no caller-supplied capacity, so a value that does not fit is not a representable state.
+- **Absence cannot be misread.** `NotFound` carries no length, so it cannot be confused with a present-but-empty value —
+  a distinction the `MemorySegment` copy-into overload cannot express, since it reports `0` for both.
+- **Expiry is checked.** The borrowed segment is scoped to the result; touching it after the try-with-resources throws
+  `IllegalStateException` rather than reading freed memory.
+
+The cost is that a `Found` keeps its block-cache entry pinned until closed, which is why the result is `AutoCloseable`
+and belongs in a try-with-resources rather than a field.
+
+> **Known gap.** The older copy-into overloads — `get(ByteBuffer, ByteBuffer)` and `get(MemorySegment, MemorySegment)` —
+> still copy as much as fits and return the *full* length, so a destination that is too small is silently truncated. The
+> caller must compare the return value against their own capacity to notice. `getPinned` is the fix; retiring those
+> overloads is tracked in [#47](https://github.com/dfa1/rocksdbffm/issues/47).
 
 ### `Path` for filesystem operations
 
@@ -232,6 +266,7 @@ This project is currently experimental. The table below tracks parity with `rock
 |:---------------------------|:------:|:-------------------------------------------------------------------------------------------------------------------------------------------------|
 | DB Open/Create             |   ✅    | Options, CreateIfMissing, ReadOnly                                                                                                               |
 | Put/Get/Delete             |   ✅    | byte[], ByteBuffer, MemorySegment; zero-copy via PinnableSlice                                                                                   |
+| Pinned reads               |   ✅    | `getPinned` → `PinnedResult` (`Found` / `NotFound`); borrowed `MemorySegment`, no sentinel, no truncation                                        |
 | WriteBatch                 |   ✅    | Atomic multi-op writes                                                                                                                           |
 | Transactions (pessimistic) |   ✅    | TransactionDB, savepoints, get-for-update                                                                                                        |
 | Checkpoints                |   ✅    | Point-in-time on-disk snapshot                                                                                                                   |

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/PinnedReuseBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/PinnedReuseBenchmark.java
@@ -1,0 +1,160 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+/// Does reusing one caller-owned slice across several gets beat allocating per get?
+///
+/// **The native allocation cannot be avoided either way.** `rocksdb_get_pinned` does
+/// `new (rocksdb_pinnableslice_t)` on every call and `c.h` exposes no
+/// `rocksdb_pinnableslice_create`, so the C++ pattern of one reused `PinnableSlice`
+/// with `Reset()` between gets is not reachable through the C API. What reuse can
+/// save is strictly the Java side: the wrapper, the [PinnedResult.Found] record, the
+/// confined [Arena] that scopes the borrowed segment, and the length holder.
+///
+/// So this measures the **ceiling** on any reuse API:
+///
+///   - `perGet` — today's public API. One arena, one wrapper and one record per get.
+///   - `reused` — everything hoisted out of the loop: one arena, one error holder and
+///     one length holder for the whole batch, zero Java allocation per get. This is
+///     what a caller-owned reused slice would compile down to at best.
+///
+/// `gets` is the number of reads per benchmark invocation, so the 1-vs-2-vs-many
+/// question is answered directly. If the two converge, a reuse API buys nothing and
+/// the per-get shape stays; if `reused` pulls ahead as `gets` grows, the gap is what
+/// such an API would be worth — and the price is the borrowed segment losing its
+/// scope, which is the use-after-free protection issue #45 was filed to add.
+///
+/// Lives in the library's own package to reach the package-private experiment hooks.
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 3, jvmArgsPrepend = {"--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow"})
+public class PinnedReuseBenchmark {
+
+	/// Reads performed per invocation, doubling, so any amortization shows up as a
+	/// trend rather than two points. 1 is the control: if reuse only pays off across a
+	/// batch, the gain at 1 should be nil.
+	@Param({"1", "2", "4", "8", "16", "32"})
+	public int gets;
+
+	/// Value size in bytes, spanning the realistic range: 8 is a timestamp or counter,
+	/// 64 a small record, 4096 a page, 65536 a blob. The pinned path is dominated by
+	/// fixed overhead at the small end — which is exactly where per-get allocation
+	/// shows up — and by data movement at the large end.
+	@Param({"8", "64", "4096", "65536"})
+	public int valueSize;
+
+	private static final int KEY_COUNT = 32;
+
+	private ReadWriteDB db;
+	private Path dbPath;
+
+	private Arena arena;
+	private MemorySegment[] keys;
+
+	/// Hoisted scratch for the reused variant — allocated once for the whole trial.
+	private MemorySegment err;
+	private MemorySegment lenHolder;
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		dbPath = Files.createTempDirectory("bench-reuse-");
+		db = RocksDB.open(dbPath);
+
+		byte[] value = new byte[valueSize];
+		for (int i = 0; i < valueSize; i++) {
+			value[i] = (byte) i;
+		}
+
+		arena = Arena.ofConfined();
+		keys = new MemorySegment[KEY_COUNT];
+		for (int i = 0; i < KEY_COUNT; i++) {
+			byte[] key = ("reuse-key-" + i).getBytes();
+			db.put(key, value);
+			keys[i] = arena.allocateFrom(ValueLayout.JAVA_BYTE, key);
+		}
+
+		err = RocksDB.errHolder(arena);
+		lenHolder = arena.allocate(ValueLayout.JAVA_LONG);
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() throws IOException {
+		db.close();
+		arena.close();
+		try (Stream<Path> paths = Files.walk(dbPath)) {
+			paths.sorted(Comparator.reverseOrder()).forEach(p -> {
+				try {
+					Files.delete(p);
+				} catch (IOException e) {
+					throw new java.io.UncheckedIOException(e);
+				}
+			});
+		}
+	}
+
+	/// Today's API: a fresh arena, wrapper and record for every get.
+	@Benchmark
+	public long perGet() {
+		long sum = 0;
+		for (int i = 0; i < gets; i++) {
+			try (PinnedResult result = db.getPinned(keys[i & (KEY_COUNT - 1)])) {
+				sum += switch (result) {
+					case PinnedResult.Found found -> found.value().get(ValueLayout.JAVA_BYTE, 0);
+					case PinnedResult.NotFound ignored -> 0;
+				};
+			}
+		}
+		return sum;
+	}
+
+	/// The ceiling: nothing allocated per get, and the value segment carries no scope.
+	@Benchmark
+	public long reused() {
+		long sum = 0;
+		for (int i = 0; i < gets; i++) {
+			MemorySegment pin = db.getPinnedRaw(keys[i & (KEY_COUNT - 1)], err);
+			if (!MemorySegment.NULL.equals(pin)) {
+				try {
+					sum += PinnableSlice.valueInto(pin, lenHolder).get(ValueLayout.JAVA_BYTE, 0);
+				} finally {
+					PinnableSlice.destroy(pin);
+				}
+			}
+		}
+		return sum;
+	}
+
+	static void main() throws Exception {
+		org.openjdk.jmh.runner.options.Options opt = new OptionsBuilder()
+				.include(PinnedReuseBenchmark.class.getSimpleName())
+				.build();
+
+		new org.openjdk.jmh.runner.Runner(opt).run();
+	}
+}

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/PinnedReadBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/PinnedReadBenchmark.java
@@ -1,0 +1,167 @@
+package io.github.dfa1.rocksdbffm.benchmark;
+
+import io.github.dfa1.rocksdbffm.PinnedResult;
+import io.github.dfa1.rocksdbffm.ReadWriteDB;
+import io.github.dfa1.rocksdbffm.RocksDB;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/// Compares the pinned read path against the copying tiers across value sizes.
+///
+/// The interesting variable is value size: `getPinned` avoids a `memcpy` of the
+/// whole value, so any advantage should grow with it and be invisible at the
+/// 26-byte values [FfmBenchmark] uses.
+///
+/// Two consumption patterns are measured, because they answer different questions:
+///
+///   - **peek** — read a few bytes out of the value (a header, a tag, a length
+///     prefix). The copying tiers must still materialize the entire value to hand
+///     you any of it; the pinned path does not.
+///   - **full** — get every byte onto the Java heap. Here the copy is unavoidable
+///     and the pinned path only moves who performs it, so the tiers should converge.
+///
+/// There is no JNI column: rocksdbjni exposes no `PinnableSlice` to Java, so the
+/// borrowed-value shape has no counterpart to compare against.
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 1, jvmArgsPrepend = {"--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow"})
+public class PinnedReadBenchmark {
+
+	/// Value sizes in bytes: small enough to be dominated by call overhead, through
+	/// to large enough that the copy dominates.
+	@Param({"32", "256", "4096", "65536"})
+	public int valueSize;
+
+	private static final byte[] KEY = "pinned-read-key".getBytes();
+
+	private ReadWriteDB db;
+	private Path dbPath;
+
+	private Arena arena;
+	private MemorySegment keySegment;
+	/// Destination for the copy-into tier, sized to the current parameter.
+	private MemorySegment destSegment;
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		dbPath = Files.createTempDirectory("bench-pinned-");
+		db = RocksDB.open(dbPath);
+
+		byte[] value = new byte[valueSize];
+		for (int i = 0; i < valueSize; i++) {
+			value[i] = (byte) i;
+		}
+		db.put(KEY, value);
+
+		arena = Arena.ofConfined();
+		keySegment = arena.allocateFrom(ValueLayout.JAVA_BYTE, KEY);
+		destSegment = arena.allocate(valueSize);
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() throws IOException {
+		db.close();
+		arena.close();
+		TestData.deleteDir(dbPath);
+	}
+
+	// ---- peek: only a few bytes of the value are actually wanted --------------
+
+	/// Copying tier: materializes the whole value on the heap to read two bytes of it.
+	@Benchmark
+	public int peekViaBytes() {
+		byte[] value = db.get(KEY);
+		return value[0] + value[value.length - 1];
+	}
+
+	/// Copying tier: `memcpy`s the whole value into a native destination to read two bytes.
+	@Benchmark
+	public int peekViaSegmentCopy() {
+		long len = db.get(keySegment, destSegment);
+		return destSegment.get(ValueLayout.JAVA_BYTE, 0)
+				+ destSegment.get(ValueLayout.JAVA_BYTE, len - 1);
+	}
+
+	/// Pinned tier: reads the two bytes straight out of the block cache.
+	@Benchmark
+	public int peekViaPinned() {
+		try (PinnedResult result = db.getPinned(keySegment)) {
+			return switch (result) {
+				case PinnedResult.Found found -> {
+					MemorySegment value = found.value();
+					yield value.get(ValueLayout.JAVA_BYTE, 0)
+							+ value.get(ValueLayout.JAVA_BYTE, value.byteSize() - 1);
+				}
+				case PinnedResult.NotFound ignored -> 0;
+			};
+		}
+	}
+
+	// ---- full: every byte is wanted on the Java heap --------------------------
+
+	/// Copying tier: the existing `byte[]` read.
+	@Benchmark
+	public byte[] fullViaBytes() {
+		return db.get(KEY);
+	}
+
+	/// Pinned tier, then copied out — the copy still happens, just later.
+	@Benchmark
+	public byte[] fullViaPinnedToArray() {
+		try (PinnedResult result = db.getPinned(keySegment)) {
+			return switch (result) {
+				case PinnedResult.Found found -> found.toArray();
+				case PinnedResult.NotFound ignored -> null;
+			};
+		}
+	}
+
+	// ---- lookup only: no value bytes are read ---------------------------------
+
+	/// Pinned tier reading only the length. No value bytes are touched, but this is
+	/// **not** a measure of bare call overhead: `value()` allocates the confined arena
+	/// that scopes the borrowed segment, so the arena cost is included here — and in
+	/// every other pinned benchmark above. That allocation is the most likely reason
+	/// the pinned path loses to `peekViaSegmentCopy` at small value sizes, where there
+	/// is almost nothing to copy.
+	@Benchmark
+	public long lookupViaPinned() {
+		try (PinnedResult result = db.getPinned(keySegment)) {
+			return switch (result) {
+				case PinnedResult.Found found -> found.value().byteSize();
+				case PinnedResult.NotFound ignored -> -1L;
+			};
+		}
+	}
+
+	static void main() throws Exception {
+		org.openjdk.jmh.runner.options.Options opt = new OptionsBuilder()
+				.include(PinnedReadBenchmark.class.getSimpleName())
+				.build();
+
+		new org.openjdk.jmh.runner.Runner(opt).run();
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
@@ -119,6 +119,52 @@ public final class BlobDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOpts.ptr(), key);
+	}
+
+	/// Pinned read of `key` with explicit [ReadOptions], e.g. for snapshot-pinned reads.
+	///
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ReadOptions readOptions, byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOptions.ptr(), key);
+	}
+
+	/// Pinned read of a key held in a direct [ByteBuffer].
+	///
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ByteBuffer key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read of a key held in a native segment — nothing is copied on either side.
+	///
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(MemorySegment key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), key, key.byteSize());
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
@@ -173,6 +173,52 @@ public final class OptimisticTransactionDB extends NativeObject {
 		return RocksDB.getIntoSegment(baseDb, readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(byte[] key) {
+		return RocksDB.getPinnedBytes(baseDb, readOpts.ptr(), key);
+	}
+
+	/// Pinned read of `key` with explicit [ReadOptions], e.g. for snapshot-pinned reads.
+	///
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ReadOptions readOptions, byte[] key) {
+		return RocksDB.getPinnedBytes(baseDb, readOptions.ptr(), key);
+	}
+
+	/// Pinned read of a key held in a direct [ByteBuffer].
+	///
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ByteBuffer key) {
+		return RocksDB.getPinned(baseDb, readOpts.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read of a key held in a native segment — nothing is copied on either side.
+	///
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(MemorySegment key) {
+		return RocksDB.getPinned(baseDb, readOpts.ptr(), key, key.byteSize());
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete
 	// -----------------------------------------------------------------------
@@ -294,6 +340,56 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @return actual value length in bytes
 	public long get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(baseDb, readOpts.ptr(), cf, key, key.byteSize(), value);
+	}
+
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param cf  target column family
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, byte[] key) {
+		return RocksDB.getCfPinnedBytes(baseDb, readOpts.ptr(), cf, key);
+	}
+
+	/// Pinned read of `key` from `cf` with explicit [ReadOptions].
+	///
+	/// @param cf          target column family
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
+		return RocksDB.getCfPinnedBytes(baseDb, readOptions.ptr(), cf, key);
+	}
+
+	/// Pinned read from `cf` of a key held in a direct [ByteBuffer].
+	///
+	/// @param cf  target column family
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ByteBuffer key) {
+		return RocksDB.getCfPinned(baseDb, readOpts.ptr(), cf, MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read from `cf` of a key held in a native segment — nothing is copied.
+	///
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, MemorySegment key) {
+		return RocksDB.getCfPinned(baseDb, readOpts.ptr(), cf, key, key.byteSize());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
@@ -1,0 +1,179 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/// A borrowed view of a value still held in RocksDB's block cache.
+///
+/// `rocksdb_get_pinned` returns a pointer directly into the cached block instead of
+/// copying the value out, which is what makes the pinned read path zero-copy. The
+/// cost is that the cache entry cannot be evicted while this object is open, so a
+/// slice held for a long time is back-pressure on the block cache — it presents as
+/// native memory growth, not as Java heap growth. Close it promptly; the intended
+/// shape is a try-with-resources whose body does not outlive the statement.
+///
+/// The segment returned by [#value()] is scoped to this slice: once [#close()] runs,
+/// touching it throws [IllegalStateException] rather than reading freed memory.
+public final class PinnableSlice extends NativeObject {
+
+	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
+	private static final MethodHandle MH_PINNABLESLICE_VALUE;
+	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
+	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
+
+	static {
+		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
+				FunctionDescriptor.of(ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+	}
+
+	/// Scope for the segment handed out by [#value()], created on first use so callers
+	/// who never look at the bytes do not pay for it.
+	///
+	/// Deliberately **shared**, not confined. A confined arena can only be closed by
+	/// the thread that created it, and [#close()] runs inside
+	/// [NativeObject#close()], which swallows what `tryClose` throws — so a confined
+	/// scope closed from another thread would fail silently and leave this segment
+	/// readable over memory the pin no longer holds. A shared arena closes from any
+	/// thread, which keeps "use after close throws" true regardless of who closes.
+	private Arena valueArena;
+	private MemorySegment value;
+
+	private PinnableSlice(MemorySegment owningPointer) {
+		super(owningPointer);
+	}
+
+	/// Wraps a non-NULL `rocksdb_pinnableslice_t*`.
+	static PinnableSlice of(MemorySegment owningPointer) {
+		return new PinnableSlice(owningPointer);
+	}
+
+	/// Returns the pinned value as a segment whose `byteSize()` is the value length.
+	///
+	/// The segment borrows RocksDB's memory — it is not a copy, and it is valid only
+	/// until this slice is closed. Repeated calls return the same segment.
+	///
+	/// @return the pinned value, sized to the value's true length
+	/// @throws IllegalStateException if this slice has already been closed
+	public MemorySegment value() {
+		if (value == null) {
+			MemorySegment ptr = ptr();
+			Arena arena = Arena.ofShared();
+			try {
+				value = rawValue(ptr, arena, arena);
+			} catch (RuntimeException | Error e) {
+				arena.close();
+				throw e;
+			}
+			valueArena = arena;
+		}
+		return value;
+	}
+
+	/// Copies the pinned value into a new array.
+	///
+	/// Convenience for callers who want the bytes on the Java heap; this is the
+	/// copying path and defeats the point of pinning, so prefer [#value()].
+	///
+	/// @return a fresh array holding a copy of the pinned value
+	/// @throws IllegalStateException if this slice has already been closed
+	public byte[] toArray() {
+		return value().toArray(ValueLayout.JAVA_BYTE);
+	}
+
+	/// Returns the length of the pinned value in bytes.
+	///
+	/// @return the value length
+	/// @throws IllegalStateException if this slice has already been closed
+	public long length() {
+		return value().byteSize();
+	}
+
+	// -----------------------------------------------------------------------
+	// Raw-pointer statics
+	//
+	// The copying get helpers own a rocksdb_pinnableslice_t* for the length of one
+	// call, copy the bytes out, and destroy it. Wrapping it would allocate a
+	// PinnableSlice and a PinnedResult per read on the hottest path in the library,
+	// which measured as a 1.5-3.5% throughput regression across all three read tiers.
+	// These statics let those helpers share this class's method handles -- so the
+	// symbols are still mapped exactly once -- without allocating anything.
+	// -----------------------------------------------------------------------
+
+	/// Reads the value out of a raw `rocksdb_pinnableslice_t*` without wrapping it.
+	///
+	/// The returned segment is unscoped and borrows RocksDB's memory: it is valid only
+	/// until [#destroy(MemorySegment)] is called on the same pointer.
+	static MemorySegment valueOf(MemorySegment pin, Arena scratch) {
+		return rawValue(pin, scratch, null);
+	}
+
+	/// Reads the value out of a raw `rocksdb_pinnableslice_t*` using a length holder the
+	/// caller already allocated, so a loop of reads allocates nothing at all.
+	///
+	/// Experiment hook for the reuse question on #47: it measures the ceiling of what a
+	/// caller-owned, reused slice could save on the Java side. The returned segment is
+	/// unscoped — valid only until [#destroy(MemorySegment)] — which is precisely the
+	/// safety that [#value()] buys with its arena.
+	static MemorySegment valueInto(MemorySegment pin, MemorySegment lenHolder) {
+		try {
+			MemorySegment data = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, lenHolder);
+			return data.reinterpret(lenHolder.get(ValueLayout.JAVA_LONG, 0));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("pinnableslice value failed", t);
+		}
+	}
+
+	/// Destroys a raw `rocksdb_pinnableslice_t*`. Safe on [MemorySegment#NULL] — the C
+	/// API's destroy is a plain `delete`, which tolerates a null pointer.
+	static void destroy(MemorySegment pin) {
+		try {
+			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("pinnableslice destroy failed", t);
+		}
+	}
+
+	/// Reads the value pointer and length, sizing the result to `scope` (or leaving it
+	/// unscoped when `scope` is `null`, in which case the segment must not escape while
+	/// the underlying slice can still be destroyed).
+	private static MemorySegment rawValue(MemorySegment pin, Arena scratch, Arena scope) {
+		try {
+			MemorySegment lenHolder = scratch.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment data = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, lenHolder);
+			long len = lenHolder.get(ValueLayout.JAVA_LONG, 0);
+			return scope == null ? data.reinterpret(len) : data.reinterpret(len, scope, null);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("pinnableslice value failed", t);
+		}
+	}
+
+	@Override
+	protected void tryClose(MemorySegment ptr) throws Throwable {
+		value = null;
+		try {
+			// Close the arena first so any segment handed out by value() is invalidated
+			// before the memory behind it is released — a use-after-close then throws
+			// rather than reading freed memory.
+			if (valueArena != null) {
+				valueArena.close();
+				valueArena = null;
+			}
+		} finally {
+			// But release the pin even if that failed. valueArena is confined, so
+			// closing this slice from a different thread throws WrongThreadException —
+			// and NativeObject.close() swallows it after having already nulled the
+			// pointer, so a skipped destroy would strand the block-cache entry forever
+			// with nothing able to retry. The finally makes the native release
+			// unconditional; the worst a failed arena close now costs is 16 bytes of
+			// scratch and a segment that outlives its memory.
+			MH_PINNABLESLICE_DESTROY.invokeExact(ptr);
+		}
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnedResult.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnedResult.java
@@ -1,0 +1,78 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.MemorySegment;
+
+/// Outcome of a pinned read: either the value was found, or the key is absent.
+///
+/// This replaces the `-1`-or-length encoding used by the copying `get` overloads.
+/// Absence is a case of the type rather than a magic number, so it cannot be
+/// mistaken for a length, and a `switch` over the result is checked by the compiler:
+///
+/// ```java
+/// try (PinnedResult result = db.getPinned(key)) {
+///     switch (result) {
+///         case PinnedResult.Found found -> consume(found.value());
+///         case PinnedResult.NotFound ignored -> handleMiss();
+///     }
+/// }
+/// ```
+///
+/// A found result holds a block-cache entry pinned until it is closed, so the
+/// result is [AutoCloseable] and belongs in a try-with-resources. Closing a
+/// [NotFound] is harmless, which is why the whole result — not just the found
+/// case — carries the close.
+///
+/// @see PinnableSlice
+public sealed interface PinnedResult extends AutoCloseable {
+
+	/// Releases the pinned block-cache entry, if any.
+	///
+	/// Unlike [AutoCloseable#close()] this throws no checked exception, and it is
+	/// idempotent: closing twice is a no-op rather than a double free.
+	@Override
+	void close();
+
+	/// The key was present; [#value()] borrows its value from the block cache.
+	///
+	/// @param slice the pinned slice holding the value; closed when this result is closed
+	record Found(PinnableSlice slice) implements PinnedResult {
+
+		/// Returns the value as a borrowed segment whose `byteSize()` is its length.
+		///
+		/// The segment is valid only until this result is closed; using it afterwards
+		/// throws [IllegalStateException].
+		///
+		/// @return the pinned value, sized to the value's true length
+		public MemorySegment value() {
+			return slice.value();
+		}
+
+		/// Copies the value onto the Java heap.
+		///
+		/// @return a fresh array holding a copy of the value
+		public byte[] toArray() {
+			return slice.toArray();
+		}
+
+		@Override
+		public void close() {
+			slice.close();
+		}
+	}
+
+	/// The key is absent from the database.
+	///
+	/// A singleton: it carries no state, and in particular no length, so it can
+	/// never be read as an empty value. That distinction is what the segment-tier
+	/// `get` overloads cannot express.
+	enum NotFound implements PinnedResult {
+
+		/// The sole instance.
+		INSTANCE;
+
+		@Override
+		public void close() {
+			// nothing was pinned
+		}
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
@@ -66,6 +66,52 @@ public final class ReadOnlyDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOpts.ptr(), key);
+	}
+
+	/// Pinned read of `key` with explicit [ReadOptions], e.g. for snapshot-pinned reads.
+	///
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ReadOptions readOptions, byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOptions.ptr(), key);
+	}
+
+	/// Pinned read of a key held in a direct [ByteBuffer].
+	///
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ByteBuffer key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read of a key held in a native segment — nothing is copied on either side.
+	///
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(MemorySegment key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), key, key.byteSize());
+	}
+
 	/// Returns the value for `key` in `cf`, or `null` if not found.
 	///
 	/// @param cf  column family to read from
@@ -106,6 +152,56 @@ public final class ReadOnlyDB extends NativeObject {
 	/// @return actual value length in bytes
 	public long get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(ptr(), readOpts.ptr(), cf, key, key.byteSize(), value);
+	}
+
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param cf  target column family
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, byte[] key) {
+		return RocksDB.getCfPinnedBytes(ptr(), readOpts.ptr(), cf, key);
+	}
+
+	/// Pinned read of `key` from `cf` with explicit [ReadOptions].
+	///
+	/// @param cf          target column family
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
+		return RocksDB.getCfPinnedBytes(ptr(), readOptions.ptr(), cf, key);
+	}
+
+	/// Pinned read from `cf` of a key held in a direct [ByteBuffer].
+	///
+	/// @param cf  target column family
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ByteBuffer key) {
+		return RocksDB.getCfPinned(ptr(), readOpts.ptr(), cf, MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read from `cf` of a key held in a native segment — nothing is copied.
+	///
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, MemorySegment key) {
+		return RocksDB.getCfPinned(ptr(), readOpts.ptr(), cf, key, key.byteSize());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -121,6 +121,60 @@ public final class ReadWriteDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOpts.ptr(), key);
+	}
+
+	/// Pinned read of `key` with explicit [ReadOptions], e.g. for snapshot-pinned reads.
+	///
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ReadOptions readOptions, byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOptions.ptr(), key);
+	}
+
+	/// Pinned read of a key held in a direct [ByteBuffer].
+	///
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ByteBuffer key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read of a key held in a native segment — nothing is copied on either side.
+	///
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(MemorySegment key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), key, key.byteSize());
+	}
+
+	/// Pinned read that allocates nothing: the caller supplies the error holder and owns
+	/// the returned raw slice pointer, which it must destroy.
+	///
+	/// Package-private experiment hook for #47 — see [RocksDB#getPinnedRaw].
+	MemorySegment getPinnedRaw(MemorySegment key, MemorySegment err) {
+		return RocksDB.getPinnedRaw(ptr(), readOpts.ptr(), key, key.byteSize(), err);
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete
 	// -----------------------------------------------------------------------
@@ -615,6 +669,56 @@ public final class ReadWriteDB extends NativeObject {
 	/// @return actual value length in bytes
 	public long get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(ptr(), readOpts.ptr(), cf, key, key.byteSize(), value);
+	}
+
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param cf  target column family
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, byte[] key) {
+		return RocksDB.getCfPinnedBytes(ptr(), readOpts.ptr(), cf, key);
+	}
+
+	/// Pinned read of `key` from `cf` with explicit [ReadOptions].
+	///
+	/// @param cf          target column family
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
+		return RocksDB.getCfPinnedBytes(ptr(), readOptions.ptr(), cf, key);
+	}
+
+	/// Pinned read from `cf` of a key held in a direct [ByteBuffer].
+	///
+	/// @param cf  target column family
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ByteBuffer key) {
+		return RocksDB.getCfPinned(ptr(), readOpts.ptr(), cf, MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read from `cf` of a key held in a native segment — nothing is copied.
+	///
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, MemorySegment key) {
+		return RocksDB.getCfPinned(ptr(), readOpts.ptr(), cf, key, key.byteSize());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -58,10 +58,6 @@ public final class RocksDB {
 	private static final MethodHandle MH_CLOSE;
 	/// `rocksdb_pinnableslice_t* rocksdb_get_pinned(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char** errptr);`
 	private static final MethodHandle MH_GET_PINNED;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 	/// `void rocksdb_put(rocksdb_t* db, const rocksdb_writeoptions_t* options, const char* key, size_t keylen, const char* val, size_t vallen, char** errptr);`
 	private static final MethodHandle MH_PUT;
 	/// `void rocksdb_delete(rocksdb_t* db, const rocksdb_writeoptions_t* options, const char* key, size_t keylen, char** errptr);`
@@ -193,13 +189,6 @@ public final class RocksDB {
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
 		MH_PUT = NativeLibrary.lookup("rocksdb_put",
 				FunctionDescriptor.ofVoid(
@@ -623,6 +612,59 @@ public final class RocksDB {
 	// Package-private shared helpers — rocksdb_t* operations, mapped once
 	// -----------------------------------------------------------------------
 
+	/// Pinned get — borrows the value from the block cache instead of copying it.
+	/// The caller owns the returned result and must close it.
+	static PinnedResult getPinned(MemorySegment db, MemorySegment readOpts, MemorySegment key, long keyLen) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, key, keyLen, err);
+			checkError(err);
+			return pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
+		}
+	}
+
+	/// Pinned get that opens no arena: the caller supplies the error holder and owns the
+	/// returned raw `rocksdb_pinnableslice_t*`, which it must pass to
+	/// [PinnableSlice#destroy(MemorySegment)].
+	///
+	/// Experiment hook for the reuse question on #47 — it is what a caller-owned,
+	/// reused slice would compile down to, and exists to measure whether that is worth
+	/// an API. Returns [MemorySegment#NULL] when the key is absent.
+	static MemorySegment getPinnedRaw(MemorySegment db, MemorySegment readOpts,
+	                                  MemorySegment key, long keyLen, MemorySegment err) {
+		try {
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, key, keyLen, err);
+			checkError(err);
+			return pin;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
+		}
+	}
+
+	/// Pinned get for a `byte[]` key — copies the key into native memory first.
+	static PinnedResult getPinnedBytes(MemorySegment db, MemorySegment readOpts, byte[] key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = errHolder(arena);
+			MemorySegment k = toNative(arena, key);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, k, (long) key.length, err);
+			checkError(err);
+			return pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
+		}
+	}
+
+	/// Maps the `rocksdb_get_pinned` return onto [PinnedResult]: `nullptr` means the key
+	/// is absent (`rocksdb/db/c.cc`), any other pointer owns a pinned block-cache entry.
+	static PinnedResult pinnedResult(MemorySegment pin) {
+		if (MemorySegment.NULL.equals(pin)) {
+			return PinnedResult.NotFound.INSTANCE;
+		}
+		return new PinnedResult.Found(PinnableSlice.of(pin));
+	}
+
 	/// byte[] get via PinnableSlice — zero-copy from block cache. Returns `null` if not found.
 	static byte[] getBytes(MemorySegment db, MemorySegment readOpts, byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
@@ -633,12 +675,11 @@ public final class RocksDB {
 			if (MemorySegment.NULL.equals(pin)) {
 				return null;
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
+			try {
+				return PinnableSlice.valueOf(pin, arena).toArray(ValueLayout.JAVA_BYTE);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -654,14 +695,11 @@ public final class RocksDB {
 			if (MemorySegment.NULL.equals(pin)) {
 				return -1;
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			int toCopy = (int) Math.min(valLen, value.remaining());
-			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(toCopy));
-			value.position(value.position() + toCopy);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return (int) valLen;
+			try {
+				return copyInto(PinnableSlice.valueOf(pin, arena), value);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -674,16 +712,39 @@ public final class RocksDB {
 			MemorySegment err = errHolder(arena);
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, key, keyLen, err);
 			checkError(err);
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			long toCopy = Math.min(valLen, value.byteSize());
-			value.copyFrom(valPtr.reinterpret(toCopy));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return valLen;
+			if (MemorySegment.NULL.equals(pin)) {
+				return 0L;
+			}
+			try {
+				return copyInto(PinnableSlice.valueOf(pin, arena), value);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
+	}
+
+	/// Copies as much of `pinned` as fits into `value`, advancing its position, and
+	/// returns the value's true length — which may exceed what was copied.
+	///
+	/// Uses the offset form of [MemorySegment#copy(MemorySegment, long, MemorySegment, long, long)]
+	/// rather than `asSlice` + `copyFrom`: it needs no intermediate slice object, and
+	/// this sits on the hottest path in the library.
+	private static int copyInto(MemorySegment pinned, ByteBuffer value) {
+		long valLen = pinned.byteSize();
+		int toCopy = (int) Math.min(valLen, value.remaining());
+		MemorySegment.copy(pinned, 0, MemorySegment.ofBuffer(value), 0, toCopy);
+		value.position(value.position() + toCopy);
+		return (int) valLen;
+	}
+
+	/// Copies as much of `pinned` as fits into `value` and returns the value's true
+	/// length — which may exceed what was copied.
+	private static long copyInto(MemorySegment pinned, MemorySegment value) {
+		long valLen = pinned.byteSize();
+		MemorySegment.copy(pinned, 0, value, 0, Math.min(valLen, value.byteSize()));
+		return valLen;
 	}
 
 	/// byte[] put — slow path, allocates native memory.
@@ -1413,6 +1474,35 @@ public final class RocksDB {
 		}
 	}
 
+	/// Pinned get with explicit column family — borrows the value from the block cache.
+	/// The caller owns the returned result and must close it.
+	static PinnedResult getCfPinned(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
+	                                MemorySegment key, long keyLen) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					db, readOpts, cf.ptr(), key, keyLen, err);
+			checkError(err);
+			return pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
+		}
+	}
+
+	/// Pinned get with explicit column family for a `byte[]` key.
+	static PinnedResult getCfPinnedBytes(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
+	                                     byte[] key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					db, readOpts, cf.ptr(), toNative(arena, key), (long) key.length, err);
+			checkError(err);
+			return pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
+		}
+	}
+
 	/// byte[] get with explicit column family via PinnableSlice. Returns `null` if not found.
 	static byte[] getCfBytes(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
 	                         byte[] key) {
@@ -1424,12 +1514,11 @@ public final class RocksDB {
 			if (MemorySegment.NULL.equals(pin)) {
 				return null;
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
+			try {
+				return PinnableSlice.valueOf(pin, arena).toArray(ValueLayout.JAVA_BYTE);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -1447,14 +1536,11 @@ public final class RocksDB {
 			if (MemorySegment.NULL.equals(pin)) {
 				return -1;
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			int toCopy = (int) Math.min(valLen, value.remaining());
-			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(toCopy));
-			value.position(value.position() + toCopy);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return (int) valLen;
+			try {
+				return copyInto(PinnableSlice.valueOf(pin, arena), value);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -1469,13 +1555,14 @@ public final class RocksDB {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
 					db, readOpts, cf.ptr(), key, keyLen, err);
 			checkError(err);
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			long toCopy = Math.min(valLen, value.byteSize());
-			value.copyFrom(valPtr.reinterpret(toCopy));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return valLen;
+			if (MemorySegment.NULL.equals(pin)) {
+				return 0L;
+			}
+			try {
+				return copyInto(PinnableSlice.valueOf(pin, arena), value);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
@@ -112,6 +112,52 @@ public final class SecondaryDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOpts.ptr(), key);
+	}
+
+	/// Pinned read of `key` with explicit [ReadOptions], e.g. for snapshot-pinned reads.
+	///
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ReadOptions readOptions, byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOptions.ptr(), key);
+	}
+
+	/// Pinned read of a key held in a direct [ByteBuffer].
+	///
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ByteBuffer key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read of a key held in a native segment — nothing is copied on either side.
+	///
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(MemorySegment key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), key, key.byteSize());
+	}
+
 	// -----------------------------------------------------------------------
 	// Iterator
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -49,10 +49,6 @@ public final class Transaction extends NativeObject {
 	private static final MethodHandle MH_GET_PINNED;
 	/// `char* rocksdb_transaction_get_for_update(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, const char* key, size_t klen, size_t* vlen, unsigned char exclusive, char** errptr);`
 	private static final MethodHandle MH_GET_FOR_UPDATE;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 
 	static {
 		MH_COMMIT = NativeLibrary.lookup("rocksdb_transaction_commit",
@@ -95,13 +91,6 @@ public final class Transaction extends NativeObject {
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE,
 						ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
 
 		MH_PUT_CF = NativeLibrary.lookup("rocksdb_transaction_put_cf",
@@ -203,15 +192,47 @@ public final class Transaction extends NativeObject {
 			if (MemorySegment.NULL.equals(pin)) {
 				return null;
 			}
-
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
+			try {
+				return PinnableSlice.valueOf(pin, arena).toArray(ValueLayout.JAVA_BYTE);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Pinned read of `key` within this transaction — borrows the value from the
+	/// block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = txn.getPinned(readOptions, key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// This takes no lock; use [#getForUpdate(ReadOptions, byte[], boolean)] when the
+	/// value read must not change before commit.
+	///
+	/// @param readOptions read options for this read
+	/// @param key         key bytes to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ReadOptions readOptions, byte[] key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment k = RocksDB.toNative(arena, key);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
+					ptr(), readOptions.ptr(), k, (long) key.length, err);
+			RocksDB.checkError(err);
+			return RocksDB.pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
 		}
 	}
 
@@ -303,14 +324,32 @@ public final class Transaction extends NativeObject {
 			if (MemorySegment.NULL.equals(pin)) {
 				return null;
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
+			try {
+				return PinnableSlice.valueOf(pin, arena).toArray(ValueLayout.JAVA_BYTE);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Pinned read of `key` from `cf` within this transaction.
+	///
+	/// @param cf          target column family
+	/// @param readOptions read options for this read
+	/// @param key         key bytes to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					ptr(), readOptions.ptr(), cf.ptr(),
+					RocksDB.toNative(arena, key), (long) key.length, err);
+			RocksDB.checkError(err);
+			return RocksDB.pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -49,6 +49,8 @@ public final class TransactionDB extends NativeObject {
 	private static final MethodHandle MH_DELETE;
 	/// `char* rocksdb_transactiondb_get(rocksdb_transactiondb_t* txn_db, const rocksdb_readoptions_t* options, const char* key, size_t klen, size_t* vlen, char** errptr);`
 	private static final MethodHandle MH_GET;
+	/// `rocksdb_pinnableslice_t* rocksdb_transactiondb_get_pinned(rocksdb_transactiondb_t* txn_db, const rocksdb_readoptions_t* options, const char* key, size_t klen, char** errptr);`
+	private static final MethodHandle MH_GET_PINNED;
 
 	// Column-family variants
 	/// `void rocksdb_transactiondb_put_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_writeoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, const char* val, size_t vallen, char** errptr);`
@@ -61,10 +63,6 @@ public final class TransactionDB extends NativeObject {
 	private static final MethodHandle MH_CREATE_ITERATOR_CF;
 	/// `void rocksdb_transactiondb_flush_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_flushoptions_t* options, rocksdb_column_family_handle_t* column_family, char** errptr);`
 	private static final MethodHandle MH_FLUSH_CF;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 
 
 	static {
@@ -95,6 +93,12 @@ public final class TransactionDB extends NativeObject {
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
+		MH_GET_PINNED = NativeLibrary.lookup("rocksdb_transactiondb_get_pinned",
+				FunctionDescriptor.of(ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
 		MH_PUT_CF = NativeLibrary.lookup("rocksdb_transactiondb_put_cf",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS,
@@ -121,13 +125,6 @@ public final class TransactionDB extends NativeObject {
 		MH_FLUSH_CF = NativeLibrary.lookup("rocksdb_transactiondb_flush_cf",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
 
 		MH_CREATE_SNAPSHOT = NativeLibrary.lookup("rocksdb_transactiondb_create_snapshot",
@@ -403,6 +400,73 @@ public final class TransactionDB extends NativeObject {
 		}
 	}
 
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Unlike [#get(byte[])], which copies out of a `malloc`ed buffer, this reads committed
+	/// data straight from the cache. Absence is a case of the returned type rather than a
+	/// sentinel, and a found result keeps its block-cache entry pinned until closed:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(byte[] key) {
+		return getPinned(readOpts, key);
+	}
+
+	/// Pinned read of `key` with explicit [ReadOptions], e.g. for snapshot-pinned reads.
+	///
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ReadOptions readOptions, byte[] key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment k = RocksDB.toNative(arena, key);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
+					ptr(), readOptions.ptr(), k, (long) key.length, err);
+			RocksDB.checkError(err);
+			return RocksDB.pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
+		}
+	}
+
+	/// Pinned read of a key held in a direct [java.nio.ByteBuffer].
+	///
+	/// @param key direct [java.nio.ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(java.nio.ByteBuffer key) {
+		return getPinned(MemorySegment.ofBuffer(key), (long) key.remaining());
+	}
+
+	/// Pinned read of a key held in a native segment — nothing is copied on either side.
+	///
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(MemorySegment key) {
+		return getPinned(key, key.byteSize());
+	}
+
+	private PinnedResult getPinned(MemorySegment key, long keyLen) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
+					ptr(), readOpts.ptr(), key, keyLen, err);
+			RocksDB.checkError(err);
+			return RocksDB.pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
+		}
+	}
+
 	// -----------------------------------------------------------------------
 	// DB Properties
 	// -----------------------------------------------------------------------
@@ -587,14 +651,71 @@ public final class TransactionDB extends NativeObject {
 			if (MemorySegment.NULL.equals(pin)) {
 				return null;
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
+			try {
+				return PinnableSlice.valueOf(pin, arena).toArray(ValueLayout.JAVA_BYTE);
+			} finally {
+				PinnableSlice.destroy(pin);
+			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
+		}
+	}
+
+	/// Pinned read of `key` from `cf` — borrows the value from the block cache.
+	///
+	/// @param cf  target column family
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, byte[] key) {
+		return getPinned(cf, readOpts, key);
+	}
+
+	/// Pinned read of `key` from `cf` with explicit [ReadOptions].
+	///
+	/// @param cf          target column family
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					ptr(), readOptions.ptr(), cf.ptr(),
+					RocksDB.toNative(arena, key), (long) key.length, err);
+			RocksDB.checkError(err);
+			return RocksDB.pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
+		}
+	}
+
+	/// Pinned read from `cf` of a key held in a direct [java.nio.ByteBuffer].
+	///
+	/// @param cf  target column family
+	/// @param key direct [java.nio.ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, java.nio.ByteBuffer key) {
+		return getPinned(cf, MemorySegment.ofBuffer(key), (long) key.remaining());
+	}
+
+	/// Pinned read from `cf` of a key held in a native segment — nothing is copied.
+	///
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, MemorySegment key) {
+		return getPinned(cf, key, key.byteSize());
+	}
+
+	private PinnedResult getPinned(ColumnFamilyHandle cf, MemorySegment key, long keyLen) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					ptr(), readOpts.ptr(), cf.ptr(), key, keyLen, err);
+			RocksDB.checkError(err);
+			return RocksDB.pinnedResult(pin);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getPinned failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
@@ -134,6 +134,52 @@ public final class TtlDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOpts.ptr(), key);
+	}
+
+	/// Pinned read of `key` with explicit [ReadOptions], e.g. for snapshot-pinned reads.
+	///
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ReadOptions readOptions, byte[] key) {
+		return RocksDB.getPinnedBytes(ptr(), readOptions.ptr(), key);
+	}
+
+	/// Pinned read of a key held in a direct [ByteBuffer].
+	///
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ByteBuffer key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read of a key held in a native segment — nothing is copied on either side.
+	///
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(MemorySegment key) {
+		return RocksDB.getPinned(ptr(), readOpts.ptr(), key, key.byteSize());
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete
 	// -----------------------------------------------------------------------
@@ -336,6 +382,56 @@ public final class TtlDB extends NativeObject {
 	/// @return actual value length in bytes
 	public long get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(ptr(), readOpts.ptr(), cf, key, key.byteSize(), value);
+	}
+
+	/// Pinned read of `key` — borrows the value from the block cache instead of copying it.
+	///
+	/// Absence is a case of the returned type rather than a sentinel, so it can be neither
+	/// mistaken for a length nor confused with a present-but-empty value. A found result
+	/// keeps its block-cache entry pinned until closed, so use try-with-resources:
+	///
+	/// ```java
+	/// try (PinnedResult result = db.getPinned(key)) {
+	///     switch (result) {
+	///         case PinnedResult.Found found -> consume(found.value());
+	///         case PinnedResult.NotFound ignored -> handleMiss();
+	///     }
+	/// }
+	/// ```
+	///
+	/// @param cf  target column family
+	/// @param key the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, byte[] key) {
+		return RocksDB.getCfPinnedBytes(ptr(), readOpts.ptr(), cf, key);
+	}
+
+	/// Pinned read of `key` from `cf` with explicit [ReadOptions].
+	///
+	/// @param cf          target column family
+	/// @param readOptions read options (e.g. snapshot)
+	/// @param key         the key to look up
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
+		return RocksDB.getCfPinnedBytes(ptr(), readOptions.ptr(), cf, key);
+	}
+
+	/// Pinned read from `cf` of a key held in a direct [ByteBuffer].
+	///
+	/// @param cf  target column family
+	/// @param key direct [ByteBuffer] containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, ByteBuffer key) {
+		return RocksDB.getCfPinned(ptr(), readOpts.ptr(), cf, MemorySegment.ofBuffer(key), key.remaining());
+	}
+
+	/// Pinned read from `cf` of a key held in a native segment — nothing is copied.
+	///
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @return [PinnedResult.Found] borrowing the value, or [PinnedResult.NotFound] if absent
+	public PinnedResult getPinned(ColumnFamilyHandle cf, MemorySegment key) {
+		return RocksDB.getCfPinned(ptr(), readOpts.ptr(), cf, key, key.byteSize());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/GetPinnedTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/GetPinnedTest.java
@@ -1,0 +1,428 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GetPinnedTest {
+
+	private static ByteBuffer direct(byte[] bytes) {
+		return ByteBuffer.allocateDirect(bytes.length).put(bytes).flip();
+	}
+
+	private static byte[] bytesOf(MemorySegment segment) {
+		return segment.toArray(ValueLayout.JAVA_BYTE);
+	}
+
+	// -----------------------------------------------------------------------
+	// Found / NotFound
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getPinned_returnsFoundHoldingTheValue(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When
+			try (PinnedResult result = db.getPinned("key".getBytes())) {
+
+				// Then
+				assertThat(result).isInstanceOf(PinnedResult.Found.class);
+				assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("value".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void getPinned_returnsNotFoundForAbsentKey(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("present".getBytes(), "value".getBytes());
+
+			// When
+			try (PinnedResult result = db.getPinned("absent".getBytes())) {
+
+				// Then
+				assertThat(result).isSameAs(PinnedResult.NotFound.INSTANCE);
+			}
+		}
+	}
+
+	@Test
+	void getPinned_distinguishesEmptyValueFromAbsentKey(@TempDir Path dir) {
+		// Given — the case the segment-tier get cannot express (#44): both report 0
+		try (var db = RocksDB.open(dir)) {
+			db.put("present-empty".getBytes(), new byte[0]);
+
+			// When
+			try (PinnedResult present = db.getPinned("present-empty".getBytes());
+			     PinnedResult absent = db.getPinned("absent".getBytes())) {
+
+				// Then
+				assertThat(present).isInstanceOf(PinnedResult.Found.class);
+				assertThat(((PinnedResult.Found) present).value().byteSize()).isZero();
+				assertThat(absent).isSameAs(PinnedResult.NotFound.INSTANCE);
+			}
+		}
+	}
+
+	@Test
+	void getPinned_switchOverResultIsExhaustive(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When — the idiomatic call site: no sentinel to compare, no branch to forget
+			String outcome;
+			try (PinnedResult result = db.getPinned("key".getBytes())) {
+				outcome = switch (result) {
+					case PinnedResult.Found found -> new String(bytesOf(found.value()));
+					case PinnedResult.NotFound ignored -> "miss";
+				};
+			}
+
+			// Then
+			assertThat(outcome).isEqualTo("value");
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Value length is intrinsic to the segment
+	// -----------------------------------------------------------------------
+
+	@Test
+	void foundValue_carriesItsOwnLength(@TempDir Path dir) {
+		// Given — a value long enough that a wrong length would be obvious
+		byte[] value = "0123456789abcdefghijklmnopqrstuv".getBytes();
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), value);
+
+			// When
+			try (PinnedResult result = db.getPinned("key".getBytes())) {
+				MemorySegment segment = ((PinnedResult.Found) result).value();
+
+				// Then — no caller-supplied capacity to compare against, so no truncation
+				assertThat(segment.byteSize()).isEqualTo(value.length);
+				assertThat(bytesOf(segment)).isEqualTo(value);
+			}
+		}
+	}
+
+	@Test
+	void foundValue_isStableAcrossRepeatedCalls(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When
+			try (PinnedResult result = db.getPinned("key".getBytes())) {
+				PinnedResult.Found found = (PinnedResult.Found) result;
+				MemorySegment first = found.value();
+				MemorySegment second = found.value();
+
+				// Then
+				assertThat(second).isSameAs(first);
+			}
+		}
+	}
+
+	@Test
+	void found_toArrayCopiesOntoTheHeap(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When
+			byte[] copied;
+			try (PinnedResult result = db.getPinned("key".getBytes())) {
+				copied = ((PinnedResult.Found) result).toArray();
+			}
+
+			// Then — the copy outlives the pin
+			assertThat(copied).isEqualTo("value".getBytes());
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Lifetime
+	// -----------------------------------------------------------------------
+
+	@Test
+	void pinnedValue_isUnusableAfterClose(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+			MemorySegment escaped;
+			try (PinnedResult result = db.getPinned("key".getBytes())) {
+				escaped = ((PinnedResult.Found) result).value();
+			}
+
+			// When / Then — reading freed memory throws instead of returning garbage
+			assertThatThrownBy(() -> bytesOf(escaped))
+					.isInstanceOf(IllegalStateException.class);
+		}
+	}
+
+	@Test
+	void found_closeIsIdempotent(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+			PinnedResult result = db.getPinned("key".getBytes());
+
+			// When — a second close must not double-free the native slice
+			result.close();
+			result.close();
+
+			// Then
+			assertThatThrownBy(() -> ((PinnedResult.Found) result).value())
+					.isInstanceOf(IllegalStateException.class);
+		}
+	}
+
+	@Test
+	void notFound_closeIsHarmless(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+
+			// When
+			PinnedResult result = db.getPinned("absent".getBytes());
+			result.close();
+			result.close();
+
+			// Then
+			assertThat(result).isSameAs(PinnedResult.NotFound.INSTANCE);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Key tiers
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getPinned_acceptsByteBufferKey(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When
+			try (PinnedResult result = db.getPinned(direct("key".getBytes()))) {
+
+				// Then
+				assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("value".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void getPinned_acceptsMemorySegmentKey(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir);
+		     Arena arena = Arena.ofConfined()) {
+			db.put("key".getBytes(), "value".getBytes());
+			MemorySegment key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "key".getBytes());
+
+			// When
+			try (PinnedResult result = db.getPinned(key)) {
+
+				// Then
+				assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("value".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void getPinned_honorsReadOptionsSnapshot(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "before".getBytes());
+
+			// When — take a snapshot, overwrite, then read pinned through the snapshot
+			try (Snapshot snap = db.getSnapshot();
+			     ReadOptions ro = ReadOptions.newReadOptions().setSnapshot(snap)) {
+				db.put("key".getBytes(), "after".getBytes());
+
+				try (PinnedResult pinned = db.getPinned(ro, "key".getBytes());
+				     PinnedResult live = db.getPinned("key".getBytes())) {
+
+					// Then
+					assertThat(bytesOf(((PinnedResult.Found) pinned).value())).isEqualTo("before".getBytes());
+					assertThat(bytesOf(((PinnedResult.Found) live).value())).isEqualTo("after".getBytes());
+				}
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Column families
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getPinned_readsFromColumnFamily(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("users"))) {
+			db.put(cf, "alice".getBytes(), "data".getBytes());
+
+			// When
+			try (PinnedResult inCf = db.getPinned(cf, "alice".getBytes());
+			     PinnedResult inDefault = db.getPinned("alice".getBytes())) {
+
+				// Then — the CF read finds it, the default CF does not
+				assertThat(bytesOf(((PinnedResult.Found) inCf).value())).isEqualTo("data".getBytes());
+				assertThat(inDefault).isSameAs(PinnedResult.NotFound.INSTANCE);
+			}
+		}
+	}
+
+	@Test
+	void getPinned_readsFromColumnFamilyWithSegmentKey(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.open(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("users"));
+		     Arena arena = Arena.ofConfined()) {
+			db.put(cf, "alice".getBytes(), "data".getBytes());
+			MemorySegment key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "alice".getBytes());
+
+			// When
+			try (PinnedResult result = db.getPinned(cf, key)) {
+
+				// Then
+				assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("data".getBytes());
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Other database types
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getPinned_worksOnReadOnlyDB(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+		}
+
+		// When
+		try (var opts = Options.newOptions();
+		     var db = RocksDB.openReadOnly(opts, dir);
+		     PinnedResult result = db.getPinned("key".getBytes())) {
+
+			// Then
+			assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("value".getBytes());
+		}
+	}
+
+	@Test
+	void getPinned_worksOnTransactionDB(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var txnOpts = TransactionDBOptions.newTransactionDBOptions();
+		     var db = RocksDB.openTransaction(opts, txnOpts, dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When
+			try (PinnedResult found = db.getPinned("key".getBytes());
+			     PinnedResult missing = db.getPinned("absent".getBytes())) {
+
+				// Then
+				assertThat(bytesOf(((PinnedResult.Found) found).value())).isEqualTo("value".getBytes());
+				assertThat(missing).isSameAs(PinnedResult.NotFound.INSTANCE);
+			}
+		}
+	}
+
+	@Test
+	void getPinned_worksInsideTransaction(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var txnOpts = TransactionDBOptions.newTransactionDBOptions();
+		     var db = RocksDB.openTransaction(opts, txnOpts, dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions()) {
+
+			// When — an uncommitted write is visible to the transaction's own pinned read
+			try (Transaction txn = db.beginTransaction(wo)) {
+				txn.put("key".getBytes(), "staged".getBytes());
+
+				try (PinnedResult result = txn.getPinned(ro, "key".getBytes())) {
+
+					// Then
+					assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("staged".getBytes());
+				}
+				txn.rollback();
+			}
+		}
+	}
+
+	@Test
+	void getPinned_worksOnTtlDB(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openWithTtl(opts, dir, java.time.Duration.ofHours(1))) {
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When
+			try (PinnedResult result = db.getPinned("key".getBytes())) {
+
+				// Then
+				assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("value".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void getPinned_worksOnOptimisticTransactionDB(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When
+			try (PinnedResult result = db.getPinned("key".getBytes())) {
+
+				// Then
+				assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("value".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void getPinned_readsAcrossReopenedColumnFamilies(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("users"))) {
+			db.put(cf, "alice".getBytes(), "data".getBytes());
+		}
+
+		// When
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var opts = Options.newOptions().setCreateIfMissing(false);
+		     var db = RocksDB.openWithColumnFamilies(opts, dir,
+				     List.of(ColumnFamilyDescriptor.of("default"),
+						     ColumnFamilyDescriptor.of("users")),
+				     handles)) {
+
+			try (PinnedResult result = db.getPinned(handles.get(1), "alice".getBytes())) {
+
+				// Then
+				assertThat(bytesOf(((PinnedResult.Found) result).value())).isEqualTo("data".getBytes());
+			}
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PinnedLeakProbeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PinnedLeakProbeTest.java
@@ -1,0 +1,43 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PinnedLeakProbeTest {
+
+	@Test
+	void closingFromAnotherThreadStillReleasesThePin(@TempDir Path dir) throws Exception {
+		// Given a pinned result whose scoping arena is confined to this thread
+		try (var db = RocksDB.open(dir)) {
+			db.put("key".getBytes(), "value".getBytes());
+			PinnedResult result = db.getPinned("key".getBytes());
+			MemorySegment borrowed = ((PinnedResult.Found) result).value();
+
+			// When it is closed from a different thread
+			Thread other = new Thread(result::close);
+			other.start();
+			other.join();
+
+			// Then the arena really did close, so the borrowed segment is dead. If it is
+			// still readable, Arena.close() threw WrongThreadException, NativeObject.close()
+			// swallowed it, and rocksdb_pinnableslice_destroy was skipped — leaking the
+			// block-cache pin with the pointer already nulled, so nothing can retry it.
+			boolean stillReadable;
+			try {
+				borrowed.get(ValueLayout.JAVA_BYTE, 0);
+				stillReadable = true;
+			} catch (RuntimeException expected) {
+				stillReadable = false;
+			}
+			assertThat(stillReadable)
+					.as("borrowed segment must be invalidated, proving the native slice was destroyed")
+					.isFalse();
+		}
+	}
+}

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,26 +1,34 @@
 #!/usr/bin/env bash
 # Run FFM and JNI benchmarks and print a side-by-side comparison.
-# Usage: ./scripts/benchmark.sh
+#
+# Usage:
+#   ./scripts/benchmark.sh                     # the FFM-vs-JNI comparison table
+#   ./scripts/benchmark.sh PinnedReadBenchmark # a single benchmark class
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-echo ">>> Building..."
-mvn install -DskipTests -q
+MAIN_CLASS="io.github.dfa1.rocksdbffm.benchmark.${1:-BenchmarkRunner}"
 
-echo ">>> Compiling benchmark sources..."
-mvn -pl benchmarks test-compile -q
+# One reactor invocation builds every upstream module and resolves the test-scope
+# classpath from it. Inside a single session Maven resolves sibling modules to their
+# target/classes, so nothing has to be installed into ~/.m2 first.
+#
+# mdep.outputFile is deliberately relative: each module writes its own file into its
+# own target/, so there is no race over a shared path and we can read exactly the one
+# belonging to benchmarks.
+echo ">>> Building and resolving classpath..."
+./mvnw -q -pl benchmarks -am test-compile \
+    dependency:build-classpath \
+    -Dmdep.includeScope=test \
+    -Dmdep.outputFile=target/benchmark-classpath.txt
 
-# Extract the full test-scope classpath (deps only, no Maven log noise)
-DEPS=$(mvn -pl benchmarks dependency:build-classpath \
-           -Dmdep.includeScope=test 2>/dev/null \
-       | grep -v '^\[' | tr -d '[:space:]')
+DEPS="$(cat benchmarks/target/benchmark-classpath.txt)"
+CP="benchmarks/target/test-classes:benchmarks/target/classes:$DEPS"
 
-CP="benchmarks/target/test-classes:benchmarks/target/classes:core/target/classes:$DEPS"
-
-echo ">>> Running benchmarks..."
+echo ">>> Running ${MAIN_CLASS}..."
 java --enable-native-access=ALL-UNNAMED \
     --sun-misc-unsafe-memory-access=allow \
     -cp "$CP" \
-    io.github.dfa1.rocksdbffm.benchmark.BenchmarkRunner
+    "$MAIN_CLASS"


### PR DESCRIPTION
Phase 1 of #47 — additive and non-breaking. No existing signature changes.

## The problem, reproduced

Probed against a real DB, 32-byte value into an 8-byte destination:

```
[buffer]  returned=32  copied=8   content=ABCDEFGH
[segment] returned=32  byteSize=8 content=ABCDEFGH
[segment] present-but-empty=0  absent=0
```

The ByteBuffer tier is worse than #47 describes: it advances `position` by the **truncated** count, so the buffer ends in exactly the state a successful 8-byte read would leave it in — the idiomatic `db.get(k, buf); buf.flip();` hands back a clean-looking 8-byte buffer with 24 bytes silently gone. The third line is #44.

## The shape

```java
try (PinnedResult result = db.getPinned(key)) {
    switch (result) {
        case PinnedResult.Found found -> consume(found.value());  // MemorySegment
        case PinnedResult.NotFound ignored -> handleMiss();
    }
}
```

- **The length is intrinsic** — `byteSize()` *is* the value length, and there is no caller-supplied capacity, so insufficient capacity is not a representable state.
- **Absence cannot be misread** — `NotFound` carries no length, closing #44's gap on this path.
- **Expiry is checked** — the borrowed segment is scoped to the result; use after close throws `IllegalStateException` rather than reading freed memory.

`AutoCloseable` rather than an `Arena` parameter: a `Found` pins its block-cache entry until released, and an `Arena` makes it easy to hand in a long-lived scope, which accumulates pins and presents as native memory growth rather than a heap leak.

## Surface

40 overloads across `ReadWriteDB`, `ReadOnlyDB`, `BlobDB`, `SecondaryDB`, `TtlDB`, `TransactionDB`, `OptimisticTransactionDB` and `Transaction` — every key tier, `ReadOptions` variants, CF variants wherever the type has them. One new symbol, `rocksdb_transactiondb_get_pinned`.

## Rule violation fixed en route

`rocksdb_pinnableslice_value`/`_destroy` were each mapped **three times** (`RocksDB`, `Transaction`, `TransactionDB`), against CLAUDE.md's no-duplicate-symbol rule — which names `PinnableSlice` as the wrapper to build for exactly this.

The copying helpers deliberately do **not** go through that wrapper: doing so allocated a `PinnableSlice` + a `PinnedResult.Found` per read on the hottest path. They use raw-pointer statics that share the same method handles — symbols mapped once, nothing allocated. A pinned read also now opens one confined `Arena` instead of two.

## On reusing one `PinnableSlice` across many gets

The C++ API documents exactly that, in [PinnableSlice; less memcpy with point lookups](https://rocksdb.org/blog/2017/08/24/pinnableslice.html) (RocksDB blog, 24 Aug 2017):

```cpp
PinnableSlice pinnable_val;
while (!stopped) {
  auto s = db->Get(opt, cf, key, &pinnable_val);
  // ... use it
  pinnable_val.Reset();  // then release it immediately
}
```

**That pattern is not reachable from the C API.** Every `rocksdb_pinnableslice_t` declaration in `c.h` either returns one or takes one to read/destroy; there is no `rocksdb_pinnableslice_create`, and nothing accepts a caller-supplied slice to fill. `rocksdb_get_pinned` does `new (rocksdb_pinnableslice_t)` per call. `rocksdb_get_pinned_v2` claims in its header comment to avoid unnecessary allocations, but its body is byte-for-byte identical.

So reuse could only save the Java side. `PinnedReuseBenchmark` measures that ceiling — `perGet` vs everything hoisted out of the loop — parameterized on reads per invocation (1, 2, 8, 32) and value size. What the hoisted variant gives up is the segment's scope, i.e. the protection #45 exists to add.

## Correction to prior art

The C++ API has no fixed-capacity destination (`db.h:599-640`: `std::string*` grows, `PinnableSlice*` borrows), so truncation is an artifact the Java binding introduced. **The C API, however, has since grown one and got it right** (`c.h:3583`):

```c
/* Returns 1 if value fits in buffer, 0 if buffer too small.
   Sets *vallen to actual value size.
   If buffer is too small, no data is copied but *vallen is set. */
unsigned char rocksdb_get_into_buffer(...);
```

That is `CopyResult` in C — including the no-partial-copy behavior #47 recommends and a `found` out-param that closes #44 — and its `PinnableSlice` is a stack local, avoiding the per-call `new`/`delete`. Phase 3 should be built on it. Details: https://github.com/dfa1/rocksdbffm/issues/47#issuecomment-5220888123

## Measurement status: unverified

The allocation changes are defensible on first principles, but every JMH run taken while preparing this was contaminated — a game at ~30% CPU, load average up to 5.8, and a three-fork run 6× slower across the board than single-fork runs minutes earlier.

**Retracted:** the claimed 1.4–3.5% wrapper-allocation regression, the 18.5% drop on `readsMemorySegment`, and the 2× advantage for pinned reads on 64 KiB values. No performance claim goes in the README until re-run on an idle machine:

```
./scripts/benchmark.sh PinnedReadBenchmark
./scripts/benchmark.sh PinnedReuseBenchmark
```

`scripts/benchmark.sh` no longer runs `mvn install` (CLAUDE.md forbids it), uses `./mvnw`, and takes an optional class argument.

## Testing

21 new tests in `GetPinnedTest`. **357 → 378 tests, 0 failures. Javadoc clean.**

## Not in scope

Phase 1 is additive, so the truncating overloads remain and still truncate. Phases 3 and 4 are breaking and belong in one release; #47 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
