### PR TITLE
refactor: extract PinnableSlice wrapper, kill triplicated native mapping

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
@@ -1,0 +1,67 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/// FFM wrapper for `rocksdb_pinnableslice_t` — the pinned-value handle returned by the
+/// byte[]-tier `rocksdb_*get_pinned[_cf]` family (`rocksdb_get_pinned[_cf]`,
+/// `rocksdb_transaction_get_pinned[_cf]`, `rocksdb_transactiondb_get_pinned[_cf]`).
+///
+/// Not the same native type as `rocksdb_pinnable_handle_t` (see `RocksDB.withPinned`),
+/// which is the newer, zero-copy `_v2` handle. `Transaction` and `TransactionDB` have no
+/// `_v2` equivalent in `rocksdb/include/rocksdb/c.h`, so they still go through this
+/// older API.
+///
+/// Package-private: purely internal plumbing for the `get_pinned`-based `get(...)`
+/// overloads on [RocksDB], [Transaction], and [TransactionDB] — never returned to callers.
+/// This is the single mapping of `rocksdb_pinnableslice_value`/`_destroy`; those three
+/// classes used to each map the same two symbols independently.
+final class PinnableSlice extends NativeObject {
+
+	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
+	private static final MethodHandle MH_VALUE;
+	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
+	private static final MethodHandle MH_DESTROY;
+
+	static {
+		MH_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
+				FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+		MH_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+	}
+
+	private PinnableSlice(MemorySegment ptr) {
+		super(ptr);
+	}
+
+	/// Wraps `ptr`, or returns `null` if `ptr` is `MemorySegment.NULL` — the
+	/// `get_pinned`/`get_pinned_cf` downcalls return NULL for NotFound or error (the two
+	/// are distinguished only by `errptr`, which callers must check separately).
+	///
+	/// @param ptr the raw `rocksdb_pinnableslice_t*`, or `MemorySegment.NULL`
+	/// @return a wrapper owning `ptr`, or `null` if `ptr` is `MemorySegment.NULL`
+	static PinnableSlice wrapOrNull(MemorySegment ptr) {
+		return MemorySegment.NULL.equals(ptr) ? null : new PinnableSlice(ptr);
+	}
+
+	/// Returns the raw value pointer and writes its length into `vallenOut`, a
+	/// caller-allocated `size_t*` slot.
+	///
+	/// @param vallenOut native slot to receive the value's length
+	/// @return pointer to the value's bytes
+	MemorySegment value(MemorySegment vallenOut) {
+		try {
+			return (MemorySegment) MH_VALUE.invokeExact(ptr(), vallenOut);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("pinnableslice value failed", t);
+		}
+	}
+
+	@Override
+	protected void tryClose(MemorySegment ptr) throws Throwable {
+		MH_DESTROY.invokeExact(ptr);
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
@@ -1,9 +1,12 @@
 package io.github.dfa1.rocksdbffm;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /// FFM wrapper for `rocksdb_pinnableslice_t` — the pinned-value handle returned by the
 /// byte[]-tier `rocksdb_*get_pinned[_cf]` family (`rocksdb_get_pinned[_cf]`,
@@ -15,9 +18,12 @@ import java.lang.invoke.MethodHandle;
 /// older API.
 ///
 /// Package-private: purely internal plumbing for the `get_pinned`-based `get(...)`
-/// overloads on [RocksDB], [Transaction], and [TransactionDB] — never returned to callers.
-/// This is the single mapping of `rocksdb_pinnableslice_value`/`_destroy`; those three
-/// classes used to each map the same two symbols independently.
+/// overloads on [RocksDB], [Transaction], and [TransactionDB] — never returned to
+/// callers. This is the single mapping of `rocksdb_pinnableslice_value`/`_destroy`;
+/// those three classes used to each map the same two symbols independently. Beyond that
+/// mapping, this class also owns every way a pinned value gets consumed — copy to
+/// `byte[]`, copy into a caller's buffer, or a zero-copy [Mapper] callback — so callers
+/// never touch the raw pointer.
 final class PinnableSlice extends NativeObject {
 
 	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
@@ -47,12 +53,80 @@ final class PinnableSlice extends NativeObject {
 		return MemorySegment.NULL.equals(ptr) ? null : new PinnableSlice(ptr);
 	}
 
+	/// Copies this slice's value into a freshly allocated array.
+	///
+	/// @param arena arena to allocate the native length scratch slot in
+	/// @return the value's bytes, copied into a new array
+	byte[] toByteArray(Arena arena) {
+		MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+		MemorySegment data = value(lenSeg);
+		long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+		return data.reinterpret(len).toArray(ValueLayout.JAVA_BYTE);
+	}
+
+	/// Copies this slice's value into `dest`, or reports insufficient capacity without
+	/// copying anything.
+	///
+	/// @param arena       arena to allocate the native length scratch slot in
+	/// @param dest        destination segment to copy into
+	/// @param destCapacity `dest`'s usable capacity in bytes
+	/// @return [CopyResult.Copied] on success, [CopyResult.NotEnoughCapacity] if `dest` is too small
+	CopyResult copyInto(Arena arena, MemorySegment dest, long destCapacity) {
+		MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+		MemorySegment data = value(lenSeg);
+		long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+		if (len > destCapacity) {
+			return new CopyResult.NotEnoughCapacity(len);
+		}
+		dest.copyFrom(data.reinterpret(len));
+		return new CopyResult.Copied();
+	}
+
+	/// [ByteBuffer] counterpart of [#copyInto(Arena, MemorySegment, long)]; also advances
+	/// `dest`'s position by the copied length on success.
+	///
+	/// @param arena arena to allocate the native length scratch slot in
+	/// @param dest  direct [ByteBuffer] to copy into
+	/// @return [CopyResult.Copied] on success, [CopyResult.NotEnoughCapacity] if `dest` is too small
+	CopyResult copyInto(Arena arena, ByteBuffer dest) {
+		MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+		MemorySegment data = value(lenSeg);
+		long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+		if (len > dest.remaining()) {
+			return new CopyResult.NotEnoughCapacity(len);
+		}
+		MemorySegment.ofBuffer(dest).copyFrom(data.reinterpret(len));
+		dest.position(dest.position() + (int) len);
+		return new CopyResult.Copied();
+	}
+
+	/// Maps this slice's value to a result via `fn`, with no intermediate copy. The view
+	/// passed to `fn` is bound to `arena` and read-only; it must not be retained beyond
+	/// the call, per [Mapper]'s contract.
+	///
+	/// @param arena arena to allocate the native length scratch slot in and bind the view to
+	/// @param fn    callback invoked with a zero-copy view of this slice's value
+	/// @param <R>   the type produced by `fn`
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the non-null result of `fn`
+	<R> R map(Arena arena, Mapper<R> fn) {
+		MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+		MemorySegment data = value(lenSeg);
+		long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+		// The `null` cleanup is deliberate: this view borrows from the slice, it does
+		// not own the memory, so closing `arena` must not attempt to free it.
+		MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
+		R result = fn.map(view);
+		Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
+		return result;
+	}
+
 	/// Returns the raw value pointer and writes its length into `vallenOut`, a
 	/// caller-allocated `size_t*` slot.
 	///
 	/// @param vallenOut native slot to receive the value's length
 	/// @return pointer to the value's bytes
-	MemorySegment value(MemorySegment vallenOut) {
+	private MemorySegment value(MemorySegment vallenOut) {
 		try {
 			return (MemorySegment) MH_VALUE.invokeExact(ptr(), vallenOut);
 		} catch (Throwable t) {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -676,13 +676,7 @@ public final class RocksDB {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, k, (long) key.length, err);
 			checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
@@ -780,9 +774,10 @@ public final class RocksDB {
 	/// `destroyHandle` stay as raw [MethodHandle] parameters rather than going through a
 	/// wrapper type: `MH_PINNABLE_HANDLE_GET_VALUE`/`MH_PINNABLE_HANDLE_DESTROY` are
 	/// already mapped exactly once, right here, so there is no duplication to hide behind
-	/// a wrapper. Contrast with [#withPinnableSlice] below, for the older
-	/// `rocksdb_pinnableslice_t` API, where [PinnableSlice] exists specifically because
-	/// that mapping used to be duplicated across three classes.
+	/// a wrapper. Contrast with the older `rocksdb_pinnableslice_t` API, where
+	/// [PinnableSlice] owns both the mapping and every way a pinned value gets consumed
+	/// (copy to `byte[]`, copy into a buffer, or this same [Mapper] callback pattern),
+	/// since that mapping used to be duplicated across three classes.
 	///
 	/// The caller has already opened `arena` in its own try-with-resources (closed once
 	/// this method returns) and obtained `scratch` (its `errptr` slot) and `handle` (or
@@ -832,36 +827,6 @@ public final class RocksDB {
 				// exception already in flight from fn.map above. Same convention as
 				// NativeObject#close().
 			}
-		}
-	}
-
-	/// Shared core for the `rocksdb_pinnableslice_t`-based scoped `get(key, Mapper)`,
-	/// used by [TransactionDB] and [Transaction] — the only two wrappers whose C API has
-	/// no `_v2`/`pinnable_handle_t` equivalent (see `rocksdb/include/rocksdb/c.h`). The
-	/// caller has already opened `arena` in its own try-with-resources (closed once this
-	/// method returns) and obtained `err` (its `errptr` slot) and `pin` (or
-	/// `MemorySegment.NULL` for NotFound/error) via its own class-specific
-	/// `get_pinned`/`get_pinned_cf` downcall.
-	///
-	/// [PinnableSlice] owns the destroy step here (via its inherited
-	/// `NativeObject#close()`, which swallows a destroy failure the same way
-	/// [#withPinnedCore] does), so this method needs no `finally` of its own — the
-	/// try-with-resources on `slice` runs before this method returns, BEFORE the
-	/// caller's own try-with-resources closes `arena`, for the same reason
-	/// [#withPinnedCore] destroys its handle before `arena` closes.
-	static <R> Optional<R> withPinnableSlice(Arena arena, MemorySegment err, MemorySegment pin, Mapper<R> fn) {
-		checkError(err);
-		try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-			if (slice == null) {
-				return Optional.empty();
-			}
-			MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment data = slice.value(lenSeg);
-			long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
-			MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
-			R result = fn.map(view);
-			Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
-			return Optional.of(result);
 		}
 	}
 
@@ -1610,13 +1575,7 @@ public final class RocksDB {
 					db, readOpts, cf.ptr(), toNative(arena, key), (long) key.length, err);
 			checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -62,10 +62,6 @@ public final class RocksDB {
 	private static final MethodHandle MH_GET_PINNED;
 	/// `unsigned char rocksdb_get_into_buffer(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char* buffer, size_t buffer_size, size_t* vallen, unsigned char* found, char** errptr);`
 	private static final MethodHandle MH_GET_INTO_BUFFER;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 	/// `rocksdb_pinnable_handle_t* rocksdb_get_pinned_v2(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char** errptr);`
 	private static final MethodHandle MH_GET_PINNED_V2;
 	/// `rocksdb_pinnable_handle_t* rocksdb_get_pinned_cf_v2(rocksdb_t* db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char** errptr);`
@@ -216,12 +212,6 @@ public final class RocksDB {
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS));
 
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
 		// get_pinned_*_v2 can block on disk I/O (a Get), so it must NOT be marked
 		// critical: a critical downcall stalls GC for its entire duration.
@@ -685,15 +675,15 @@ public final class RocksDB {
 			MemorySegment k = toNative(arena, key);
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, k, (long) key.length, err);
 			checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -785,19 +775,19 @@ public final class RocksDB {
 		}
 	}
 
-	/// Shared core for every scoped zero-copy `get(key, Mapper)` in this codebase,
-	/// regardless of which native handle kind backs it: `rocksdb_pinnable_handle_t`
-	/// (`get_pinned_v2`/`_cf_v2`, used everywhere a plain `rocksdb_t*` exists — see
-	/// [#withPinned]/[#withPinnedCf] above) or `rocksdb_pinnableslice_t` (the older API,
-	/// still needed by [TransactionDB] and [Transaction] — the only two wrappers with no
-	/// `_v2` equivalent in `rocksdb/include/rocksdb/c.h`). Both handle kinds expose the
-	/// same shape — `getValue(handle, size_t* vallen) -> const char*` then
-	/// `destroy(handle) -> void` — so one method covers both; `valueHandle`/
-	/// `destroyHandle` are the caller's own bindings for whichever pair applies. The
-	/// caller has already opened `arena` in its own try-with-resources (closed once this
-	/// method returns) and obtained `scratch` (its `errptr` slot) and `handle` (or
+	/// Shared core for the `rocksdb_pinnable_handle_t`-based scoped `get(key, Mapper)` —
+	/// used only by [#withPinned]/[#withPinnedCf] above, which is why `valueHandle`/
+	/// `destroyHandle` stay as raw [MethodHandle] parameters rather than going through a
+	/// wrapper type: `MH_PINNABLE_HANDLE_GET_VALUE`/`MH_PINNABLE_HANDLE_DESTROY` are
+	/// already mapped exactly once, right here, so there is no duplication to hide behind
+	/// a wrapper. Contrast with [#withPinnableSlice] below, for the older
+	/// `rocksdb_pinnableslice_t` API, where [PinnableSlice] exists specifically because
+	/// that mapping used to be duplicated across three classes.
+	///
+	/// The caller has already opened `arena` in its own try-with-resources (closed once
+	/// this method returns) and obtained `scratch` (its `errptr` slot) and `handle` (or
 	/// `MemorySegment.NULL` for NotFound/error) via its own class-specific
-	/// `get_pinned`/`get_pinned_cf` downcall.
+	/// `get_pinned_v2`/`get_pinned_cf_v2` downcall.
 	///
 	/// `scratch` is the same native slot the caller already used as `errptr`: once
 	/// [#checkError] passes below, that slot is dead, so `valueHandle`'s
@@ -842,6 +832,36 @@ public final class RocksDB {
 				// exception already in flight from fn.map above. Same convention as
 				// NativeObject#close().
 			}
+		}
+	}
+
+	/// Shared core for the `rocksdb_pinnableslice_t`-based scoped `get(key, Mapper)`,
+	/// used by [TransactionDB] and [Transaction] — the only two wrappers whose C API has
+	/// no `_v2`/`pinnable_handle_t` equivalent (see `rocksdb/include/rocksdb/c.h`). The
+	/// caller has already opened `arena` in its own try-with-resources (closed once this
+	/// method returns) and obtained `err` (its `errptr` slot) and `pin` (or
+	/// `MemorySegment.NULL` for NotFound/error) via its own class-specific
+	/// `get_pinned`/`get_pinned_cf` downcall.
+	///
+	/// [PinnableSlice] owns the destroy step here (via its inherited
+	/// `NativeObject#close()`, which swallows a destroy failure the same way
+	/// [#withPinnedCore] does), so this method needs no `finally` of its own — the
+	/// try-with-resources on `slice` runs before this method returns, BEFORE the
+	/// caller's own try-with-resources closes `arena`, for the same reason
+	/// [#withPinnedCore] destroys its handle before `arena` closes.
+	static <R> Optional<R> withPinnableSlice(Arena arena, MemorySegment err, MemorySegment pin, Mapper<R> fn) {
+		checkError(err);
+		try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+			if (slice == null) {
+				return Optional.empty();
+			}
+			MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment data = slice.value(lenSeg);
+			long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+			MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
+			R result = fn.map(view);
+			Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
+			return Optional.of(result);
 		}
 	}
 
