### PR TITLE
feat: configure SonarCloud analysis

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,48 @@
+name: Sonar
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'zulu'
+          cache: 'maven'
+
+      - name: Install Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+
+      - name: Build, test, and run Sonar analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn --batch-mode verify -P coverage \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=dfa1_rocksdbffm \
+            -Dsonar.organization=dfa11 \
+            -Dsonar.host.url=https://sonarcloud.io

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           version: 0.15.2
 
+      - name: Cache RocksDB native builds
+        uses: actions/cache@v4
+        with:
+          path: |
+            native/osx-aarch64/src/main/resources/native
+            native/linux-x86_64/src/main/resources/native
+            native/linux-aarch64/src/main/resources/native
+            native/windows-x86_64/src/main/resources/native
+            native/windows-aarch64/src/main/resources/native
+          key: rocksdb-${{ hashFiles('rocksdb/CMakeLists.txt') }}-ubuntu-latest-${{ runner.arch }}
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 ![Windows aarch64](https://img.shields.io/badge/windows_aarch64-fully_supported-green.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/dfa1/rocksdbffm/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dfa1/rocksdbffm/actions/workflows/ci.yml?query=branch%3Amain)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=dfa1_rocksdbffm&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=dfa1_rocksdbffm)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dfa1_rocksdbffm&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dfa1_rocksdbffm)
 
 **rocksdbffm** is an experimental Java wrapper for [RocksDB](https://rocksdb.org/) using the **Foreign
 Function & Memory (FFM) API**.

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,18 @@
 			be aligned. See the note above the benchmark table in README.md.
 		-->
 		<rocksdbjni.version>10.10.1.1</rocksdbjni.version>
+		<!-- rocksdb/ is a git submodule (upstream C++ checkout) — not our code.
+		     benchmarks/ is JMH benchmark harness code with no tests by design. -->
+		<sonar.exclusions>rocksdb/**</sonar.exclusions>
+		<sonar.coverage.exclusions>rocksdb/**,benchmarks/**</sonar.coverage.exclusions>
+		<sonar.coverage.jacoco.xmlReportPaths>
+			${maven.multiModuleProjectDirectory}/core/target/site/jacoco/jacoco.xml
+		</sonar.coverage.jacoco.xmlReportPaths>
+		<!-- Default for the @{argLine} placeholder in the surefire config below. jacoco:prepare-agent
+		     overwrites this with the agent arguments when the coverage profile is active; without this
+		     default, a plain build (no coverage profile) would pass the literal token "@{argLine}" to
+		     the JVM instead of resolving it to nothing. -->
+		<argLine />
 	</properties>
 
 	<dependencyManagement>
@@ -134,7 +146,9 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>3.5.6</version>
 					<configuration>
-						<argLine>--enable-native-access=ALL-UNNAMED</argLine>
+						<!-- @{argLine} expands to the JaCoCo agent arguments set by jacoco:prepare-agent
+						     when the coverage profile is active; empty otherwise. -->
+						<argLine>@{argLine} --enable-native-access=ALL-UNNAMED</argLine>
 						<reuseForks>false</reuseForks>
 					</configuration>
 				</plugin>
@@ -201,6 +215,11 @@
 						<pushChanges>false</pushChanges>
 						<localCheckout>true</localCheckout>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.8.13</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -287,6 +306,33 @@
 							<autoPublish>true</autoPublish>
 							<waitUntil>published</waitUntil>
 						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<!-- Activated in CI: mvn verify -P coverage -->
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>prepare-agent</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>report</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
## Summary
- Add a `coverage` Maven profile (JaCoCo prepare-agent + report) and `sonar.*` properties (excludes the `rocksdb/` submodule everywhere, and `benchmarks/` from coverage too — no tests by design).
- Add `.github/workflows/sonar.yml`: scheduled daily + `workflow_dispatch`, mirrors this repo's own CI conventions (checkout with submodules, zig setup) rather than a stale template.
- Add Quality Gate + Coverage badges to the README.
- Fix a latent bug the coverage profile would have tripped over: surefire's `argLine` was a hardcoded literal (`--enable-native-access=ALL-UNNAMED`), which would have silently discarded JaCoCo's instrumentation flag. Switched to `@{argLine} --enable-native-access=ALL-UNNAMED` with an empty default `<argLine/>` property, so both plain and `-P coverage` builds resolve correctly.

Closes #62 (except the manual, one-time SonarCloud project creation + `SONAR_TOKEN` secret, done outside this PR).

## Test plan
- [x] `./mvnw -pl core validate` (checkstyle) — clean
- [x] `./mvnw -pl native/osx-aarch64,core -am test` (plain build) — passes, confirms `@{argLine}` default doesn't break non-coverage builds
- [x] `./mvnw verify -P coverage` (full reactor) — passes, `core/target/site/jacoco/jacoco.xml` produced matching `sonar.coverage.jacoco.xmlReportPaths`
- [ ] `sonar.yml` green on a manual `workflow_dispatch` run (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)