### PR TITLE
fix: pin third-party GitHub Actions to a full commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'maven' # Caches ~/.m2/repository
 
       - name: Install Zig
-        uses: goto-bus-stop/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
         with:
           version: 0.15.2
 

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -22,4 +22,4 @@ jobs:
           cache: 'maven'
 
       - name: Submit dependencies
-        uses: advanced-security/maven-dependency-submission-action@v4
+        uses: advanced-security/maven-dependency-submission-action@fe8d4d650a4b66508612d0683ce4726d51dfe6ac # v4.1.3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
 
       - name: Install Zig
-        uses: goto-bus-stop/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
         with:
           version: 0.15.2
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'maven'
 
       - name: Install Zig
-        uses: goto-bus-stop/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
         with:
           version: 0.15.2
 


### PR DESCRIPTION
## Summary
SonarCloud flagged 4 open HIGH-security vulnerabilities (rule `githubactions:S7637`, "Use full commit SHA hash for this dependency") in the first scan after #63: https://sonarcloud.io/project/issues?impactSoftwareQualities=SECURITY&issueStatuses=OPEN%2CCONFIRMED&id=dfa1_rocksdbffm

- `.github/workflows/ci.yml:33`
- `.github/workflows/publish.yml:40`
- `.github/workflows/sonar.yml:29`
- `.github/workflows/dependency-submission.yml:25`

All four point at `goto-bus-stop/setup-zig@v2` or `advanced-security/maven-dependency-submission-action@v4` — both mutable tags. Pinned each to its current commit SHA (resolved via the GitHub API), with the version kept as a trailing comment for readability:

- `goto-bus-stop/setup-zig@v2` → `@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1`
- `advanced-security/maven-dependency-submission-action@v4` → `@fe8d4d650a4b66508612d0683ce4726d51dfe6ac # v4.1.3`

First-party `actions/*` steps (`checkout`, `setup-java`, `cache`) weren't flagged by Sonar and are left as-is.

## Test plan
- [x] All 4 edited workflow YAML files parse cleanly
- [ ] `ci.yml` green on next push/PR run
- [ ] Next scheduled/dispatched `sonar.yml` run shows these 4 vulnerabilities resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)