### PR TITLE
docs: fix CI badge rendering "no status"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![Windows](https://img.shields.io/badge/windows-fully_supported-green.svg)
 ![Windows aarch64](https://img.shields.io/badge/windows_aarch64-fully_supported-green.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![CI](https://github.com/dfa1/rocksdbffm/workflows/CI/badge.svg?branch=main)](https://github.com/dfa1/rocksdbffm/actions?query=branch=main)
+[![CI](https://github.com/dfa1/rocksdbffm/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dfa1/rocksdbffm/actions/workflows/ci.yml?query=branch%3Amain)
 
 **rocksdbffm** is an experimental Java wrapper for [RocksDB](https://rocksdb.org/) using the **Foreign
 Function & Memory (FFM) API**.


### PR DESCRIPTION
The CI badge in the README renders **no status** instead of the build result.

## Cause

It uses GitHub's legacy workflow-badge URL, `/workflows/<name>/badge.svg`, superseded by `/actions/workflows/<file>/badge.svg`. The legacy form no longer resolves the workflow. Fetching both:

```
/workflows/CI/badge.svg?branch=main             ->  <title>CI - no status</title>
/actions/workflows/ci.yml/badge.svg?branch=main ->  <title>CI - passing</title>
```

## Also fixed

The link target was malformed: `?query=branch=main` is not GitHub's filter syntax — it uses `branch:main`. So clicking the badge landed on an unfiltered list of every action run in the repository. It now points at `ci.yml` filtered to `branch%3Amain`.

## Before / after

| | |
|:--|:--|
| before | ![before](https://github.com/dfa1/rocksdbffm/workflows/CI/badge.svg?branch=main) |
| after | ![after](https://github.com/dfa1/rocksdbffm/actions/workflows/ci.yml/badge.svg?branch=main) |

One line, docs only. Branched from `main`, independent of #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
