### PR TITLE
test: cover 0%-coverage classes; wire integration-tests into coverage report

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/MemorySize.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/MemorySize.java
@@ -78,14 +78,6 @@ public final class MemorySize implements Comparable<MemorySize> {
 		return bytes;
 	}
 
-	/// Returns the sum of this size and `other`.
-	///
-	/// @param other the size to add
-	/// @return a new [MemorySize] representing the combined byte count
-	public MemorySize add(MemorySize other) {
-		return new MemorySize(Math.addExact(this.bytes, other.bytes));
-	}
-
 	// -----------------------------------------------------------------------
 	// Value semantics
 	// -----------------------------------------------------------------------

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineOptionsTest.java
@@ -1,0 +1,205 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BackupEngineOptionsTest {
+
+	@Test
+	void create_usesRocksDbDefaults(@TempDir Path dir) {
+		// Given / When
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// Then
+			assertThat(sut.isShareTableFiles()).isTrue();
+			assertThat(sut.isSync()).isTrue();
+			assertThat(sut.isDestroyOldData()).isFalse();
+			assertThat(sut.isBackupLogFiles()).isTrue();
+			assertThat(sut.getMaxBackgroundOperations()).isEqualTo(1);
+			// The javadoc's "-1 means all" describes setMaxValidBackupsToOpen's accepted
+			// sentinel; the native default is actually INT_MAX, which means the same thing.
+			assertThat(sut.getMaxValidBackupsToOpen()).isEqualTo(Integer.MAX_VALUE);
+		}
+	}
+
+	@Test
+	void setShareTableFiles_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setShareTableFiles(false);
+
+			// Then
+			assertThat(sut.isShareTableFiles()).isFalse();
+		}
+	}
+
+	@Test
+	void setSync_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setSync(false);
+
+			// Then
+			assertThat(sut.isSync()).isFalse();
+		}
+	}
+
+	@Test
+	void setDestroyOldData_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setDestroyOldData(true);
+
+			// Then
+			assertThat(sut.isDestroyOldData()).isTrue();
+		}
+	}
+
+	@Test
+	void setBackupLogFiles_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setBackupLogFiles(false);
+
+			// Then
+			assertThat(sut.isBackupLogFiles()).isFalse();
+		}
+	}
+
+	@Test
+	void setBackupRateLimit_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setBackupRateLimit(MemorySize.ofMB(50));
+
+			// Then
+			assertThat(sut.getBackupRateLimit()).isEqualTo(MemorySize.ofMB(50));
+		}
+	}
+
+	@Test
+	void setRestoreRateLimit_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setRestoreRateLimit(MemorySize.ofMB(75));
+
+			// Then
+			assertThat(sut.getRestoreRateLimit()).isEqualTo(MemorySize.ofMB(75));
+		}
+	}
+
+	@Test
+	void setMaxBackgroundOperations_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setMaxBackgroundOperations(4);
+
+			// Then
+			assertThat(sut.getMaxBackgroundOperations()).isEqualTo(4);
+		}
+	}
+
+	@Test
+	void setCallbackTriggerIntervalSize_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setCallbackTriggerIntervalSize(MemorySize.ofMB(16));
+
+			// Then
+			assertThat(sut.getCallbackTriggerIntervalSize()).isEqualTo(MemorySize.ofMB(16));
+		}
+	}
+
+	@Test
+	void setMaxValidBackupsToOpen_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setMaxValidBackupsToOpen(3);
+
+			// Then
+			assertThat(sut.getMaxValidBackupsToOpen()).isEqualTo(3);
+		}
+	}
+
+	@Test
+	void setShareFilesWithChecksumNaming_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			sut.setShareFilesWithChecksumNaming(2);
+
+			// Then
+			assertThat(sut.getShareFilesWithChecksumNaming()).isEqualTo(2);
+		}
+	}
+
+	@Test
+	void setBackupDir_changesTargetDirectory(@TempDir Path dir) {
+		// Given
+		var otherDir = dir.resolve("elsewhere");
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When / Then — no exception is thrown when repointing the backup directory
+			sut.setBackupDir(otherDir);
+		}
+	}
+
+	@Test
+	void setEnv_acceptsDefaultEnv(@TempDir Path dir) {
+		// Given
+		try (var env = Env.defaultEnv();
+		     var sut = BackupEngineOptions.create(dir)) {
+
+			// When / Then — no exception is thrown when wiring an explicit Env
+			sut.setEnv(env);
+		}
+	}
+
+	@Test
+	void fluentSetters_returnSameInstance(@TempDir Path dir) {
+		// Given
+		try (var sut = BackupEngineOptions.create(dir)) {
+
+			// When
+			var result = sut.setShareTableFiles(true);
+
+			// Then
+			assertThat(result).isSameAs(sut);
+		}
+	}
+
+	@Test
+	void close_isIdempotent(@TempDir Path dir) {
+		// Given
+		var sut = BackupEngineOptions.create(dir);
+
+		// When
+		sut.close();
+
+		// Then — closing twice must not crash the JVM
+		sut.close();
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineTest.java
@@ -1,0 +1,229 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BackupEngineTest {
+
+	@Test
+	void createNewBackup_isVisibleInGetBackupInfo(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
+
+			db.put("k".getBytes(), "v".getBytes());
+
+			// When
+			engine.createNewBackup(db, true);
+
+			// Then
+			List<BackupInfo> result = engine.getBackupInfo();
+			assertThat(result).hasSize(1);
+			assertThat(result.getFirst().backupId()).isEqualTo(BackupId.of(1));
+			assertThat(result.getFirst().numberOfFiles()).isGreaterThan(0);
+		}
+	}
+
+	@Test
+	void getBackupInfo_isEmptyForFreshEngine(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
+
+			// When
+			var result = engine.getBackupInfo();
+
+			// Then
+			assertThat(result).isEmpty();
+		}
+	}
+
+	@Test
+	void verifyBackup_succeedsForValidBackup(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
+
+			db.put("k".getBytes(), "v".getBytes());
+			engine.createNewBackup(db);
+
+			// When / Then — must not throw
+			engine.verifyBackup(BackupId.of(1));
+		}
+	}
+
+	@Test
+	void verifyBackup_throwsForUnknownBackupId(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
+
+			engine.createNewBackup(db);
+
+			// When
+			var thrown = assertThatThrownBy(() -> engine.verifyBackup(BackupId.of(42)));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	@Test
+	void purgeOldBackups_keepsOnlyMostRecent(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
+
+			engine.createNewBackup(db);
+			engine.createNewBackup(db);
+			engine.createNewBackup(db);
+
+			// When
+			engine.purgeOldBackups(1);
+
+			// Then
+			var result = engine.getBackupInfo();
+			assertThat(result).hasSize(1);
+			assertThat(result.getFirst().backupId()).isEqualTo(BackupId.of(3));
+		}
+	}
+
+	@Test
+	void restoreDbFromLatestBackup_recoversData(@TempDir Path dir) {
+		var dbDir = dir.resolve("db");
+		var backupDir = dir.resolve("backup");
+		var restoreDir = dir.resolve("restore");
+
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dbDir);
+		     var engine = BackupEngine.open(opts, backupDir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+			engine.createNewBackup(db);
+
+			// When
+			try (var restoreOptions = RestoreOptions.create()) {
+				engine.restoreDbFromLatestBackup(restoreDir, restoreOptions);
+			}
+		}
+
+		// Then
+		try (var opts = Options.newOptions();
+		     var restored = RocksDB.open(opts, restoreDir)) {
+			assertThat(restored.get("k".getBytes())).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void restoreDbFromLatestBackup_withSeparateWalDir(@TempDir Path dir) {
+		var dbDir = dir.resolve("db");
+		var backupDir = dir.resolve("backup");
+		var restoreDir = dir.resolve("restore");
+		var walDir = dir.resolve("wal");
+
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dbDir);
+		     var engine = BackupEngine.open(opts, backupDir)) {
+
+			// flushBeforeBackup=true: the value must land in an SST file rather than
+			// staying WAL-only, since we open the restored DB below without pointing
+			// it back at walDir — a WAL-only write would be invisible there.
+			db.put("k".getBytes(), "v".getBytes());
+			engine.createNewBackup(db, true);
+
+			// When
+			try (var restoreOptions = RestoreOptions.create()) {
+				engine.restoreDbFromLatestBackup(restoreDir, walDir, restoreOptions);
+			}
+		}
+
+		// Then
+		try (var opts = Options.newOptions();
+		     var restored = RocksDB.open(opts, restoreDir)) {
+			assertThat(restored.get("k".getBytes())).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void restoreDbFromBackup_selectsSpecificBackupId(@TempDir Path dir) {
+		var dbDir = dir.resolve("db");
+		var backupDir = dir.resolve("backup");
+		var restoreDir = dir.resolve("restore");
+
+		// Given — two backups with different content
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dbDir);
+		     var engine = BackupEngine.open(opts, backupDir)) {
+
+			db.put("k".getBytes(), "first".getBytes());
+			engine.createNewBackup(db, true);
+
+			db.put("k".getBytes(), "second".getBytes());
+			engine.createNewBackup(db, true);
+
+			// When — restore the first backup, not the latest
+			try (var restoreOptions = RestoreOptions.create()) {
+				engine.restoreDbFromBackup(BackupId.of(1), restoreDir, restoreOptions);
+			}
+		}
+
+		// Then
+		try (var opts = Options.newOptions();
+		     var restored = RocksDB.open(opts, restoreDir)) {
+			assertThat(restored.get("k".getBytes())).isEqualTo("first".getBytes());
+		}
+	}
+
+	@Test
+	void open_withBackupEngineOptionsAndEnv(@TempDir Path dir) {
+		var dbDir = dir.resolve("db");
+		var backupDir = dir.resolve("backup");
+
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dbDir);
+		     var env = Env.defaultEnv();
+		     var beOpts = BackupEngineOptions.create(backupDir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+
+			// When
+			try (var engine = BackupEngine.open(beOpts, env)) {
+				engine.createNewBackup(db);
+
+				// Then
+				assertThat(engine.getBackupInfo()).hasSize(1);
+			}
+		}
+	}
+
+	@Test
+	void close_isIdempotent(@TempDir Path dir) {
+		// Given
+		var opts = Options.newOptions().setCreateIfMissing(true);
+		var db = RocksDB.open(opts, dir.resolve("db"));
+		var engine = BackupEngine.open(opts, dir.resolve("backup"));
+
+		// When
+		engine.close();
+
+		// Then — closing twice must not crash the JVM
+		engine.close();
+
+		db.close();
+		opts.close();
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BackupIdTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BackupIdTest.java
@@ -1,0 +1,140 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BackupIdTest {
+
+	@Test
+	void of_storesExactValue() {
+		// Given
+		var sut = BackupId.of(42);
+
+		// When
+		var result = sut.toLong();
+
+		// Then
+		assertThat(result).isEqualTo(42);
+	}
+
+	@Test
+	void of_acceptsZero() {
+		// Given
+		var sut = BackupId.of(0);
+
+		// When
+		var result = sut.toLong();
+
+		// Then
+		assertThat(result).isZero();
+	}
+
+	@Test
+	void of_rejectsNegativeValues() {
+		// Given / When / Then
+		assertThatThrownBy(() -> BackupId.of(-1)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void of_acceptsMaxUint32Value() {
+		// Given
+		var sut = BackupId.of(0xFFFFFFFFL);
+
+		// When
+		var result = sut.toLong();
+
+		// Then
+		assertThat(result).isEqualTo(0xFFFFFFFFL);
+	}
+
+	@Test
+	void of_rejectsValuesAboveUint32Range() {
+		// Given / When / Then
+		assertThatThrownBy(() -> BackupId.of(0xFFFFFFFFL + 1)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void fromNative_interpretsNegativeIntAsUnsigned() {
+		// Given — a native uint32_t with the high bit set overflows into a negative Java int
+		int nativeValue = -1; // bit pattern 0xFFFFFFFF
+
+		// When
+		var result = BackupId.fromNative(nativeValue);
+
+		// Then
+		assertThat(result.toLong()).isEqualTo(0xFFFFFFFFL);
+	}
+
+	@Test
+	void toNativeInt_roundTripsThroughFromNative() {
+		// Given
+		var sut = BackupId.of(0xFFFFFFFFL);
+
+		// When
+		var result = sut.toNativeInt();
+
+		// Then
+		assertThat(BackupId.fromNative(result)).isEqualTo(sut);
+	}
+
+	@Test
+	void compareTo_ordersUnsignedNearUint32Boundary() {
+		// Given — 0x7FFFFFFF (as signed long) vs 0x80000000 (would be negative as a signed int)
+		var belowBoundary = BackupId.of(0x7FFFFFFFL);
+		var atBoundary = BackupId.of(0x80000000L);
+
+		// When
+		var result = belowBoundary.compareTo(atBoundary);
+
+		// Then
+		assertThat(result).isNegative();
+	}
+
+	@Test
+	void equals_isByValue() {
+		// Given / When / Then
+		assertThat(BackupId.of(10)).isEqualTo(BackupId.of(10));
+		assertThat(BackupId.of(10)).isNotEqualTo(BackupId.of(11));
+	}
+
+	@Test
+	void equals_returnsFalseForNonBackupId() {
+		// Given
+		var sut = BackupId.of(1);
+
+		// When
+		var result = sut.equals("not a backup id");
+
+		// Then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	void hashCode_isConsistentWithEquals() {
+		// Given
+		var a = BackupId.of(99);
+		var b = BackupId.of(99);
+
+		// When
+		var hashA = a.hashCode();
+		var hashB = b.hashCode();
+
+		// Then
+		assertThat(a).isEqualTo(b);
+		assertThat(hashA).isEqualTo(hashB);
+	}
+
+	@Test
+	void toString_includesValue() {
+		// Given
+		var sut = BackupId.of(7);
+
+		// When
+		var result = sut.toString();
+
+		// Then
+		assertThat(result).isEqualTo("BackupId(7)");
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BackupInfoTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BackupInfoTest.java
@@ -1,0 +1,36 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BackupInfoTest {
+
+	@Test
+	void components_areExposedExactly() {
+		// Given
+		var backupId = BackupId.of(3);
+		var size = MemorySize.ofMB(5);
+
+		// When
+		var sut = new BackupInfo(backupId, 1_700_000_000L, size, 12L);
+
+		// Then
+		assertThat(sut.backupId()).isEqualTo(backupId);
+		assertThat(sut.timestamp()).isEqualTo(1_700_000_000L);
+		assertThat(sut.size()).isEqualTo(size);
+		assertThat(sut.numberOfFiles()).isEqualTo(12L);
+	}
+
+	@Test
+	void equals_isByValue() {
+		// Given
+		var a = new BackupInfo(BackupId.of(1), 100L, MemorySize.ofBytes(50), 2L);
+		var b = new BackupInfo(BackupId.of(1), 100L, MemorySize.ofBytes(50), 2L);
+		var c = new BackupInfo(BackupId.of(2), 100L, MemorySize.ofBytes(50), 2L);
+
+		// When / Then
+		assertThat(a).isEqualTo(b);
+		assertThat(a).isNotEqualTo(c);
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/MemorySizeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/MemorySizeTest.java
@@ -94,19 +94,6 @@ class MemorySizeTest {
 	}
 
 	@Test
-	void add_returnsSumInBytes() {
-		// Given
-		var a = MemorySize.ofMB(1);
-		var b = MemorySize.ofMB(2);
-
-		// When
-		var result = a.add(b);
-
-		// Then
-		assertThat(result).isEqualTo(MemorySize.ofMB(3));
-	}
-
-	@Test
 	void toString_showsLargestEvenUnit() {
 		assertThat(MemorySize.ofGB(1).toString()).isEqualTo("1 GB");
 		assertThat(MemorySize.ofMB(64).toString()).isEqualTo("64 MB");

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PerfContextTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PerfContextTest.java
@@ -1,0 +1,130 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PerfContextTest {
+
+	@AfterEach
+	void resetPerfLevel() {
+		PerfContext.setPerfLevel(PerfLevel.DISABLE);
+	}
+
+	@Test
+	void newPerfContext_resetsCountersToZero(@TempDir Path dir) {
+		// Given — accumulate some activity, then start a fresh measurement window
+		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+			try (var warmup = PerfContext.newPerfContext()) {
+				db.get("k".getBytes());
+			}
+
+			// When
+			try (var sut = PerfContext.newPerfContext()) {
+
+				// Then
+				assertThat(sut.metric(PerfMetric.USER_KEY_COMPARISON_COUNT)).isZero();
+			}
+		}
+	}
+
+	@Test
+	void currentPerfContext_doesNotResetCounters(@TempDir Path dir) {
+		// Given
+		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir)) {
+
+			try (var warmup = PerfContext.newPerfContext()) {
+				db.put("k".getBytes(), "v".getBytes());
+				db.get("k".getBytes());
+
+				// When
+				try (var sut = PerfContext.currentPerfContext()) {
+
+					// Then — sees the accumulation from before it was created
+					assertThat(sut.metric(PerfMetric.USER_KEY_COMPARISON_COUNT)).isGreaterThan(0);
+				}
+			}
+		}
+	}
+
+	@Test
+	void reset_zeroesAccumulatedCounters(@TempDir Path dir) {
+		// Given
+		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir);
+		     var sut = PerfContext.newPerfContext()) {
+
+			db.put("k".getBytes(), "v".getBytes());
+			db.get("k".getBytes());
+			assertThat(sut.metric(PerfMetric.USER_KEY_COMPARISON_COUNT)).isGreaterThan(0);
+
+			// When
+			sut.reset();
+
+			// Then
+			assertThat(sut.metric(PerfMetric.USER_KEY_COMPARISON_COUNT)).isZero();
+		}
+	}
+
+	@Test
+	void report_excludingZeroCounters_omitsUnusedMetrics(@TempDir Path dir) {
+		// Given
+		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir);
+		     var sut = PerfContext.newPerfContext()) {
+
+			db.put("k".getBytes(), "v".getBytes());
+			db.get("k".getBytes());
+
+			// When
+			var result = sut.report(true);
+
+			// Then
+			assertThat(result).isNotBlank();
+		}
+	}
+
+	@Test
+	void report_includingZeroCounters_isLongerThanExcluding(@TempDir Path dir) {
+		// Given
+		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.open(opts, dir);
+		     var sut = PerfContext.newPerfContext()) {
+
+			db.put("k".getBytes(), "v".getBytes());
+			db.get("k".getBytes());
+
+			// When
+			var withZeros = sut.report(false);
+			var withoutZeros = sut.report(true);
+
+			// Then
+			assertThat(withZeros.length()).isGreaterThan(withoutZeros.length());
+		}
+	}
+
+	@Test
+	void close_isIdempotent() {
+		// Given
+		var sut = PerfContext.newPerfContext();
+
+		// When
+		sut.close();
+
+		// Then — closing twice must not crash the JVM
+		sut.close();
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PerfLevelTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PerfLevelTest.java
@@ -1,0 +1,36 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PerfLevelTest {
+
+	@Test
+	void fromValue_resolvesEveryDeclaredConstant() {
+		for (PerfLevel level : PerfLevel.values()) {
+			// Given / When
+			var result = PerfLevel.fromValue(level.value);
+
+			// Then
+			assertThat(result).isEqualTo(level);
+		}
+	}
+
+	@Test
+	void fromValue_rejectsUnknownValue() {
+		// Given / When / Then
+		assertThatThrownBy(() -> PerfLevel.fromValue(-1)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void values_matchExpectedOrdinals() {
+		// Given / When / Then
+		assertThat(PerfLevel.UNINITIALIZED.value).isZero();
+		assertThat(PerfLevel.DISABLE.value).isEqualTo(1);
+		assertThat(PerfLevel.ENABLE_COUNT.value).isEqualTo(2);
+		assertThat(PerfLevel.ENABLE_TIME_EXCEPT_FOR_MUTEX.value).isEqualTo(3);
+		assertThat(PerfLevel.ENABLE_TIME.value).isEqualTo(4);
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PerfMetricTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PerfMetricTest.java
@@ -1,0 +1,54 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PerfMetricTest {
+
+	@Test
+	void values_haveUniqueNonNegativeNativeValues() {
+		// Given
+		var metrics = PerfMetric.values();
+
+		// When
+		var distinctValues = new HashSet<Integer>();
+		for (PerfMetric metric : metrics) {
+			distinctValues.add(metric.value);
+		}
+
+		// Then
+		assertThat(distinctValues).hasSize(metrics.length);
+		assertThat(distinctValues).allSatisfy(v -> assertThat(v).isNotNegative());
+	}
+
+	@Test
+	void valueOf_roundTripsThroughName() {
+		// Given / When / Then
+		assertThat(PerfMetric.valueOf("BLOCK_CACHE_HIT_COUNT")).isEqualTo(PerfMetric.BLOCK_CACHE_HIT_COUNT);
+	}
+
+	@Test
+	void metric_isReadableForEveryDeclaredMetric(@TempDir Path dir) {
+		// Given
+		PerfContext.setPerfLevel(PerfLevel.ENABLE_TIME);
+		try (Options options = Options.newOptions().setCreateIfMissing(true);
+		     ReadWriteDB db = RocksDB.open(options, dir);
+		     PerfContext ctx = PerfContext.newPerfContext()) {
+
+			db.put("key".getBytes(), "value".getBytes());
+			db.get("key".getBytes());
+
+			// When / Then — must not throw for any declared constant
+			for (PerfMetric metric : PerfMetric.values()) {
+				assertThat(ctx.metric(metric)).isGreaterThanOrEqualTo(0);
+			}
+		} finally {
+			PerfContext.setPerfLevel(PerfLevel.DISABLE);
+		}
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PrepopulateBlobCacheTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PrepopulateBlobCacheTest.java
@@ -1,0 +1,47 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PrepopulateBlobCacheTest {
+
+	@Test
+	void fromValue_resolvesEveryDeclaredConstant() {
+		for (PrepopulateBlobCache v : PrepopulateBlobCache.values()) {
+			// Given / When
+			var result = PrepopulateBlobCache.fromValue(v.value);
+
+			// Then
+			assertThat(result).isEqualTo(v);
+		}
+	}
+
+	@Test
+	void fromValue_rejectsUnknownValue() {
+		// Given / When / Then
+		assertThatThrownBy(() -> PrepopulateBlobCache.fromValue(99)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void values_matchExpectedOrdinals() {
+		// Given / When / Then
+		assertThat(PrepopulateBlobCache.DISABLE.value).isZero();
+		assertThat(PrepopulateBlobCache.FLUSH_ONLY.value).isEqualTo(1);
+	}
+
+	@Test
+	void options_roundTripsThroughSetAndGet() {
+		// Given
+		try (var opts = Options.newOptions()) {
+
+			// When
+			opts.setPrepopulateBlobCache(PrepopulateBlobCache.FLUSH_ONLY);
+			var result = opts.getPrepopulateBlobCache();
+
+			// Then
+			assertThat(result).isEqualTo(PrepopulateBlobCache.FLUSH_ONLY);
+		}
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterTest.java
@@ -1,0 +1,121 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateLimiterTest {
+
+	@Test
+	void create_withDefaultRefillAndFairness(@TempDir Path dir) {
+		// Given
+		try (var sut = RateLimiter.create(MemorySize.ofMB(100));
+		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When
+			db.put("k".getBytes(), "v".getBytes());
+
+			// Then — DB opens and accepts writes with the limiter attached
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void create_withExplicitRefillAndFairness(@TempDir Path dir) {
+		// Given
+		try (var sut = RateLimiter.create(MemorySize.ofMB(100), 50_000L, 5);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When / Then — DB opens successfully with the limiter attached
+			assertThat(db).isNotNull();
+		}
+	}
+
+	@Test
+	void createAutoTuned_withDefaultRefillAndFairness(@TempDir Path dir) {
+		// Given
+		try (var sut = RateLimiter.createAutoTuned(MemorySize.ofMB(100));
+		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When / Then
+			assertThat(db).isNotNull();
+		}
+	}
+
+	@Test
+	void createAutoTuned_withExplicitRefillAndFairness(@TempDir Path dir) {
+		// Given
+		try (var sut = RateLimiter.createAutoTuned(MemorySize.ofMB(100), 100_000L, 10);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When / Then
+			assertThat(db).isNotNull();
+		}
+	}
+
+	@Test
+	void createWithMode_readsOnly(@TempDir Path dir) {
+		// Given
+		try (var sut = RateLimiter.createWithMode(
+				MemorySize.ofMB(100), 100_000L, 10, RateLimiter.Mode.READS_ONLY, false);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When / Then
+			assertThat(db).isNotNull();
+		}
+	}
+
+	@Test
+	void createWithMode_allIoAutoTuned(@TempDir Path dir) {
+		// Given
+		try (var sut = RateLimiter.createWithMode(
+				MemorySize.ofMB(100), 100_000L, 10, RateLimiter.Mode.ALL_IO, true);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When / Then
+			assertThat(db).isNotNull();
+		}
+	}
+
+	@Test
+	void mode_valuesMatchExpectedOrdinals() {
+		// Given / When / Then
+		assertThat(RateLimiter.Mode.READS_ONLY.value).isZero();
+		assertThat(RateLimiter.Mode.WRITES_ONLY.value).isEqualTo(1);
+		assertThat(RateLimiter.Mode.ALL_IO.value).isEqualTo(2);
+	}
+
+	@Test
+	void sharedOwnership_survivesIndependentClose() {
+		// Given — RateLimiter is not owned by Options; both may be closed independently
+		var sut = RateLimiter.create(MemorySize.ofMB(10));
+		var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
+
+		// When
+		opts.close();
+
+		// Then — the limiter itself is still usable/closable after Options is gone
+		sut.close();
+	}
+
+	@Test
+	void close_isIdempotent() {
+		// Given
+		var sut = RateLimiter.create(MemorySize.ofMB(10));
+
+		// When
+		sut.close();
+
+		// Then — closing twice must not crash the JVM
+		sut.close();
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RestoreOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RestoreOptionsTest.java
@@ -1,0 +1,43 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestoreOptionsTest {
+
+	@Test
+	void create_returnsUsableInstance() {
+		// Given / When
+		try (var sut = RestoreOptions.create()) {
+
+			// Then
+			assertThat(sut).isNotNull();
+		}
+	}
+
+	@Test
+	void setKeepLogFiles_returnsSameInstanceForChaining() {
+		// Given
+		try (var sut = RestoreOptions.create()) {
+
+			// When
+			var result = sut.setKeepLogFiles(true);
+
+			// Then
+			assertThat(result).isSameAs(sut);
+		}
+	}
+
+	@Test
+	void close_isIdempotent() {
+		// Given
+		var sut = RestoreOptions.create();
+
+		// When
+		sut.close();
+
+		// Then — closing twice must not crash the JVM
+		sut.close();
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SstFileManagerTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SstFileManagerTest.java
@@ -1,0 +1,154 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SstFileManagerTest {
+
+	@Test
+	void getTotalSize_reflectsActualSstUsage(@TempDir Path dir) {
+		// Given
+		try (var env = Env.defaultEnv();
+		     var sut = SstFileManager.create(env);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+			try (var flushOptions = FlushOptions.newFlushOptions().setWait(true)) {
+				db.flush(flushOptions);
+			}
+
+			// When
+			var result = sut.getTotalSize();
+
+			// Then
+			assertThat(result.toBytes()).isGreaterThan(0);
+		}
+	}
+
+	@Test
+	void setMaxAllowedSpaceUsage_notReachedUnderGenerousLimit(@TempDir Path dir) {
+		// Given
+		try (var env = Env.defaultEnv();
+		     var sut = SstFileManager.create(env)
+				     .setMaxAllowedSpaceUsage(MemorySize.ofGB(10))
+				     .setCompactionBufferSize(MemorySize.ofMB(512));
+		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When
+			db.put("k".getBytes(), "v".getBytes());
+
+			// Then
+			assertThat(sut.isMaxAllowedSpaceReached()).isFalse();
+			assertThat(sut.isMaxAllowedSpaceReachedIncludingCompactions()).isFalse();
+		}
+	}
+
+	@Test
+	void setMaxAllowedSpaceUsage_zeroMeansNoLimit(@TempDir Path dir) {
+		// Given
+		try (var env = Env.defaultEnv();
+		     var sut = SstFileManager.create(env).setMaxAllowedSpaceUsage(MemorySize.ZERO);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When
+			db.put("k".getBytes(), "v".getBytes());
+			try (var flushOptions = FlushOptions.newFlushOptions().setWait(true)) {
+				db.flush(flushOptions);
+			}
+
+			// Then — a zero limit means "unlimited", never reached
+			assertThat(sut.isMaxAllowedSpaceReached()).isFalse();
+		}
+	}
+
+	@Test
+	void setDeleteRateBytesPerSecond_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var env = Env.defaultEnv();
+		     var sut = SstFileManager.create(env)
+				     .setDeleteRateBytesPerSecond(MemorySize.ofMB(64).toBytes());
+		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When
+			var result = sut.getDeleteRateBytesPerSecond();
+
+			// Then
+			assertThat(result).isEqualTo(MemorySize.ofMB(64).toBytes());
+		}
+	}
+
+	@Test
+	void setMaxTrashDbRatio_roundTrips(@TempDir Path dir) {
+		// Given
+		try (var env = Env.defaultEnv();
+		     var sut = SstFileManager.create(env).setMaxTrashDbRatio(0.5);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			// When
+			var result = sut.getMaxTrashDbRatio();
+
+			// Then
+			assertThat(result).isEqualTo(0.5);
+		}
+	}
+
+	@Test
+	void getTotalTrashSize_isNonNegative(@TempDir Path dir) {
+		// Given
+		try (var env = Env.defaultEnv();
+		     var sut = SstFileManager.create(env);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
+		     var db = RocksDB.open(opts, dir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+
+			// When
+			var result = sut.getTotalTrashSize();
+
+			// Then
+			assertThat(result.toBytes()).isGreaterThanOrEqualTo(0);
+		}
+	}
+
+	@Test
+	void sharedOwnership_survivesIndependentCloseBeforeOptions(@TempDir Path dir) {
+		// Given — sfm uses shared ownership, safe to close before Options
+		try (var env = Env.defaultEnv();
+		     var sut = SstFileManager.create(env);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut)) {
+
+			// When
+			sut.close();
+
+			// Then — Options (and the underlying shared_ptr) is still valid
+			try (var db = RocksDB.open(opts, dir)) {
+				db.put("k".getBytes(), "v".getBytes());
+				assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+			}
+		}
+	}
+
+	@Test
+	void close_isIdempotent() {
+		// Given
+		var env = Env.defaultEnv();
+		var sut = SstFileManager.create(env);
+
+		// When
+		sut.close();
+
+		// Then — closing twice must not crash the JVM
+		sut.close();
+
+		env.close();
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TickerTypeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TickerTypeTest.java
@@ -1,0 +1,73 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TickerTypeTest {
+
+	@Test
+	void values_haveUniqueNonNegativeNativeValues() {
+		// Given
+		var tickers = TickerType.values();
+
+		// When
+		var distinctValues = new java.util.HashSet<Integer>();
+		for (TickerType ticker : tickers) {
+			distinctValues.add(ticker.getValue());
+		}
+
+		// Then
+		assertThat(distinctValues).hasSize(tickers.length);
+		assertThat(distinctValues).allSatisfy(v -> assertThat(v).isNotNegative());
+	}
+
+	@Test
+	void valueOf_roundTripsThroughName() {
+		// Given / When / Then
+		assertThat(TickerType.valueOf("BLOCK_CACHE_HIT")).isEqualTo(TickerType.BLOCK_CACHE_HIT);
+	}
+
+	@Test
+	void getTickerCount_reflectsRealDbActivity(@TempDir Path dir) {
+		// Given
+		try (Options options = Options.newOptions()
+				.setCreateIfMissing(true)
+				.enableStatistics()
+				.setStatisticsLevel(StatsLevel.ALL);
+		     ReadWriteDB db = RocksDB.open(options, dir)) {
+
+			db.put("key".getBytes(), "value".getBytes());
+			db.get("key".getBytes());
+			db.get("missing".getBytes());
+
+			// When
+			long keysWritten = options.getTickerCount(TickerType.NUMBER_KEYS_WRITTEN);
+			long bloomOrGetMisses = options.getTickerCount(TickerType.NUMBER_KEYS_READ);
+
+			// Then
+			assertThat(keysWritten).isGreaterThan(0);
+			assertThat(bloomOrGetMisses).isGreaterThanOrEqualTo(0);
+		}
+	}
+
+	@Test
+	void getTickerCount_isCallableForEveryDeclaredTicker(@TempDir Path dir) {
+		// Given — every ticker must be a valid index into the native rocksdb::Tickers enum
+		try (Options options = Options.newOptions()
+				.setCreateIfMissing(true)
+				.enableStatistics();
+		     ReadWriteDB db = RocksDB.open(options, dir)) {
+
+			db.put("key".getBytes(), "value".getBytes());
+
+			// When / Then — must not throw for any declared constant
+			for (TickerType ticker : TickerType.values()) {
+				assertThat(options.getTickerCount(ticker)).isGreaterThanOrEqualTo(0);
+			}
+		}
+	}
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -18,10 +18,16 @@
 	</properties>
 
 	<dependencies>
+		<!-- compile (not test) scope: this module has no main sources of its own — its
+		     "compile" classpath is otherwise unused — but jacoco:report-aggregate only pulls
+		     a reactor dependency's classes/sources into the coverage report for
+		     compile/runtime/provided scope, using test-scoped deps for their exec data alone.
+		     Without this, core's classes exercised only by these integration tests would
+		     never show up as covered. -->
 		<dependency>
 			<groupId>io.github.dfa1</groupId>
 			<artifactId>rocksdbffm-core</artifactId>
-			<scope>test</scope>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.github.dfa1</groupId>
@@ -82,7 +88,11 @@
 					<includes>
 						<include>**/*IntegrationTest.java</include>
 					</includes>
-					<argLine>--enable-native-access=ALL-UNNAMED</argLine>
+					<!-- @{argLine} expands to the JaCoCo agent arguments set by
+					     jacoco:prepare-agent-integration (default propertyName is "argLine", same
+					     as prepare-agent's — not a separate "failsafeArgLine") when the coverage
+					     profile is active; empty otherwise (default from the root pom). -->
+					<argLine>@{argLine} --enable-native-access=ALL-UNNAMED</argLine>
 				</configuration>
 				<executions>
 					<execution>
@@ -96,4 +106,39 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<!-- Overrides (not merges with) the root coverage profile: this module has no
+			     unit tests, only failsafe-driven integration tests, so it needs
+			     prepare-agent-integration + report-aggregate instead of prepare-agent + report.
+			     report-aggregate pulls in core's classes/sources (declared as a reactor
+			     dependency above) plus both core's own jacoco.exec and this module's
+			     jacoco-it.exec, crediting core's classes with what integration tests exercise
+			     that unit tests don't. -->
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>prepare-agent-integration</id>
+								<goals>
+									<goal>prepare-agent-integration</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>report-aggregate</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report-aggregate</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,8 @@
 		<sonar.exclusions>rocksdb/**</sonar.exclusions>
 		<sonar.coverage.exclusions>rocksdb/**,benchmarks/**</sonar.coverage.exclusions>
 		<sonar.coverage.jacoco.xmlReportPaths>
-			${maven.multiModuleProjectDirectory}/core/target/site/jacoco/jacoco.xml
+			${maven.multiModuleProjectDirectory}/core/target/site/jacoco/jacoco.xml,
+			${maven.multiModuleProjectDirectory}/integration-tests/target/site/jacoco-aggregate/jacoco.xml
 		</sonar.coverage.jacoco.xmlReportPaths>
 		<!-- Default for the @{argLine} placeholder in the surefire config below. jacoco:prepare-agent
 		     overwrites this with the agent arguments when the coverage profile is active; without this


### PR DESCRIPTION
## Summary

SonarCloud's [coverage page](https://sonarcloud.io/component_measures?id=dfa1_rocksdbffm&metric=coverage&view=list) showed 12 classes at 0%: `TickerType`, `BackupEngineOptions`, `BackupEngine`, `PerfMetric`, `SstFileManager`, `PerfContext`, `RateLimiter`, `RestoreOptions`, `BackupId`, `PerfLevel`, `PrepopulateBlobCache`, `BackupInfo`.

Most of these were already exercised by `integration-tests` (`BackupEngineIntegrationTest`, `PerfContextIntegrationTest`, `RateLimiterIntegrationTest`, `SstFileManagerIntegrationTest`) — that module's coverage just never reached Sonar. Three separate wiring bugs, all fixed:

1. `integration-tests/pom.xml`'s failsafe `argLine` was a hardcoded literal — same landmine `core`'s surefire config had before #63 — so JaCoCo's instrumentation flag was silently discarded. Fixed via `@{argLine}` (`prepare-agent-integration`'s default `propertyName` is `argLine`, same as `prepare-agent`'s — not a separate `failsafeArgLine`, which is what my first attempt at this assumed and had to correct after verifying no `jacoco-it.exec` was produced).
2. `jacoco:report-aggregate` only pulls a reactor dependency's classes/sources into the report for `compile`/`runtime`/`provided` scope; `core` was `test`-scoped there, so only its exec data (with nowhere to attribute it) was collected. Promoted to `compile` scope — safe since `integration-tests` has no main sources and is never published (`maven.deploy.skip=true`).
3. Root `pom.xml`'s `sonar.coverage.jacoco.xmlReportPaths` only listed `core`'s own report; added `integration-tests`' `report-aggregate` output.

`TickerType` and `PrepopulateBlobCache` were genuinely untested anywhere (not even via integration tests) and now have dedicated tests.

Per the maintainer's call: all 12 classes also got dedicated unit tests directly in `core/src/test`, on top of the wiring fix above — fast isolated unit tests catch regressions integration tests are too slow/broad to run on every change.

Also dropped `MemorySize.add(MemorySize)` — dead code, called only from its own now-removed test, never from production code.

## Verification

- `./mvnw -pl core javadoc:javadoc` — zero output (required by CLAUDE.md)
- `./mvnw verify -P coverage` (full reactor) — green; `core/target/site/jacoco/jacoco.xml` alone now shows real coverage for all 12 previously-0% classes (e.g. `TickerType` 0→1659/1659 instructions, `BackupEngine` 0→514/579)
- `jacoco-it.exec` now produced by `integration-tests` (previously never written)
- `integration-tests/target/site/jacoco-aggregate/jacoco.xml` now attributes coverage back to `core`'s classes

## Test plan
- [x] Full reactor `./mvnw verify -P coverage` passes locally
- [ ] CI green
- [ ] Next scheduled/dispatched `sonar.yml` run shows the 12 classes off the 0% list

🤖 Generated with [Claude Code](https://claude.com/claude-code)