### PR TITLE
chore: upgrade rocksdb submodule from v11.0.4 to v11.8.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This project is heavily AI-driven. As an agent, your goal is to:
 - **Language:** Java 25+.
 - **Core API:** `java.lang.foreign` (Foreign Function & Memory API).
 - **Native Library:** RocksDB (C API via `include/rocksdb/c.h`), built from the `rocksdb/` git submodule (pinned to
-  v11.0.4).
+  v11.8.1).
 - **Native Compiler:** `zig cc` / `zig c++` — used as a drop-in C/C++ compiler via
   `CC="zig cc" CXX="zig c++" PORTABLE=1 make shared_lib`. Zig bundles clang + libc++ for every target, enabling
   cross-compilation without a separate sysroot.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.dfa1/rocksdbffm-core.svg)](https://central.sonatype.com/artifact/io.github.dfa1/rocksdbffm-core)
 ![PURL](https://img.shields.io/badge/purl-pkg%3Amaven%2Fio.github.dfa1%2Frocksdbffm--core%400.6-blue)
-![RocksDB](https://img.shields.io/badge/RocksDB-11.0.4-green.svg)
+![RocksDB](https://img.shields.io/badge/RocksDB-11.8.1-green.svg)
 ![MacOS](https://img.shields.io/badge/macOS-fully_supported-green.svg)
 ![Linux](https://img.shields.io/badge/linux-fully_supported-green.svg)
 ![Linux aarch64](https://img.shields.io/badge/linux_aarch64-fully_supported-green.svg)
@@ -196,7 +196,7 @@ Benchmarks performed on JDK 25 (Apple M5). Each tier uses the same pre-seeded ke
 overhead, not cache miss variance.
 
 > **Note:** the two sides do not run the same RocksDB build, and cannot be made to. The FFM column uses the bundled
-> native library built from the `rocksdb/` submodule (**v11.0.4**). The JNI column uses `org.rocksdb:rocksdbjni`
+> native library built from the `rocksdb/` submodule (**v11.8.1**). The JNI column uses `org.rocksdb:rocksdbjni`
 > **10.10.1.1** — the newest release that exists, since `rocksdbjni` has published no 11.x at all. Treat the deltas as
 > indicative of binding overhead rather than a controlled like-for-like comparison; part of any difference may come
 > from the engine rather than the binding.

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<!--
 			JNI baseline used only by the benchmarks module to compare against.
 			This is NOT the version of the native library we ship: that is built
-			from the rocksdb/ submodule (v11.0.4). rocksdbjni has no 11.x release
+			from the rocksdb/ submodule (v11.8.1). rocksdbjni has no 11.x release
 			at all (10.10.1.1 is the newest published), so the two versions cannot
 			be aligned. See the note above the benchmark table in README.md.
 		-->


### PR DESCRIPTION
## Summary

Closes #53. Bumps the `rocksdb/` submodule pin from `v11.0.4` to `v11.8.1` and updates the version note in `CLAUDE.md`, `README.md`, and `pom.xml`.

- Diffed the full `include/rocksdb/c.h` symbol set between the two tags: one function (`rocksdb_writebatch_wi_create_from`) was removed upstream and is not referenced anywhere in this binding; every `rocksdb_*` symbol used in `core/src/main/java` is still present in v11.8.1.
- No new API mapped in this change — scope is intentionally limited to the version bump per #53. The expanded C API (11.6.0), async read APIs (11.8.0), and `FlushOptions::listener_wait` (11.8.0) mentioned in #53 are left for follow-up issues.
- Rebuilt the native library for all five bundled classifiers (osx-aarch64, linux-x86_64, linux-aarch64, windows-x86_64, windows-aarch64) via zig cc/c++ against the new submodule commit.

## Test plan

- [x] `./mvnw generate-resources -Pnative-build` — rebuilt native libs for all 5 classifiers against v11.8.1
- [x] `./mvnw test -pl core -am` — 404 tests, 0 failures, 0 errors
- [x] `./mvnw javadoc:javadoc -pl core` — zero output

🤖 Generated with [Claude Code](https://claude.com/claude-code)