### PR TITLE
Transaction#get: use rocksdb_transaction_get instead of PinnableSlice

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -21,6 +21,8 @@ public final class Transaction extends NativeObject {
 
 	/// `rocksdb_pinnableslice_t* rocksdb_transaction_get_pinned_cf(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen, char** errptr);`
 	private static final MethodHandle MH_GET_PINNED_CF;
+	/// `char* rocksdb_transaction_get(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, const char* key, size_t klen, size_t* vlen, char** errptr);`
+	private static final MethodHandle MH_GET;
 	/// `char* rocksdb_transaction_get_for_update_cf(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen, size_t* vlen, unsigned char exclusive, char** errptr);`
 	private static final MethodHandle MH_GET_FOR_UPDATE_CF;
 	/// `void rocksdb_transaction_put_cf(rocksdb_transaction_t* txn, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen, const char* val, size_t vlen, char** errptr);`
@@ -45,8 +47,6 @@ public final class Transaction extends NativeObject {
 	private static final MethodHandle MH_PUT;
 	/// `void rocksdb_transaction_delete(rocksdb_transaction_t* txn, const char* key, size_t klen, char** errptr);`
 	private static final MethodHandle MH_DELETE;
-	/// `rocksdb_pinnableslice_t* rocksdb_transaction_get_pinned(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, const char* key, size_t klen, char** errptr);`
-	private static final MethodHandle MH_GET_PINNED;
 	/// `char* rocksdb_transaction_get_for_update(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, const char* key, size_t klen, size_t* vlen, unsigned char exclusive, char** errptr);`
 	private static final MethodHandle MH_GET_FOR_UPDATE;
 	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
@@ -83,11 +83,11 @@ public final class Transaction extends NativeObject {
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
 
-		MH_GET_PINNED = NativeLibrary.lookup("rocksdb_transaction_get_pinned",
+		MH_GET = NativeLibrary.lookup("rocksdb_transaction_get",
 				FunctionDescriptor.of(ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
-						ValueLayout.ADDRESS));
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
 		MH_GET_FOR_UPDATE = NativeLibrary.lookup("rocksdb_transaction_get_for_update",
 				FunctionDescriptor.of(ValueLayout.ADDRESS,
@@ -182,8 +182,7 @@ public final class Transaction extends NativeObject {
 	// Read operations
 	// -----------------------------------------------------------------------
 
-	/// Reads the value for `key` within this transaction, using PinnableSlice
-	/// to avoid an intermediate copy. Returns `null` if not found.
+	/// Reads the value for `key` within this transaction. Returns `null` if not found.
 	///
 	/// Slow path: allocates native memory for the key.
 	///
@@ -194,21 +193,20 @@ public final class Transaction extends NativeObject {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment k = RocksDB.toNative(arena, key);
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 
-			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
-					ptr(), readOptions.ptr(), k, (long) key.length, err);
+			MemorySegment valPtr = (MemorySegment) MH_GET.invokeExact(
+					ptr(), readOptions.ptr(), k, (long) key.length, valLenSeg, err);
 
 			RocksDB.checkError(err);
 
-			if (MemorySegment.NULL.equals(pin)) {
+			if (MemorySegment.NULL.equals(valPtr)) {
 				return null;
 			}
 
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
 			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
 			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+			RocksDB.free(valPtr);
 			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);


### PR DESCRIPTION
## What

`Transaction#get(ReadOptions, byte[])` allocated a `PinnableSlice` via
`rocksdb_transaction_get_pinned`, read the value out of it, and then
immediately destroyed the slice on every call. As pointed out in #49,
the simpler `rocksdb_transaction_get` C API returns a malloc'd `char*`
buffer directly:

```c
char* rocksdb_transaction_get(
    rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options,
    const char* key, size_t klen, size_t* vlen, char** errptr);
```

This avoids the extra native allocation + destroy round trip per call.

## How

Switched `get()` to call `rocksdb_transaction_get` and free the result
with `RocksDB.free(...)`, mirroring the existing
`Transaction#getForUpdate` implementation in the same file, which
already uses this exact `char* + size_t* vlen + errptr` pattern and
frees via `rocksdb_free`. Removed the now-unused
`rocksdb_transaction_get_pinned` method handle
(`MH_GET_PINNED`); `MH_PINNABLESLICE_VALUE` / `MH_PINNABLESLICE_DESTROY`
are still used by the column-family-scoped `get(cf, ...)` overload,
which is out of scope for this issue and left as a possible follow-up.

## Testing

I could not run `./mvnw test` in my environment — it requires JDK 25
(only JDK 22 is available here) plus building the native RocksDB
library via `zig cc`/the `rocksdb` git submodule, which isn't set up
locally. The change was verified by hand against the working
`getForUpdate()` implementation in the same file, which uses the
identical `char*`/`vlen`/`errptr` calling convention this PR adopts.
Would appreciate CI (or a maintainer) confirming green.

Closes #49

---
Note: implemented with AI assistance (Claude); I reviewed and verified the diff against the existing code patterns in this file before submitting.