### PR TITLE
fix: migrate get(MemorySegment, MemorySegment) to CopyResult

### DIFF
--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
@@ -166,7 +166,7 @@ public class FfmBenchmark {
 	}
 
 	@Benchmark
-	public long readsMemorySegment() {
+	public CopyResult readsMemorySegment() {
 		return db.get(readKeyMemorySegment, readValMemorySegment);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
@@ -112,12 +112,14 @@ public final class BlobDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get via PinnableSlice into a caller-supplied native segment.
+	/// Single-copy get into a caller-supplied native segment via `rocksdb_get_into_buffer`.
+	/// Copies nothing into `value` when its capacity is too small.
 	///
-	/// @param key native segment containing the key
+	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return the actual value length in bytes
-	public long get(MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(MemorySegment key, MemorySegment value) {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
@@ -164,13 +164,14 @@ public final class OptimisticTransactionDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get via PinnableSlice into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get into a caller-supplied native segment via `rocksdb_get_into_buffer`.
+	/// Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(MemorySegment key, MemorySegment value) {
 		return RocksDB.getIntoSegment(baseDb, readOpts.ptr(), key, key.byteSize(), value);
 	}
 
@@ -287,14 +288,15 @@ public final class OptimisticTransactionDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get from `cf` into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get from `cf` into a caller-supplied native segment via
+	/// `rocksdb_get_into_buffer_cf`. Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param cf    column family to read from
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(baseDb, readOpts.ptr(), cf, key, key.byteSize(), value);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
@@ -57,13 +57,14 @@ public final class ReadOnlyDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get via PinnableSlice into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get into a caller-supplied native segment via `rocksdb_get_into_buffer`.
+	/// Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(MemorySegment key, MemorySegment value) {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
@@ -99,14 +100,15 @@ public final class ReadOnlyDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get from `cf` into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get from `cf` into a caller-supplied native segment via
+	/// `rocksdb_get_into_buffer_cf`. Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param cf    column family to read from
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(ptr(), readOpts.ptr(), cf, key, key.byteSize(), value);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -112,13 +112,14 @@ public final class ReadWriteDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get via PinnableSlice into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get into a caller-supplied native segment via `rocksdb_get_into_buffer`.
+	/// Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(MemorySegment key, MemorySegment value) {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
@@ -608,14 +609,15 @@ public final class ReadWriteDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get from `cf` via PinnableSlice into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get from `cf` into a caller-supplied native segment via
+	/// `rocksdb_get_into_buffer_cf`. Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param cf    target column family
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(ptr(), readOpts.ptr(), cf, key, key.byteSize(), value);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -688,20 +688,24 @@ public final class RocksDB {
 		}
 	}
 
-	/// MemorySegment get via PinnableSlice — copies once into the caller's segment.
-	/// Returns actual value length.
-	static long getIntoSegment(MemorySegment db, MemorySegment readOpts, MemorySegment key, long keyLen, MemorySegment value) {
+	/// MemorySegment get via `rocksdb_get_into_buffer` — copies directly into the caller's
+	/// segment, with no intermediate PinnableSlice. Copies nothing when `value` is too small.
+	static CopyResult getIntoSegment(MemorySegment db, MemorySegment readOpts, MemorySegment key, long keyLen, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, key, keyLen, err);
-			checkError(err);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
+			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
+			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db, readOpts, key, keyLen,
+					value, value.byteSize(), valLenSeg, foundSeg, err);
+			checkError(err);
+			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
+				return new CopyResult.NotFound();
+			}
 			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			long toCopy = Math.min(valLen, value.byteSize());
-			value.copyFrom(valPtr.reinterpret(toCopy));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return valLen;
+			if (fit == 0) {
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -1481,22 +1485,25 @@ public final class RocksDB {
 		}
 	}
 
-	/// MemorySegment get with explicit column family via PinnableSlice.
-	/// Returns actual value length.
-	static long getCfIntoSegment(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
-	                             MemorySegment key, long keyLen, MemorySegment value) {
+	/// MemorySegment get with explicit column family via `rocksdb_get_into_buffer_cf` —
+	/// copies directly into the caller's segment. Copies nothing when `value` is too small.
+	static CopyResult getCfIntoSegment(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
+	                                   MemorySegment key, long keyLen, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
-					db, readOpts, cf.ptr(), key, keyLen, err);
-			checkError(err);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
+			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
+			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db, readOpts, cf.ptr(), key, keyLen,
+					value, value.byteSize(), valLenSeg, foundSeg, err);
+			checkError(err);
+			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
+				return new CopyResult.NotFound();
+			}
 			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			long toCopy = Math.min(valLen, value.byteSize());