@@ -1589,15 +1609,15 @@ public final class RocksDB {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
 					db, readOpts, cf.ptr(), toNative(arena, key), (long) key.length, err);
 			checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -248,13 +248,7 @@ public final class Transaction extends NativeObject {
 			RocksDB.checkError(err);
 
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -276,18 +270,7 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.remaining()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-				value.position(value.position() + (int) valLen);
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -309,17 +292,7 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.byteSize()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				value.copyFrom(valPtr.reinterpret(valLen));
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value, value.byteSize());
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -349,7 +322,10 @@ public final class Transaction extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnableSlice(arena, err, pin, fn);
+			RocksDB.checkError(err);
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				return slice == null ? Optional.empty() : Optional.of(slice.map(arena, fn));
+			}
 		}
 	}
 
@@ -569,13 +545,7 @@ public final class Transaction extends NativeObject {
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -599,18 +569,7 @@ public final class Transaction extends NativeObject {
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.remaining()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-				value.position(value.position() + (int) valLen);
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -633,17 +592,7 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.byteSize()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				value.copyFrom(valPtr.reinterpret(valLen));
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value, value.byteSize());
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -672,7 +621,10 @@ public final class Transaction extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnableSlice(arena, err, pin, fn);
+			RocksDB.checkError(err);
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				return slice == null ? Optional.empty() : Optional.of(slice.map(arena, fn));
+			}
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -51,10 +51,6 @@ public final class Transaction extends NativeObject {
 	private static final MethodHandle MH_GET_PINNED;
 	/// `char* rocksdb_transaction_get_for_update(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, const char* key, size_t klen, size_t* vlen, unsigned char exclusive, char** errptr);`
 	private static final MethodHandle MH_GET_FOR_UPDATE;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 
 	static {
 		MH_COMMIT = NativeLibrary.lookup("rocksdb_transaction_commit",
@@ -97,13 +93,6 @@ public final class Transaction extends NativeObject {
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE,
 						ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
 
 		MH_PUT_CF = NativeLibrary.lookup("rocksdb_transaction_put_cf",
@@ -258,16 +247,15 @@ public final class Transaction extends NativeObject {
 
 			RocksDB.checkError(err);
 
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -287,20 +275,20 @@ public final class Transaction extends NativeObject {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
 					ptr(), readOptions.ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.remaining()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+				value.position(value.position() + (int) valLen);
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.remaining()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-			value.position(value.position() + (int) valLen);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -320,19 +308,19 @@ public final class Transaction extends NativeObject {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
 					ptr(), readOptions.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.byteSize()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				value.copyFrom(valPtr.reinterpret(valLen));
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.byteSize()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			value.copyFrom(valPtr.reinterpret(valLen));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -361,7 +349,7 @@ public final class Transaction extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+			return RocksDB.withPinnableSlice(arena, err, pin, fn);
 		}
 	}
 
@@ -580,15 +568,15 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr(),
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -610,20 +598,20 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.remaining()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+				value.position(value.position() + (int) valLen);
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.remaining()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-			value.position(value.position() + (int) valLen);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -644,19 +632,19 @@ public final class Transaction extends NativeObject {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
 					ptr(), readOptions.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.byteSize()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				value.copyFrom(valPtr.reinterpret(valLen));
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.byteSize()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			value.copyFrom(valPtr.reinterpret(valLen));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -684,7 +672,7 @@ public final class Transaction extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+			return RocksDB.withPinnableSlice(arena, err, pin, fn);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -443,7 +443,10 @@ public final class TransactionDB extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnableSlice(arena, err, pin, fn);
+			RocksDB.checkError(err);
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				return slice == null ? Optional.empty() : Optional.of(slice.map(arena, fn));
+			}
 		}
 	}
 
@@ -652,13 +655,7 @@ public final class TransactionDB extends NativeObject {
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
@@ -681,18 +678,7 @@ public final class TransactionDB extends NativeObject {
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.remaining()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-				value.position(value.position() + (int) valLen);
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
@@ -714,17 +700,7 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.byteSize()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				value.copyFrom(valPtr.reinterpret(valLen));
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value, value.byteSize());
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
@@ -749,7 +725,10 @@ public final class TransactionDB extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnableSlice(arena, err, pin, fn);
+			RocksDB.checkError(err);
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				return slice == null ? Optional.empty() : Optional.of(slice.map(arena, fn));
+			}
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -68,10 +68,6 @@ public final class TransactionDB extends NativeObject {
 	private static final MethodHandle MH_CREATE_ITERATOR_CF;
 	/// `void rocksdb_transactiondb_flush_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_flushoptions_t* options, rocksdb_column_family_handle_t* column_family, char** errptr);`
 	private static final MethodHandle MH_FLUSH_CF;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 
 
 	static {
@@ -134,14 +130,6 @@ public final class TransactionDB extends NativeObject {
 		MH_FLUSH_CF = NativeLibrary.lookup("rocksdb_transactiondb_flush_cf",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
-
 
 		MH_CREATE_SNAPSHOT = NativeLibrary.lookup("rocksdb_transactiondb_create_snapshot",
 				FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
@@ -455,7 +443,7 @@ public final class TransactionDB extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+			return RocksDB.withPinnableSlice(arena, err, pin, fn);
 		}
 	}
 
@@ -663,15 +651,15 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr(),
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -692,20 +680,20 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOpts.ptr(), cf.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.remaining()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+				value.position(value.position() + (int) valLen);
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.remaining()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-			value.position(value.position() + (int) valLen);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -725,19 +713,19 @@ public final class TransactionDB extends NativeObject {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
 					ptr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.byteSize()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				value.copyFrom(valPtr.reinterpret(valLen));
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.byteSize()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			value.copyFrom(valPtr.reinterpret(valLen));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -761,7 +749,7 @@ public final class TransactionDB extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+			return RocksDB.withPinnableSlice(arena, err, pin, fn);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #58. Based on #57 (`feat/with-pinned`) — this PR's diff is scoped to just the `PinnableSlice` extraction; the base includes everything from #57.

`rocksdb_pinnableslice_value`/`rocksdb_pinnableslice_destroy` were each mapped to a `MethodHandle` independently in `RocksDB`, `Transaction`, and `TransactionDB` — the exact pattern `CLAUDE.md`'s "don't map multiple times the same symbol... create always a java wrapper for that (i.e. PinnableSlice)" rule warns about.

- New package-private `PinnableSlice extends NativeObject` — the single owner of the `rocksdb_pinnableslice_value`/`_destroy` mapping. `wrapOrNull(ptr)` mirrors the `get_pinned`/`_cf` contract (`NULL` on NotFound/error), `value(vallenOut)` wraps the value accessor, `tryClose()` destroys — inherited `NativeObject#close()` semantics (idempotent, swallows a destroy failure) apply for free.
- `RocksDB`'s byte[]/`MemorySegment` `get*(Cf)?(Bytes|IntoSegment)` helpers now go through `PinnableSlice` via try-with-resources instead of raw `MethodHandle.invokeExact` pairs. `getIntoSegment`/`getCfIntoSegment` previously had no NULL-pin check at all, relying on `rocksdb_pinnableslice_value`'s own NULL-safety (writes `*vallen=0`); made that explicit with a null check returning the same `0L`, rather than teaching `PinnableSlice` to tolerate a null receiver.
- `getIntoBuffer`/`getCfIntoBuffer` are untouched — they already moved to the more efficient `rocksdb_get_into_buffer`/`_cf` (no `PinnableSlice` involved at all) in #54, merged after this branch started. Rebased on top of that rather than reintroducing the older path.
- `RocksDB.withPinnedCore` (the `rocksdb_pinnable_handle_t` path used only by `withPinned`/`withPinnedCf`) is untouched — its `valueHandle`/`destroyHandle` `MethodHandle` parameters stay as-is since that mapping was never duplicated. Split out a dedicated `RocksDB.withPinnableSlice(arena, err, pin, fn)` for the `rocksdb_pinnableslice_t` path instead of forcing both native handle kinds through one `MethodHandle`-shaped generic.
- `Transaction` and `TransactionDB` no longer map `rocksdb_pinnableslice_value`/`_destroy` themselves; their byte[]-tier `get(...)` and Mapper-based `get(...)` methods go through `PinnableSlice` / `RocksDB.withPinnableSlice`.

Pure internal refactor: no public API or observable behavior change.

## Test plan

- [x] `./mvnw -pl core -am test` — 397 tests, 0 failures
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] No new tests added — this is an internal refactor fully covered by the existing suite (byte[]/MemorySegment/Mapper-tier `get` tests across `RocksDBTest`, `ColumnFamilyTest`, `TransactionDBTest`, `PinnedGetTest`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)