### PR TITLE
feat: scoped zero-copy get(key, Mapper) across every DB type + RocksIterator

### DIFF
--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/BenchmarkRunner.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/BenchmarkRunner.java
@@ -19,6 +19,7 @@ import java.util.Map;
 ///   - byte[]       — FFM vs JNI
 ///   - ByteBuffer   — FFM vs JNI
 ///   - MemorySegment — FFM only (no JNI equivalent)
+///   - Instant deserialize: byte[] get vs zero-copy get(key, Mapper) — FFM only (no JNI equivalent)
 public class BenchmarkRunner {
 
 	// Display order drives LABELS iteration — ROW_ORDER is unused (LABELS is LinkedHashMap)
@@ -30,6 +31,8 @@ public class BenchmarkRunner {
 		LABELS.put("readsBytes", "Read  — byte[]");
 		LABELS.put("readsDirectByteBuffer", "Read  — DirectByteBuffer");
 		LABELS.put("readsMemorySegment", "Read  — MemorySegment (FFM)");
+		LABELS.put("readsInstantViaByteArray", "Read Instant — byte[] + deserialize");
+		LABELS.put("readsInstantViaPinned", "Read Instant — get(key, Mapper) (FFM)");
 		LABELS.put("writesBytes", "Write — byte[]");
 		LABELS.put("writesDirectByteBuffer", "Write — DirectByteBuffer");
 		LABELS.put("writesMemorySegment", "Write — MemorySegment (FFM)");

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/BenchmarkRunner.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/BenchmarkRunner.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /// Runs FFM and JNI benchmarks back-to-back and prints a comparison table.
 /// ```
@@ -20,6 +21,10 @@ import java.util.Map;
 ///   - ByteBuffer   — FFM vs JNI
 ///   - MemorySegment — FFM only (no JNI equivalent)
 ///   - Instant deserialize: byte[] get vs zero-copy get(key, Mapper) — FFM only (no JNI equivalent)
+///   - Blob read, size-swept: byte[] vs MemorySegment vs get(key, Mapper), 8 B..1 MB (FFM only) —
+///     [FfmBlobSizeBenchmark], printed as its own per-size table since it has no single mean
+///     to fold into the row above (folding it in either drops five of the six sizes measured,
+///     or silently keeps only the last one, which is what happened before this table existed)
 public class BenchmarkRunner {
 
 	// Display order drives LABELS iteration — ROW_ORDER is unused (LABELS is LinkedHashMap)
@@ -47,6 +52,8 @@ public class BenchmarkRunner {
 		run(JniBenchmark.class, "JNI", scores, 1);
 
 		printTable(scores);
+
+		runBlobSizeSweep();
 	}
 
 	private static void run(Class<?> benchClass, String label, Map<String, double[]> scores, int col)
@@ -94,6 +101,54 @@ public class BenchmarkRunner {
 		String jniStr = jniAvail ? String.format("%,14.0f", jni) : "           N/A";
 		String gainStr = jniAvail ? String.format("%+7.1f%%", (ffm - jni) / jni * 100) : "    N/A";
 		System.out.printf("%-32s %,14.0f %s %s%n", label, ffm, jniStr, gainStr);
+	}
+
+	private static void runBlobSizeSweep() throws Exception {
+		System.out.printf("%n=== FFM: blob read, size sweep ===%n%n");
+		Options opt = new OptionsBuilder()
+				.include(FfmBlobSizeBenchmark.class.getSimpleName())
+				.build();
+		Collection<RunResult> results = new Runner(opt).run();
+
+		// blobValueSize -> [byte[], MemorySegment, Pinned (Mapper)]
+		Map<Long, double[]> bySize = new TreeMap<>();
+		for (RunResult r : results) {
+			String name = r.getPrimaryResult().getLabel();
+			long size = Long.parseLong(r.getParams().getParam("blobValueSize"));
+			double mean = r.getPrimaryResult().getStatistics().getMean();
+			double[] row = bySize.computeIfAbsent(size, k -> new double[3]);
+			switch (name) {
+				case "readsBlobViaByteArray" -> row[0] = mean;
+				case "readsBlobViaMemorySegment" -> row[1] = mean;
+				case "readsBlobViaPinned" -> row[2] = mean;
+				default -> throw new IllegalStateException("unexpected benchmark: " + name);
+			}
+		}
+
+		System.out.println();
+		System.out.println("=".repeat(88));
+		System.out.printf("%-12s %16s %16s %18s %10s%n",
+				"Value size", "byte[]", "MemorySegment", "Pinned (Mapper)", "Gain*");
+		System.out.println("-".repeat(88));
+		for (Map.Entry<Long, double[]> e : bySize.entrySet()) {
+			double[] v = e.getValue();
+			double gain = (v[2] - v[0]) / v[0] * 100;
+			System.out.printf("%-12s %,16.0f %,16.0f %,18.0f %+9.1f%%%n",
+					formatSize(e.getKey()), v[0], v[1], v[2], gain);
+		}
+		System.out.println("-".repeat(88));
+		System.out.println("* Pinned (Mapper) vs byte[]");
+		System.out.println("=".repeat(88));
+	}
+
+	private static String formatSize(long bytes) {
+		if (bytes >= 1024 * 1024) {
+			return (bytes / (1024 * 1024)) + " MB";
+		}
+		if (bytes >= 1024) {
+			return (bytes / 1024) + " KB";
+		}
+		return bytes + " B";
 	}
 
 	private BenchmarkRunner() {

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
@@ -11,7 +11,6 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -29,7 +28,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.Throughput)
@@ -73,17 +71,6 @@ public class FfmBenchmark {
 	private byte[] instantKeyBytes;
 	private MemorySegment instantKeyMemorySegment;
 
-	// Blob tier — same byte[] get vs get(key, Mapper) comparison, swept across value sizes to
-	// see whether the zero-copy gain grows with the amount of data that would otherwise
-	// be copied. JMH requires @Param fields to be public.
-	@Param({"8", "16", "1024", "4096", "65536", "1048576"})
-	public int blobValueSize;
-	private byte[] blobKeyBytes;
-	private MemorySegment blobKeyMemorySegment;
-	// Pre-allocated exactly once at trial size, reused across all invocations — models a
-	// caller who already knows the value size and sizes their buffer accordingly.
-	private MemorySegment blobValueMemorySegment;
-
 	@Setup(Level.Trial)
 	public void setup() throws Exception {
 		dbPath = Files.createTempDirectory("bench-ffm-");
@@ -119,14 +106,6 @@ public class FfmBenchmark {
 		ByteBuffer instantValue = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.nativeOrder());
 		instantValue.putLong(Instant.now().getEpochSecond());
 		db.put(instantKeyBytes, instantValue.array());
-
-		// --- blob tier ---
-		blobKeyBytes = "blob-key".getBytes();
-		blobKeyMemorySegment = arenaMemorySegment.allocateFrom(ValueLayout.JAVA_BYTE, blobKeyBytes);
-		byte[] blobValue = new byte[blobValueSize];
-		new Random(42).nextBytes(blobValue);
-		db.put(blobKeyBytes, blobValue);
-		blobValueMemorySegment = arenaMemorySegment.allocate(blobValueSize);
 
 		// --- batch: byte[] tier ---
 		batchKeys = TestData.batchKeys();
@@ -239,26 +218,6 @@ public class FfmBenchmark {
 	public Instant readsInstantViaPinned() {
 		return db.get(instantKeyMemorySegment,
 				value -> Instant.ofEpochSecond(value.get(ValueLayout.JAVA_LONG, 0))).orElseThrow();
-	}
-
-	// ---- Blob read, value size swept via @Param: three tiers -----------------
-	// byte[] get (allocates a new array every call), get(MemorySegment,MemorySegment)
-	// (caller-preallocated buffer, still a native memcpy into it), and get(key, Mapper)
-	// (zero-copy, no allocation and no copy at all).
-
-	@Benchmark
-	public int readsBlobViaByteArray() {
-		return db.get(blobKeyBytes).length;
-	}
-
-	@Benchmark
-	public CopyResult readsBlobViaMemorySegment() {
-		return db.get(blobKeyMemorySegment, blobValueMemorySegment);
-	}
-
-	@Benchmark
-	public long readsBlobViaPinned() {
-		return db.get(blobKeyMemorySegment, MemorySegment::byteSize).orElseThrow();
 	}
 
 	// ---- batch (byte[] keys, same as JNI) ---------------------------------

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
@@ -11,6 +11,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -25,7 +26,10 @@ import java.nio.file.Files;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.Throughput)
@@ -65,6 +69,21 @@ public class FfmBenchmark {
 	private MemorySegment[] batchKeysMemorySegment;
 	private MemorySegment[] batchValuesMemorySegment;
 
+	// Instant tier — 8-byte long value, byte[] get + deserialize vs zero-copy get(key, Mapper)
+	private byte[] instantKeyBytes;
+	private MemorySegment instantKeyMemorySegment;
+
+	// Blob tier — same byte[] get vs get(key, Mapper) comparison, swept across value sizes to
+	// see whether the zero-copy gain grows with the amount of data that would otherwise
+	// be copied. JMH requires @Param fields to be public.
+	@Param({"8", "16", "1024", "4096", "65536", "1048576"})
+	public int blobValueSize;
+	private byte[] blobKeyBytes;
+	private MemorySegment blobKeyMemorySegment;
+	// Pre-allocated exactly once at trial size, reused across all invocations — models a
+	// caller who already knows the value size and sizes their buffer accordingly.
+	private MemorySegment blobValueMemorySegment;
+
 	@Setup(Level.Trial)
 	public void setup() throws Exception {
 		dbPath = Files.createTempDirectory("bench-ffm-");
@@ -93,6 +112,21 @@ public class FfmBenchmark {
 
 		// Seed the read key
 		db.put(TestData.READ_KEY_BYTES, TestData.READ_VALUE_BYTES);
+
+		// --- Instant tier ---
+		instantKeyBytes = "instant-key".getBytes();
+		instantKeyMemorySegment = arenaMemorySegment.allocateFrom(ValueLayout.JAVA_BYTE, instantKeyBytes);
+		ByteBuffer instantValue = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.nativeOrder());
+		instantValue.putLong(Instant.now().getEpochSecond());
+		db.put(instantKeyBytes, instantValue.array());
+
+		// --- blob tier ---
+		blobKeyBytes = "blob-key".getBytes();
+		blobKeyMemorySegment = arenaMemorySegment.allocateFrom(ValueLayout.JAVA_BYTE, blobKeyBytes);
+		byte[] blobValue = new byte[blobValueSize];
+		new Random(42).nextBytes(blobValue);
+		db.put(blobKeyBytes, blobValue);
+		blobValueMemorySegment = arenaMemorySegment.allocate(blobValueSize);
 
 		// --- batch: byte[] tier ---
 		batchKeys = TestData.batchKeys();
@@ -190,6 +224,41 @@ public class FfmBenchmark {
 	@Benchmark
 	public CopyResult readsMemorySegment() {
 		return db.get(readKeyMemorySegment, readValMemorySegment);
+	}
+
+	// ---- Instant deserialize: byte[] get vs zero-copy get(key, Mapper) (FFM-only) ----
+
+	@Benchmark
+	public Instant readsInstantViaByteArray() {
+		byte[] value = db.get(instantKeyBytes);
+		long epochSecond = ByteBuffer.wrap(value).order(ByteOrder.nativeOrder()).getLong();
+		return Instant.ofEpochSecond(epochSecond);
+	}
+
+	@Benchmark
+	public Instant readsInstantViaPinned() {
+		return db.get(instantKeyMemorySegment,
+				value -> Instant.ofEpochSecond(value.get(ValueLayout.JAVA_LONG, 0))).orElseThrow();
+	}
+
+	// ---- Blob read, value size swept via @Param: three tiers -----------------
+	// byte[] get (allocates a new array every call), get(MemorySegment,MemorySegment)
+	// (caller-preallocated buffer, still a native memcpy into it), and get(key, Mapper)
+	// (zero-copy, no allocation and no copy at all).
+
+	@Benchmark
+	public int readsBlobViaByteArray() {
+		return db.get(blobKeyBytes).length;
+	}
+
+	@Benchmark
+	public CopyResult readsBlobViaMemorySegment() {
+		return db.get(blobKeyMemorySegment, blobValueMemorySegment);
+	}
+
+	@Benchmark
+	public long readsBlobViaPinned() {
+		return db.get(blobKeyMemorySegment, MemorySegment::byteSize).orElseThrow();
 	}
 
 	// ---- batch (byte[] keys, same as JNI) ---------------------------------

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBlobSizeBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBlobSizeBenchmark.java
@@ -1,0 +1,109 @@
+package io.github.dfa1.rocksdbffm.benchmark;
+
+import io.github.dfa1.rocksdbffm.CopyResult;
+import io.github.dfa1.rocksdbffm.ReadWriteDB;
+import io.github.dfa1.rocksdbffm.RocksDB;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/// Blob read, value size swept via `@Param`: three tiers — byte[] get (allocates a new array
+/// every call), get(MemorySegment,MemorySegment) (caller-preallocated buffer, still a native
+/// memcpy into it), and get(key, Mapper) (zero-copy, no allocation and no copy at all).
+///
+/// Kept in its own class/state, separate from [FfmBenchmark]: `@Param` is applied at the
+/// `@State` level, so every benchmark method sharing that state reruns once per parameter
+/// value even when the method doesn't use the parameter. Folding this sweep into
+/// [FfmBenchmark] used to force its unrelated byte[]/ByteBuffer/MemorySegment/Instant
+/// benchmarks to run six times each (once per blob size) for no reason — for the Instant
+/// benchmarks specifically, it also meant each trial ran alongside a co-resident blob value
+/// (up to 1 MB) written into the same DB, silently skewing block-cache behavior for those
+/// unrelated reads.
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 1, jvmArgsPrepend = {"--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow"})
+public class FfmBlobSizeBenchmark {
+
+	private ReadWriteDB db;
+	private Path dbPath;
+	private Arena arena;
+
+	// JMH requires @Param fields to be public.
+	@Param({"8", "16", "1024", "4096", "65536", "1048576"})
+	public int blobValueSize;
+
+	private byte[] blobKeyBytes;
+	private MemorySegment blobKeyMemorySegment;
+	// Pre-allocated exactly once at trial size, reused across all invocations — models a
+	// caller who already knows the value size and sizes their buffer accordingly.
+	private MemorySegment blobValueMemorySegment;
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		dbPath = Files.createTempDirectory("bench-ffm-blob-");
+		db = RocksDB.openReadWrite(dbPath);
+		arena = Arena.ofConfined();
+
+		blobKeyBytes = "blob-key".getBytes();
+		blobKeyMemorySegment = arena.allocateFrom(ValueLayout.JAVA_BYTE, blobKeyBytes);
+		byte[] blobValue = new byte[blobValueSize];
+		new Random(42).nextBytes(blobValue);
+		db.put(blobKeyBytes, blobValue);
+		blobValueMemorySegment = arena.allocate(blobValueSize);
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() throws IOException {
+		db.close();
+		arena.close();
+		TestData.deleteDir(dbPath);
+	}
+
+	@Benchmark
+	public int readsBlobViaByteArray() {
+		return db.get(blobKeyBytes).length;
+	}
+
+	@Benchmark
+	public CopyResult readsBlobViaMemorySegment() {
+		return db.get(blobKeyMemorySegment, blobValueMemorySegment);
+	}
+
+	@Benchmark
+	public long readsBlobViaPinned() {
+		return db.get(blobKeyMemorySegment, MemorySegment::byteSize).orElseThrow();
+	}
+
+	static void main() throws Exception {
+		org.openjdk.jmh.runner.options.Options opt = new OptionsBuilder()
+				.addProfiler(GCProfiler.class)
+				.include(FfmBlobSizeBenchmark.class.getSimpleName())
+				.build();
+
+		new org.openjdk.jmh.runner.Runner(opt).run();
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
@@ -123,6 +123,23 @@ public final class BlobDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
+	/// read-only view of the value directly to `fn`, with no intermediate copy.
+	///
+	/// The view passed to `fn` is bound to an arena that is closed the moment `fn`
+	/// returns, so it must not be retained beyond the call — doing so throws
+	/// `IllegalStateException` (used after this call returns) or `WrongThreadException`
+	/// (used from another thread) rather than reading freed memory.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinned(ptr(), readOpts.ptr(), key, fn);
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Mapper.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Mapper.java
@@ -1,0 +1,21 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.MemorySegment;
+
+/// Callback invoked by scoped zero-copy reads with a view of a pinned value.
+///
+/// The segment is only valid for the duration of [#map(MemorySegment)]; it is bound to
+/// an arena that is closed as soon as this method returns, so it — and any view derived
+/// from it — must not be retained past the call.
+///
+/// @param <R> the type produced from mapping the pinned value
+@FunctionalInterface
+public interface Mapper<R> {
+
+	/// Maps `value` to a result. Every caller in this codebase rejects a `null` return
+	/// with `NullPointerException` rather than accepting it silently.
+	///
+	/// @param value zero-copy, read-only view of the pinned value
+	/// @return the value produced from `value`; must not be `null`
+	R map(MemorySegment value);
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/NativeLibrary.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/NativeLibrary.java
@@ -20,11 +20,11 @@ public class NativeLibrary {
 	private static final Linker LINKER = Linker.nativeLinker();
 	private static final SymbolLookup LIB = SymbolLookup.libraryLookup(resolveLibPath(), Arena.ofAuto());
 
-	static MethodHandle lookup(String name, FunctionDescriptor fd) {
+	static MethodHandle lookup(String name, FunctionDescriptor fd, Linker.Option... options) {
 		return LINKER.downcallHandle(
 				LIB.find(name).orElseThrow(() ->
 						new UnsatisfiedLinkError("Symbol not found: " + name)),
-				fd);
+				fd, options);
 	}
 
 	private static String resolveLibPath() {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
@@ -175,6 +175,23 @@ public final class OptimisticTransactionDB extends NativeObject {
 		return RocksDB.getIntoSegment(baseDb, readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
+	/// read-only view of the value directly to `fn`, with no intermediate copy.
+	///
+	/// The view passed to `fn` is bound to an arena that is closed the moment `fn`
+	/// returns, so it must not be retained beyond the call — doing so throws
+	/// `IllegalStateException` (used after this call returns) or `WrongThreadException`
+	/// (used from another thread) rather than reading freed memory.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinned(baseDb, readOpts.ptr(), key, fn);
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete
 	// -----------------------------------------------------------------------
@@ -322,6 +339,19 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// small, or [CopyResult.NotFound] if the key is absent
 	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(baseDb, readOpts.ptr(), cf, key, key.byteSize(), value);
+	}
+
+	/// Scoped zero-copy get from `cf`. See [#get(MemorySegment, Mapper)] for
+	/// the lifetime contract on the view passed to `fn`.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinnedCf(baseDb, readOpts.ptr(), cf, key, fn);
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
@@ -68,6 +68,23 @@ public final class ReadOnlyDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
+	/// read-only view of the value directly to `fn`, with no intermediate copy.
+	///
+	/// The view passed to `fn` is bound to an arena that is closed the moment `fn`
+	/// returns, so it must not be retained beyond the call — doing so throws
+	/// `IllegalStateException` (used after this call returns) or `WrongThreadException`
+	/// (used from another thread) rather than reading freed memory.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinned(ptr(), readOpts.ptr(), key, fn);
+	}
+
 	/// Returns the value for `key` in `cf`, or `null` if not found.
 	///
 	/// @param cf  column family to read from
@@ -110,6 +127,19 @@ public final class ReadOnlyDB extends NativeObject {
 	/// small, or [CopyResult.NotFound] if the key is absent
 	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(ptr(), readOpts.ptr(), cf, key, key.byteSize(), value);
+	}
+
+	/// Scoped zero-copy get from `cf`. See [#get(MemorySegment, Mapper)] for
+	/// the lifetime contract on the view passed to `fn`.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinnedCf(ptr(), readOpts.ptr(), cf, key, fn);
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -122,6 +122,36 @@ public final class ReadWriteDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
+	/// read-only view of the value directly to `fn`, with no intermediate copy.
+	///
+	/// The view passed to `fn` is bound to an arena that is closed the moment `fn`
+	/// returns, so it must not be retained beyond the call — doing so throws
+	/// `IllegalStateException` (used after this call returns) or `WrongThreadException`
+	/// (used from another thread) rather than reading freed memory.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinned(ptr(), readOpts.ptr(), key, fn);
+	}
+
+	/// Scoped zero-copy get from `cf`. See [#get(MemorySegment, Mapper)] for
+	/// the lifetime contract on the view passed to `fn`.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinnedCf(ptr(), readOpts.ptr(), cf, key, fn);
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -2,6 +2,7 @@ package io.github.dfa1.rocksdbffm;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
@@ -11,6 +12,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 
@@ -64,6 +66,14 @@ public final class RocksDB {
 	private static final MethodHandle MH_PINNABLESLICE_VALUE;
 	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
 	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
+	/// `rocksdb_pinnable_handle_t* rocksdb_get_pinned_v2(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char** errptr);`
+	private static final MethodHandle MH_GET_PINNED_V2;
+	/// `rocksdb_pinnable_handle_t* rocksdb_get_pinned_cf_v2(rocksdb_t* db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char** errptr);`
+	private static final MethodHandle MH_GET_PINNED_CF_V2;
+	/// `const char* rocksdb_pinnable_handle_get_value(const rocksdb_pinnable_handle_t* handle, size_t* vallen);`
+	private static final MethodHandle MH_PINNABLE_HANDLE_GET_VALUE;
+	/// `void rocksdb_pinnable_handle_destroy(rocksdb_pinnable_handle_t* handle);`
+	private static final MethodHandle MH_PINNABLE_HANDLE_DESTROY;
 	/// `void rocksdb_put(rocksdb_t* db, const rocksdb_writeoptions_t* options, const char* key, size_t keylen, const char* val, size_t vallen, char** errptr);`
 	private static final MethodHandle MH_PUT;
 	/// `void rocksdb_delete(rocksdb_t* db, const rocksdb_writeoptions_t* options, const char* key, size_t keylen, char** errptr);`
@@ -212,6 +222,31 @@ public final class RocksDB {
 
 		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+		// get_pinned_*_v2 can block on disk I/O (a Get), so it must NOT be marked
+		// critical: a critical downcall stalls GC for its entire duration.
+		MH_GET_PINNED_V2 = NativeLibrary.lookup("rocksdb_get_pinned_v2",
+				FunctionDescriptor.of(ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
+		MH_GET_PINNED_CF_V2 = NativeLibrary.lookup("rocksdb_get_pinned_cf_v2",
+				FunctionDescriptor.of(ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
+		// get_value/destroy are pure in-memory pointer arithmetic — safe and worth
+		// marking critical(false) (no heap-array access) to skip transition overhead.
+		MH_PINNABLE_HANDLE_GET_VALUE = NativeLibrary.lookup("rocksdb_pinnable_handle_get_value",
+				FunctionDescriptor.of(ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+				Linker.Option.critical(false));
+
+		MH_PINNABLE_HANDLE_DESTROY = NativeLibrary.lookup("rocksdb_pinnable_handle_destroy",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
+				Linker.Option.critical(false));
 
 		MH_PUT = NativeLibrary.lookup("rocksdb_put",
 				FunctionDescriptor.ofVoid(
@@ -708,6 +743,105 @@ public final class RocksDB {
 			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// withPinned — scoped zero-copy get via rocksdb_pinnable_handle_t
+	// -----------------------------------------------------------------------
+
+	/// Scoped zero-copy get via `rocksdb_get_pinned_v2`. Thin wrapper around the
+	/// handle-specific downcall; [#withPinnedCore] owns the actual lifetime logic.
+	static <R> Optional<R> withPinned(MemorySegment db, MemorySegment readOpts,
+	                                   MemorySegment key, Mapper<R> fn) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment scratch = errHolder(arena);
+			MemorySegment handle;
+			try {
+				handle = (MemorySegment) MH_GET_PINNED_V2.invokeExact(db, readOpts, key, key.byteSize(), scratch);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("get_pinned failed", t);
+			}
+			return withPinnedCore(arena, scratch, handle,
+					MH_PINNABLE_HANDLE_GET_VALUE, MH_PINNABLE_HANDLE_DESTROY, fn);
+		}
+	}
+
+	/// Scoped zero-copy get from `cf` via `rocksdb_get_pinned_cf_v2`. Thin wrapper
+	/// around the handle-specific downcall; [#withPinnedCore] owns the lifetime logic.
+	static <R> Optional<R> withPinnedCf(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
+	                                     MemorySegment key, Mapper<R> fn) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment scratch = errHolder(arena);
+			MemorySegment handle;
+			try {
+				handle = (MemorySegment) MH_GET_PINNED_CF_V2.invokeExact(
+						db, readOpts, cf.ptr(), key, key.byteSize(), scratch);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("get_pinned failed", t);
+			}
+			return withPinnedCore(arena, scratch, handle,
+					MH_PINNABLE_HANDLE_GET_VALUE, MH_PINNABLE_HANDLE_DESTROY, fn);
+		}
+	}
+
+	/// Shared core for every scoped zero-copy `get(key, Mapper)` in this codebase,
+	/// regardless of which native handle kind backs it: `rocksdb_pinnable_handle_t`
+	/// (`get_pinned_v2`/`_cf_v2`, used everywhere a plain `rocksdb_t*` exists — see
+	/// [#withPinned]/[#withPinnedCf] above) or `rocksdb_pinnableslice_t` (the older API,
+	/// still needed by [TransactionDB] and [Transaction] — the only two wrappers with no
+	/// `_v2` equivalent in `rocksdb/include/rocksdb/c.h`). Both handle kinds expose the
+	/// same shape — `getValue(handle, size_t* vallen) -> const char*` then
+	/// `destroy(handle) -> void` — so one method covers both; `valueHandle`/
+	/// `destroyHandle` are the caller's own bindings for whichever pair applies. The
+	/// caller has already opened `arena` in its own try-with-resources (closed once this
+	/// method returns) and obtained `scratch` (its `errptr` slot) and `handle` (or
+	/// `MemorySegment.NULL` for NotFound/error) via its own class-specific
+	/// `get_pinned`/`get_pinned_cf` downcall.
+	///
+	/// `scratch` is the same native slot the caller already used as `errptr`: once
+	/// [#checkError] passes below, that slot is dead, so `valueHandle`'s
+	/// `size_t* vallen` out-param reuses it in place instead of a second
+	/// `arena.allocate` call.
+	///
+	/// The native handle is destroyed in the `finally` block below, BEFORE the caller's
+	/// try-with-resources closes `arena` on return. That means a segment that escapes
+	/// `fn` and is read back on the calling thread, in the narrow gap between this
+	/// method returning and the caller's arena actually closing, would be a genuine
+	/// use-after-free rather than a loud failure — but no caller code runs in that gap
+	/// (it is a single native destroy call immediately followed by the caller's resource
+	/// close, with nothing in between), and cross-thread access is independently blocked
+	/// by the confined arena's thread-ownership check regardless of open/closed state.
+	/// So in practice an escaped segment still fails loudly: `IllegalStateException` once
+	/// the caller's arena closes, or `WrongThreadException` from another thread.
+	static <R> Optional<R> withPinnedCore(Arena arena, MemorySegment scratch, MemorySegment handle,
+	                                       MethodHandle valueHandle, MethodHandle destroyHandle, Mapper<R> fn) {
+		checkError(scratch);
+		if (MemorySegment.NULL.equals(handle)) {
+			return Optional.empty();
+		}
+		try {
+			MemorySegment data;
+			try {
+				data = (MemorySegment) valueHandle.invokeExact(handle, scratch);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("pinned handle get_value failed", t);
+			}
+			long len = scratch.get(ValueLayout.JAVA_LONG, 0);
+			// The `null` cleanup is deliberate: this view borrows from the handle, it
+			// does not own the memory, so closing `arena` must not attempt to free it.
+			MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
+			R result = fn.map(view);
+			Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
+			return Optional.of(result);
+		} finally {
+			try {
+				destroyHandle.invokeExact(handle);
+			} catch (Throwable t) {
+				// Swallowed deliberately: a destroy failure here must not mask an
+				// exception already in flight from fn.map above. Same convention as
+				// NativeObject#close().
+			}
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
@@ -6,6 +6,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.Optional;
 
 /// FFM wrapper for `rocksdb_iterator_t`.
@@ -320,6 +321,64 @@ public final class RocksIterator extends NativeObject {
 			return data.reinterpret(lenSegment.get(ValueLayout.JAVA_LONG, 0));
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("value failed", t);
+		}
+	}
+
+	/// Scoped zero-copy read of the current key. `fn` receives a read-only view valid
+	/// only for the duration of this call.
+	///
+	/// Unlike [#keySegment()], the view here is bound to an arena that closes the moment
+	/// `fn` returns. [#next()], [#prev()], [#seek(byte[])], and friends reuse the
+	/// iterator's internal buffer in place rather than allocating a new one, so a plain
+	/// [#keySegment()] view that escapes past the next positioning call does not fail —
+	/// it silently starts reporting a different key's bytes. Scoping the view to this
+	/// call turns that into a loud failure instead: `IllegalStateException` if used after
+	/// this call returns, `WrongThreadException` if handed to another thread.
+	///
+	/// Only call when [#isValid()] is true.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param fn  callback invoked with a zero-copy view of the current key
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`
+	public <R> R key(Mapper<R> fn) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment data;
+			try {
+				data = (MemorySegment) MH_KEY.invokeExact(ptr(), lenSegment);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("key failed", t);
+			}
+			long len = lenSegment.get(ValueLayout.JAVA_LONG, 0);
+			MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
+			R result = fn.map(view);
+			Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
+			return result;
+		}
+	}
+
+	/// Scoped zero-copy read of the current value. See [#key(Mapper)] for the
+	/// lifetime contract on the view passed to `fn`.
+	///
+	/// Only call when [#isValid()] is true.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param fn  callback invoked with a zero-copy view of the current value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`
+	public <R> R value(Mapper<R> fn) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment data;
+			try {
+				data = (MemorySegment) MH_VALUE.invokeExact(ptr(), lenSegment);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("value failed", t);
+			}
+			long len = lenSegment.get(ValueLayout.JAVA_LONG, 0);
+			MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
+			R result = fn.map(view);
+			Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
+			return result;
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
@@ -114,6 +114,23 @@ public final class SecondaryDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
+	/// read-only view of the value directly to `fn`, with no intermediate copy.
+	///
+	/// The view passed to `fn` is bound to an arena that is closed the moment `fn`
+	/// returns, so it must not be retained beyond the call — doing so throws
+	/// `IllegalStateException` (used after this call returns) or `WrongThreadException`
+	/// (used from another thread) rather than reading freed memory.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinned(ptr(), readOpts.ptr(), key, fn);
+	}
+
 	// -----------------------------------------------------------------------
 	// Iterator
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -6,6 +6,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 
 /// FFM wrapper for `rocksdb_transaction_t`.
 ///
@@ -337,6 +338,33 @@ public final class Transaction extends NativeObject {
 		}
 	}
 
+	/// Scoped zero-copy get: reads `key` via `rocksdb_transaction_get_pinned` and passes
+	/// a read-only view of the value directly to `fn`, with no intermediate copy.
+	///
+	/// The view passed to `fn` is bound to an arena that is closed the moment `fn`
+	/// returns, so it must not be retained beyond the call — doing so throws
+	/// `IllegalStateException` (used after this call returns) or `WrongThreadException`
+	/// (used from another thread) rather than reading freed memory.
+	///
+	/// @param <R>         the type produced by `fn`
+	/// @param readOptions read options for this read
+	/// @param key         native segment containing the key
+	/// @param fn          callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin;
+			try {
+				pin = (MemorySegment) MH_GET_PINNED.invokeExact(ptr(), readOptions.ptr(), key, key.byteSize(), err);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("get_pinned failed", t);
+			}
+			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+		}
+	}
+
 	/// Reads the value for `key` and acquires a pessimistic lock on it for
 	/// the duration of this transaction. Returns `null` if not found.
 	///
@@ -631,6 +659,32 @@ public final class Transaction extends NativeObject {
 			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Scoped zero-copy get from `cf`. See
+	/// [#get(ReadOptions, MemorySegment, Mapper)] for the lifetime contract on
+	/// the view passed to `fn`.
+	///
+	/// @param <R>         the type produced by `fn`
+	/// @param cf          column family to read from
+	/// @param readOptions read options for this read
+	/// @param key         native segment containing the key
+	/// @param fn          callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key,
+	                            Mapper<R> fn) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin;
+			try {
+				pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+						ptr(), readOptions.ptr(), cf.ptr(), key, key.byteSize(), err);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("get_pinned failed", t);
+			}
+			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -54,6 +54,8 @@ public final class TransactionDB extends NativeObject {
 	private static final MethodHandle MH_DELETE;
 	/// `char* rocksdb_transactiondb_get(rocksdb_transactiondb_t* txn_db, const rocksdb_readoptions_t* options, const char* key, size_t klen, size_t* vlen, char** errptr);`
 	private static final MethodHandle MH_GET;
+	/// `rocksdb_pinnableslice_t* rocksdb_transactiondb_get_pinned(rocksdb_transactiondb_t* txn_db, const rocksdb_readoptions_t* options, const char* key, size_t klen, char** errptr);`
+	private static final MethodHandle MH_GET_PINNED;
 
 	// Column-family variants
 	/// `void rocksdb_transactiondb_put_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_writeoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, const char* val, size_t vallen, char** errptr);`
@@ -99,6 +101,12 @@ public final class TransactionDB extends NativeObject {
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+		MH_GET_PINNED = NativeLibrary.lookup("rocksdb_transactiondb_get_pinned",
+				FunctionDescriptor.of(ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
 
 		MH_PUT_CF = NativeLibrary.lookup("rocksdb_transactiondb_put_cf",
 				FunctionDescriptor.ofVoid(
@@ -425,6 +433,32 @@ public final class TransactionDB extends NativeObject {
 		}
 	}
 
+	/// Scoped zero-copy get: reads `key` via `rocksdb_transactiondb_get_pinned` and passes
+	/// a read-only view of the value directly to `fn`, with no intermediate copy.
+	///
+	/// The view passed to `fn` is bound to an arena that is closed the moment `fn`
+	/// returns, so it must not be retained beyond the call — doing so throws
+	/// `IllegalStateException` (used after this call returns) or `WrongThreadException`
+	/// (used from another thread) rather than reading freed memory.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin;
+			try {
+				pin = (MemorySegment) MH_GET_PINNED.invokeExact(ptr(), readOpts.ptr(), key, key.byteSize(), err);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("get_pinned failed", t);
+			}
+			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+		}
+	}
+
 	// -----------------------------------------------------------------------
 	// DB Properties
 	// -----------------------------------------------------------------------
@@ -706,6 +740,28 @@ public final class TransactionDB extends NativeObject {
 			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
+		}
+	}
+
+	/// Scoped zero-copy get from `cf`. See [#get(MemorySegment, Mapper)] for
+	/// the lifetime contract on the view passed to `fn`.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin;
+			try {
+				pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(ptr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
+			} catch (Throwable t) {
+				throw RocksDBException.wrap("get_pinned failed", t);
+			}
+			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
@@ -136,6 +136,23 @@ public final class TtlDB extends NativeObject {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
+	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
+	/// read-only view of the value directly to `fn`, with no intermediate copy.
+	///
+	/// The view passed to `fn` is bound to an arena that is closed the moment `fn`
+	/// returns, so it must not be retained beyond the call — doing so throws
+	/// `IllegalStateException` (used after this call returns) or `WrongThreadException`
+	/// (used from another thread) rather than reading freed memory.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinned(ptr(), readOpts.ptr(), key, fn);
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete
 	// -----------------------------------------------------------------------
@@ -340,6 +357,19 @@ public final class TtlDB extends NativeObject {
 	/// small, or [CopyResult.NotFound] if the key is absent
 	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(ptr(), readOpts.ptr(), cf, key, key.byteSize(), value);
+	}
+
+	/// Scoped zero-copy get from `cf`. See [#get(MemorySegment, Mapper)] for
+	/// the lifetime contract on the view passed to `fn`.
+	///
+	/// @param <R> the type produced by `fn`
+	/// @param cf  target column family
+	/// @param key native segment containing the key
+	/// @param fn  callback invoked with a zero-copy view of the pinned value
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
+	public <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
+		return RocksDB.withPinnedCf(ptr(), readOpts.ptr(), cf, key, fn);
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BlobDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BlobDBTest.java
@@ -399,4 +399,40 @@ class BlobDBTest {
 			assertThat(out.position()).isZero();
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// get — scoped zero-copy (Mapper)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void get_zeroCopy_returnsValue(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openBlob(dir);
+		     Arena arena = Arena.ofConfined()) {
+			db.put("k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom("k").asSlice(0, 1);
+
+			// When
+			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void get_zeroCopy_returnsEmpty_whenKeyAbsent(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openBlob(dir);
+		     Arena arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom("missing").asSlice(0, 7);
+
+			// When
+			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isEmpty();
+		}
+	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
@@ -751,6 +751,63 @@ class OptimisticTransactionDBTest {
 	}
 
 	// -----------------------------------------------------------------------
+	// get — scoped zero-copy (Mapper)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void get_zeroCopy_returnsValue(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir);
+		     Arena arena = Arena.ofConfined()) {
+			db.put("k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom("k").asSlice(0, 1);
+
+			// When
+			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void get_zeroCopy_returnsEmpty_whenKeyAbsent(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir);
+		     Arena arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom("missing").asSlice(0, 7);
+
+			// When
+			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isEmpty();
+		}
+	}
+
+	@Test
+	void get_zeroCopy_fromColumnFamily(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     Arena arena = Arena.ofConfined()) {
+			db.put(cf, "k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom("k").asSlice(0, 1);
+
+			// When
+			var result = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("v".getBytes());
+		}
+	}
+
+	// -----------------------------------------------------------------------
 	// DB Properties
 	// -----------------------------------------------------------------------
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PinnedGetTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PinnedGetTest.java
@@ -1,0 +1,298 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PinnedGetTest {
+
+	// -----------------------------------------------------------------------
+	// Happy path / absent key
+	// -----------------------------------------------------------------------
+
+	@Test
+	void pinnedGet_returnsValue_forExistingKey(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+
+				// When
+				var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+				// Then
+				assertThat(result).isPresent();
+				assertThat(result.get()).isEqualTo("v".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void pinnedGet_returnsEmpty_forAbsentKey(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("missing").asSlice(0, 7);
+
+				// When
+				var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+				// Then
+				assertThat(result).isEmpty();
+			}
+		}
+	}
+
+	@Test
+	void pinnedGet_emptyValue_doesNotThrow(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), new byte[0]);
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+
+				// When
+				var result = db.get(key, MemorySegment::byteSize);
+
+				// Then
+				assertThat(result).contains(0L);
+			}
+		}
+	}
+
+	@Test
+	void pinnedGet_mapperReturnsNull_throwsNullPointerException(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+
+				// When / Then — a mapper that returns null must not be silently
+				// conflated with Optional.empty() (which means "key not found")
+				assertThatThrownBy(() -> db.get(key, value -> null))
+						.isInstanceOf(NullPointerException.class);
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Lifetime enforcement — the whole point of this API
+	// -----------------------------------------------------------------------
+
+	@Test
+	void pinnedGet_segmentUsedAfterReturn_throwsIllegalStateException(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+				MemorySegment[] escaped = new MemorySegment[1];
+
+				// When — smuggle the view out via a captured array, then use it after return
+				db.get(key, value -> escaped[0] = value);
+
+				// Then
+				assertThatThrownBy(() -> escaped[0].get(ValueLayout.JAVA_BYTE, 0))
+						.isInstanceOf(IllegalStateException.class);
+			}
+		}
+	}
+
+	@Test
+	void pinnedGet_segmentUsedFromAnotherThread_throwsWrongThreadException(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+				AtomicReference<Throwable> caughtOnOtherThread = new AtomicReference<>();
+
+				// When — hand the view to another thread while the call is still in progress
+				db.get(key, value -> {
+					Thread other = new Thread(() -> {
+						try {
+							value.get(ValueLayout.JAVA_BYTE, 0);
+						} catch (Throwable t) {
+							caughtOnOtherThread.set(t);
+						}
+					});
+					other.start();
+					try {
+						other.join();
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new RuntimeException(e);
+					}
+					return true;
+				});
+
+				// Then
+				assertThat(caughtOnOtherThread.get()).isInstanceOf(WrongThreadException.class);
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Exception propagation and cleanup
+	// -----------------------------------------------------------------------
+
+	@Test
+	void pinnedGet_readerThrows_propagatesAndCleansUp(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+
+				// When
+				RuntimeException thrown = new RuntimeException("boom");
+
+				// Then — the exception propagates out of get() unchanged
+				assertThatThrownBy(() -> db.get(key, value -> {
+					throw thrown;
+				})).isSameAs(thrown);
+
+				// And a later, independent call still succeeds — proving the handle and
+				// arena from the failed call were destroyed/closed rather than leaked
+				var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+				assertThat(result).isPresent();
+				assertThat(result.get()).isEqualTo("v".getBytes());
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Leak check — repeated calls must not exhaust native handles
+	// -----------------------------------------------------------------------
+
+	@Test
+	void pinnedGet_manyIterations_doesNotLeakHandles(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+
+				// When / Then — a leaked handle or arena per call would eventually crash
+				// or exhaust memory; reaching the end without error is the signal.
+				for (int i = 0; i < 50_000; i++) {
+					var result = db.get(key, value -> value.get(ValueLayout.JAVA_BYTE, 0));
+					assertThat(result).contains((byte) 'v');
+				}
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Column family overload
+	// -----------------------------------------------------------------------
+
+	@Test
+	void pinnedGetCf_returnsValue_forExistingKey(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+			db.put(cf, "k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+
+				// When
+				var result = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+				// Then
+				assertThat(result).isPresent();
+				assertThat(result.get()).isEqualTo("v".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void pinnedGetCf_returnsEmpty_forAbsentKey(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("missing").asSlice(0, 7);
+
+				// When
+				var result = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+				// Then
+				assertThat(result).isEmpty();
+			}
+		}
+	}
+
+	@Test
+	void pinnedGetCf_isIsolatedFromDefaultFamily(@TempDir Path dir) {
+		// Given — same key written only into the non-default family
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+			db.put(cf, "k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+
+				// When
+				var viaDefault = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+				var viaCf = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+				// Then
+				assertThat(viaDefault).isEmpty();
+				assertThat(viaCf).isPresent();
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Default-CF equivalence — proves the two overloads target the right handles
+	// -----------------------------------------------------------------------
+
+	@Test
+	void pinnedGet_and_pinnedGetCf_agreeOnDefaultFamily(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openReadWrite(opts, dir,
+				     List.of(ColumnFamilyDescriptor.of("default")), handles)) {
+			var defaultCf = handles.get(0);
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (Arena arena = Arena.ofConfined()) {
+				MemorySegment key = arena.allocateFrom("k").asSlice(0, 1);
+
+				// When
+				var viaPlain = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+				var viaDefaultCf = db.get(defaultCf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+				// Then
+				assertThat(viaPlain).isPresent();
+				assertThat(viaDefaultCf).isPresent();
+				assertThat(viaPlain.get()).isEqualTo(viaDefaultCf.get()).isEqualTo("v".getBytes());
+			}
+
+			defaultCf.close();
+		}
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
@@ -165,6 +165,76 @@ class ReadOnlyDBTest {
 	}
 
 	// -----------------------------------------------------------------------
+	// get — scoped zero-copy (Mapper)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void get_zeroCopy_returnsValue(@TempDir Path dir) {
+		// Given
+		try (var rw = RocksDB.openReadWrite(dir)) {
+			rw.put("key".getBytes(), "value".getBytes());
+		}
+
+		try (var ro = RocksDB.openReadOnly(dir);
+		     Arena arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom("key").asSlice(0, 3);
+
+			// When
+			var result = ro.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("value".getBytes());
+		}
+	}
+
+	@Test
+	void get_zeroCopy_returnsEmpty_whenKeyAbsent(@TempDir Path dir) {
+		// Given
+		try (var rw = RocksDB.openReadWrite(dir)) {
+			rw.put("seed".getBytes(), "val".getBytes());
+		}
+
+		try (var ro = RocksDB.openReadOnly(dir);
+		     Arena arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom("missing").asSlice(0, 7);
+
+			// When
+			var result = ro.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isEmpty();
+		}
+	}
+
+	@Test
+	void get_zeroCopy_fromColumnFamily(@TempDir Path dir) {
+		// Given
+		try (var rw = RocksDB.openReadWrite(dir);
+		     var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+			rw.put(cf, "key".getBytes(), "value".getBytes());
+		}
+
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var opts = Options.newOptions();
+		     var ro = RocksDB.openReadOnly(opts, dir,
+				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")), handles);
+		     Arena arena = Arena.ofConfined()) {
+			var cf1 = handles.get(1);
+			var key = arena.allocateFrom("key").asSlice(0, 3);
+
+			// When
+			var result = ro.get(cf1, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("value".getBytes());
+
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	// -----------------------------------------------------------------------
 	// get — column family overloads
 	// -----------------------------------------------------------------------
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RocksIteratorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RocksIteratorTest.java
@@ -3,12 +3,15 @@ package io.github.dfa1.rocksdbffm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RocksIteratorTest {
 
@@ -245,9 +248,9 @@ class RocksIteratorTest {
 				var valSeg = it.valueSegment();
 
 				// Then
-				assertThat(keySeg.toArray(java.lang.foreign.ValueLayout.JAVA_BYTE))
+				assertThat(keySeg.toArray(ValueLayout.JAVA_BYTE))
 						.isEqualTo("k".getBytes());
-				assertThat(valSeg.toArray(java.lang.foreign.ValueLayout.JAVA_BYTE))
+				assertThat(valSeg.toArray(ValueLayout.JAVA_BYTE))
 						.isEqualTo("v".getBytes());
 			}
 		}
@@ -424,6 +427,109 @@ class RocksIteratorTest {
 				it.seekToFirst();
 				assertThat(it.isValid()).isTrue();
 				assertThat(it.key()).isEqualTo("k".getBytes());
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// key/value — scoped zero-copy (Mapper)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void key_value_zeroCopy_returnsCurrentPosition(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+				assertThat(it.isValid()).isTrue();
+
+				// When
+				var key = it.key(seg -> seg.toArray(ValueLayout.JAVA_BYTE));
+				var value = it.value(seg -> seg.toArray(ValueLayout.JAVA_BYTE));
+
+				// Then
+				assertThat(key).isEqualTo("k".getBytes());
+				assertThat(value).isEqualTo("v".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void key_zeroCopy_segmentUsedAfterReturn_throwsIllegalStateException(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+				assertThat(it.isValid()).isTrue();
+				MemorySegment[] escaped = new MemorySegment[1];
+
+				// When — smuggle the view out via a captured array, then use it after return
+				it.key(value -> escaped[0] = value);
+
+				// Then
+				assertThatThrownBy(() -> escaped[0].get(ValueLayout.JAVA_BYTE, 0))
+						.isInstanceOf(IllegalStateException.class);
+			}
+		}
+	}
+
+	@Test
+	void key_zeroCopy_staysCorrectAcrossNavigation_insteadOfSilentlyGoingStale(@TempDir Path dir) {
+		// Given — the exact bug the scoped API prevents: a raw keySegment() read before
+		// next() would silently start reporting the new position's bytes with no error.
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+
+				// When
+				var firstKey = it.key(value -> value.toArray(ValueLayout.JAVA_BYTE));
+				it.next();
+				var secondKey = it.key(value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+				// Then
+				assertThat(firstKey).isEqualTo("a".getBytes());
+				assertThat(secondKey).isEqualTo("b".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void key_zeroCopy_mapperReturnsNull_throwsNullPointerException(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+				assertThat(it.isValid()).isTrue();
+
+				// When / Then
+				assertThatThrownBy(() -> it.key(value -> null))
+						.isInstanceOf(NullPointerException.class);
+			}
+		}
+	}
+
+	@Test
+	void value_zeroCopy_mapperReturnsNull_throwsNullPointerException(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (RocksIterator it = db.newIterator()) {
+				it.seekToFirst();
+				assertThat(it.isValid()).isTrue();
+
+				// When / Then
+				assertThatThrownBy(() -> it.value(value -> null))
+						.isInstanceOf(NullPointerException.class);
 			}
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
@@ -276,6 +276,56 @@ class SecondaryDBTest {
 	}
 
 	// -----------------------------------------------------------------------
+	// get — scoped zero-copy (Mapper)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void get_zeroCopy_returnsValue(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
+		     var fo = FlushOptions.newFlushOptions()) {
+			primary.put("k".getBytes(), "v".getBytes());
+			primary.flush(fo);
+		}
+
+		try (var opts = Options.newOptions();
+		     var secondary = RocksDB.openSecondary(opts, primaryDir, secondaryDir);
+		     Arena arena = Arena.ofConfined()) {
+			secondary.tryCatchUpWithPrimary();
+			var key = arena.allocateFrom("k").asSlice(0, 1);
+
+			// When
+			var result = secondary.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void get_zeroCopy_returnsEmpty_whenKeyAbsent(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir)) {
+			primary.put("seed".getBytes(), "val".getBytes());
+		}
+
+		try (var opts = Options.newOptions();
+		     var secondary = RocksDB.openSecondary(opts, primaryDir, secondaryDir);
+		     Arena arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom("missing").asSlice(0, 7);
+
+			// When
+			var result = secondary.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isEmpty();
+		}
+	}
+
+	// -----------------------------------------------------------------------
 	// DB Properties
 	// -----------------------------------------------------------------------
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
@@ -100,6 +100,82 @@ class TransactionDBTest {
 		}
 	}
 
+	// -----------------------------------------------------------------------
+	// get — scoped zero-copy (Mapper)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void transactionDb_get_zeroCopy_returnsValue(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     Arena arena = Arena.ofConfined()) {
+			db.put("k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom("k").asSlice(0, 1);
+
+			// When
+			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void transactionDb_get_zeroCopy_returnsEmpty_whenKeyAbsent(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     Arena arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom("missing").asSlice(0, 7);
+
+			// When
+			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isEmpty();
+		}
+	}
+
+	@Test
+	void transaction_get_zeroCopy_readsUncommittedWritesWithinSameTransaction(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo);
+		     Arena arena = Arena.ofConfined()) {
+			txn.put("k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom("k").asSlice(0, 1);
+
+			// When
+			var result = txn.get(ro, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("v".getBytes());
+			txn.commit();
+		}
+	}
+
+	@Test
+	void transaction_get_zeroCopy_returnsEmpty_whenKeyAbsent(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo);
+		     Arena arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom("missing").asSlice(0, 7);
+
+			// When
+			var result = txn.get(ro, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isEmpty();
+			txn.rollback();
+		}
+	}
+
 	@Test
 	void getForUpdate_locksAndReturnsValue(@TempDir Path dir) {
 		// Given

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
@@ -1088,4 +1088,40 @@ class TtlDBTest {
 			handles.forEach(ColumnFamilyHandle::close);
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// get — scoped zero-copy (Mapper)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void get_zeroCopy_returnsValue(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
+		     Arena arena = Arena.ofConfined()) {
+			db.put("k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom("k").asSlice(0, 1);
+
+			// When
+			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isPresent();
+			assertThat(result.get()).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void get_zeroCopy_returnsEmpty_whenKeyAbsent(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
+		     Arena arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom("missing").asSlice(0, 7);
+
+			// When
+			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
+
+			// Then
+			assertThat(result).isEmpty();
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Implements #55. Adds `ReadWriteDB.withPinned(...)` — a scoped, zero-copy read built on the `rocksdb_pinnable_handle_t` C API (`rocksdb_get_pinned_v2`/`_cf_v2`, `rocksdb_pinnable_handle_get_value`, `rocksdb_pinnable_handle_destroy`), as an alternative to `get(byte[])` for hot read paths.

- `PinnedReader<R>` — functional callback, `R read(MemorySegment value) throws Exception`, invoked with a read-only view of the pinned value. No intermediate `byte[]` copy.
- `RocksDB.withPinned0` — private core shared by both public overloads (plain and column-family). Checks `errptr` before the null-handle check (a `NULL` return means either NotFound or error — the two are only distinguished by `errptr`), binds the value pointer to a confined `Arena` via `reinterpret(len, arena, null)` (the `null` cleanup is deliberate — the view borrows from the handle, it does not own the memory).
- The `finally` block closes the arena **before** destroying the native handle. Reversed, there'd be a window where a still-valid `MemorySegment` points at block-cache memory the handle already released. With this order, a view that escapes the callback fails loudly: `IllegalStateException` if used after the call returns, `WrongThreadException` if handed to another thread — both covered by tests, both firing as expected (not silently passing).
- `get_pinned_*_v2` is **not** marked critical (a `Get` can block on disk I/O; a critical downcall would stall GC for its duration). `get_value`/`destroy` are `Linker.Option.critical(false)`, which needed `NativeLibrary.lookup` to grow a `Linker.Option...` parameter.

**Deviation from the issue's sketch:** no separate `RocksPinned` class with its own `Linker`/`SymbolLookup`. The four method handles live in `RocksDB.java` next to the existing `get_pinned`/`PinnableSlice` handles — that's where every other `rocksdb_t*` handle in this codebase lives (`RocksDB.java`'s own doc comment calls it out as "the single holder of all `rocksdb_t*` method handles"). The CF parameter is the existing `ColumnFamilyHandle` wrapper rather than a raw `MemorySegment`, matching every other CF-taking method here.

## Test plan

- [x] `WithPinnedTest` (11 cases): happy path, absent key, empty value, escape-after-return (`IllegalStateException`), escape-to-another-thread (`WrongThreadException`), reader exception propagates and cleanup still runs, 50k-iteration loop as a leak smoke test (scaled down from the issue's 100k-with-RSS-measurement to fit a fast unit-test suite), CF overload (happy/absent/isolation), and a default-CF equivalence test proving `withPinned` and `withPinned(cf, ...)` are wired to the right native symbols.
- [x] `./mvnw test -pl core -am` — 415 tests, 0 failures, 0 errors
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] New JMH comparison in `FfmBenchmark`: an `Instant` stored as an 8-byte long, read via `get(byte[])` + manual deserialize vs. `withPinned` deserializing straight out of the pinned view. Quick local run (1 fork, short warmup): ~7.0M ops/s (byte[]) vs. ~8.1M ops/s (`withPinned`), consistent with skipping one heap allocation + copy per read. `BenchmarkRunner` lists both as FFM-only (no JNI equivalent), same treatment as the existing `MemorySegment` tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)