-			value.copyFrom(valPtr.reinterpret(toCopy));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return valLen;
+			if (fit == 0) {
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
@@ -103,13 +103,14 @@ public final class SecondaryDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get via PinnableSlice into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get into a caller-supplied native segment via `rocksdb_get_into_buffer`.
+	/// Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(MemorySegment key, MemorySegment value) {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -383,13 +383,16 @@ public final class TransactionDB extends NativeObject {
 		}
 	}
 
-	/// Zero-copy get into a caller-supplied native segment.
-	/// Returns the actual value length, or -1 if not found.
+	/// Single-copy get into a caller-supplied native segment. Copies nothing into `value`
+	/// when its capacity is too small. `rocksdb_transactiondb_get` has no fixed-capacity C
+	/// variant, so the capacity check happens on the Java side after the native call, rather
+	/// than inside a single native round trip like [ReadWriteDB#get(MemorySegment, MemorySegment)].
 	///
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes, or -1 if not found
-	public long get(MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
@@ -397,13 +400,16 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOpts.ptr(), key, key.byteSize(), valLenSeg, err);
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(valPtr)) {
-				return -1L;
+				return new CopyResult.NotFound();
 			}
 			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			long toCopy = Math.min(valLen, value.byteSize());
-			value.copyFrom(valPtr.reinterpret(toCopy));
+			if (valLen > value.byteSize()) {
+				RocksDB.free(valPtr);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			value.copyFrom(valPtr.reinterpret(valLen));
 			RocksDB.free(valPtr);
-			return valLen;
+			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
@@ -125,13 +125,14 @@ public final class TtlDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get via PinnableSlice into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get into a caller-supplied native segment via `rocksdb_get_into_buffer`.
+	/// Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(MemorySegment key, MemorySegment value) {
 		return RocksDB.getIntoSegment(ptr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
@@ -329,14 +330,15 @@ public final class TtlDB extends NativeObject {
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
-	/// Zero-copy get from `cf` into a caller-supplied native segment.
-	/// Returns the actual value length.
+	/// Single-copy get from `cf` into a caller-supplied native segment via
+	/// `rocksdb_get_into_buffer_cf`. Copies nothing into `value` when its capacity is too small.
 	///
 	/// @param cf    column family to read from
 	/// @param key   native segment containing the key
 	/// @param value native segment to write the value into
-	/// @return actual value length in bytes
-	public long get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		return RocksDB.getCfIntoSegment(ptr(), readOpts.ptr(), cf, key, key.byteSize(), value);
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
@@ -169,10 +169,10 @@ class OptimisticTransactionDBTest {
 			var out = arena.allocate(32);
 
 			// When
-			long len = db.get(key.asSlice(0, 1), out);
+			CopyResult result = db.get(key.asSlice(0, 1), out);
 
 			// Then
-			assertThat(len).isEqualTo(1);
+			assertThat(result).isEqualTo(new CopyResult.Copied());
 			assertThat(out.asSlice(0, 1).toArray(ValueLayout.JAVA_BYTE)).isEqualTo("v".getBytes());
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
@@ -153,10 +153,10 @@ class ReadOnlyDBTest {
 			var value = arena.allocate(32);
 
 			// When
-			long len = ro.get(key.asSlice(0, 3), value);
+			CopyResult result = ro.get(key.asSlice(0, 3), value);
 
 			// Then
-			assertThat(len).isEqualTo(5);
+			assertThat(result).isEqualTo(new CopyResult.Copied());
 			assertThat(value.asSlice(0, 5).toArray(ValueLayout.JAVA_BYTE))
 					.isEqualTo("value".getBytes());
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RocksDBInvariantTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RocksDBInvariantTest.java
@@ -172,10 +172,10 @@ class RocksDBInvariantTest {
 			MemorySegment readBuffer = arena.allocate(testCase.value().length);
 
 			// When
-			long length = db.get(key, readBuffer);
+			CopyResult result = db.get(key, readBuffer);
 
 			// Then
-			assertThat(length).as(testCase.name()).isEqualTo(testCase.value().length);
+			assertThat(result).as(testCase.name()).isEqualTo(new CopyResult.Copied());
 			assertThat(readBuffer.toArray(ValueLayout.JAVA_BYTE)).as(testCase.name()).isEqualTo(testCase.value());
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
@@ -183,10 +183,10 @@ class SecondaryDBTest {
 			var out = arena.allocate(32);
 
 			// When
-			long len = secondary.get(key.asSlice(0, 1), out);
+			CopyResult result = secondary.get(key.asSlice(0, 1), out);
 
 			// Then
-			assertThat(len).isEqualTo(1);
+			assertThat(result).isEqualTo(new CopyResult.Copied());
 			assertThat(out.asSlice(0, 1).toArray(ValueLayout.JAVA_BYTE)).isEqualTo("v".getBytes());
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
@@ -300,10 +300,10 @@ class TransactionDBTest {
 			var out = arena.allocate(32);
 
 			// When
-			long len = db.get(key.asSlice(0, 1), out);
+			CopyResult result = db.get(key.asSlice(0, 1), out);
 
 			// Then
-			assertThat(len).isEqualTo(1);
+			assertThat(result).isEqualTo(new CopyResult.Copied());
 			assertThat(out.asSlice(0, 1).toArray(ValueLayout.JAVA_BYTE)).isEqualTo("v".getBytes());
 		}
 	}


### PR DESCRIPTION
## Summary

PR #54 (phase 3 of #47) converted `get(ByteBuffer, ByteBuffer)` from a length-or-truncating-copy `int` to `CopyResult`, and switched its native path from `rocksdb_get_pinned` + `PinnableSlice` to the single-call `rocksdb_get_into_buffer(_cf)`. The `MemorySegment, MemorySegment` tier was left behind on both counts, across every DB wrapper that has it — spotted in `TtlDB.get(ColumnFamilyHandle, MemorySegment, MemorySegment)` while reviewing, then found to be systemic.

- `RocksDB.getIntoSegment`/`getCfIntoSegment` now return `CopyResult` and call `rocksdb_get_into_buffer(_cf)` directly instead of `get_pinned` + `PinnableSlice` value/destroy (3 native calls → 1).
- All 11 public call sites updated: `BlobDB`, `ReadOnlyDB` (+cf), `OptimisticTransactionDB` (+cf), `ReadWriteDB` (+cf), `TransactionDB`, `SecondaryDB`, `TtlDB` (+cf). `TransactionDB` keeps its Java-side capacity check (no `rocksdb_transactiondb_get_into_buffer` in `c.h`), mirroring its own `get(ByteBuffer, ByteBuffer)`.
- Fixed "Zero-copy get into a caller-supplied native segment" javadoc wording along the way: `rocksdb_get_into_buffer` does copy once inside the C layer, so "Single-copy" (matching the `ByteBuffer` sibling's existing wording) is accurate — "Zero-copy" was not.
- No CF `MemorySegment, MemorySegment` test coverage existed on any class before this change; not added here since it's a pre-existing gap, not a regression from this fix.

## Test plan

- [x] `./mvnw -pl core -am test` — 363 tests, 0 failures
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] Updated the 5 existing `MemorySegment,MemorySegment` tests (`OptimisticTransactionDBTest`, `ReadOnlyDBTest`, `RocksDBInvariantTest`, `SecondaryDBTest`, `TransactionDBTest`) to assert on `CopyResult` instead of the old `long`

🤖 Generated with [Claude Code](https://claude.com/claude-code)