### PR TITLE
Close remaining tier gaps: WriteBatch, TransactionDB, OptimisticTransactionDB, SstFileWriter, Transaction

### DIFF
--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
@@ -59,10 +59,11 @@ public class FfmBenchmark {
 
 	private WriteBatch batch;
 	private byte[][] batchKeys;
+	private byte[][] batchValues;
 	private ByteBuffer[] batchKeysByteBuffer;
-	private ByteBuffer batchValueByteBuffer;
+	private ByteBuffer[] batchValuesByteBuffer;
 	private MemorySegment[] batchKeysMemorySegment;
-	private MemorySegment batchValueMemorySegment;
+	private MemorySegment[] batchValuesMemorySegment;
 
 	@Setup(Level.Trial)
 	public void setup() throws Exception {
@@ -95,21 +96,24 @@ public class FfmBenchmark {
 
 		// --- batch: byte[] tier ---
 		batchKeys = TestData.batchKeys();
+		batchValues = TestData.batchValues();
 		batch = WriteBatch.create();
 
 		// --- batch: ByteBuffer tier ---
 		batchKeysByteBuffer = new ByteBuffer[TestData.WRITE_BATCH_SIZE];
+		batchValuesByteBuffer = new ByteBuffer[TestData.WRITE_BATCH_SIZE];
 		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
 			batchKeysByteBuffer[i] = ByteBuffer.allocateDirect(batchKeys[i].length).put(batchKeys[i]).flip();
+			batchValuesByteBuffer[i] = ByteBuffer.allocateDirect(batchValues[i].length).put(batchValues[i]).flip();
 		}
-		batchValueByteBuffer = ByteBuffer.allocateDirect(TestData.BATCH_VALUE.length).put(TestData.BATCH_VALUE).flip();
 
 		// --- batch: MemorySegment tier ---
 		batchKeysMemorySegment = new MemorySegment[TestData.WRITE_BATCH_SIZE];
+		batchValuesMemorySegment = new MemorySegment[TestData.WRITE_BATCH_SIZE];
 		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
 			batchKeysMemorySegment[i] = arenaMemorySegment.allocateFrom(ValueLayout.JAVA_BYTE, batchKeys[i]);
+			batchValuesMemorySegment[i] = arenaMemorySegment.allocateFrom(ValueLayout.JAVA_BYTE, batchValues[i]);
 		}
-		batchValueMemorySegment = arenaMemorySegment.allocateFrom(ValueLayout.JAVA_BYTE, TestData.BATCH_VALUE);
 	}
 
 	@TearDown(Level.Trial)
@@ -194,7 +198,7 @@ public class FfmBenchmark {
 	public void batchWrites() {
 		batch.clear();
 		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
-			batch.put(batchKeys[i], TestData.BATCH_VALUE);
+			batch.put(batchKeys[i], batchValues[i]);
 		}
 		db.write(batch);
 	}
@@ -204,7 +208,7 @@ public class FfmBenchmark {
 		batch.clear();
 		try (Arena arena = Arena.ofConfined()) {
 			for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
-				batch.put(arena, batchKeys[i], TestData.BATCH_VALUE);
+				batch.put(arena, batchKeys[i], batchValues[i]);
 			}
 			db.write(arena, batch);
 		}
@@ -217,8 +221,8 @@ public class FfmBenchmark {
 		batch.clear();
 		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
 			batchKeysByteBuffer[i].rewind();
-			batchValueByteBuffer.rewind();
-			batch.put(batchKeysByteBuffer[i], batchValueByteBuffer);
+			batchValuesByteBuffer[i].rewind();
+			batch.put(batchKeysByteBuffer[i], batchValuesByteBuffer[i]);
 		}
 		db.write(batch);
 	}
@@ -229,7 +233,7 @@ public class FfmBenchmark {
 	public void batchWritesMemorySegment() {
 		batch.clear();
 		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
-			batch.put(batchKeysMemorySegment[i], batchValueMemorySegment);
+			batch.put(batchKeysMemorySegment[i], batchValuesMemorySegment[i]);
 		}
 		db.write(batch);
 	}

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
@@ -59,6 +59,10 @@ public class FfmBenchmark {
 
 	private WriteBatch batch;
 	private byte[][] batchKeys;
+	private ByteBuffer[] batchKeysByteBuffer;
+	private ByteBuffer batchValueByteBuffer;
+	private MemorySegment[] batchKeysMemorySegment;
+	private MemorySegment batchValueMemorySegment;
 
 	@Setup(Level.Trial)
 	public void setup() throws Exception {
@@ -89,9 +93,23 @@ public class FfmBenchmark {
 		// Seed the read key
 		db.put(TestData.READ_KEY_BYTES, TestData.READ_VALUE_BYTES);
 
-		// --- batch ---
+		// --- batch: byte[] tier ---
 		batchKeys = TestData.batchKeys();
 		batch = WriteBatch.create();
+
+		// --- batch: ByteBuffer tier ---
+		batchKeysByteBuffer = new ByteBuffer[TestData.WRITE_BATCH_SIZE];
+		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
+			batchKeysByteBuffer[i] = ByteBuffer.allocateDirect(batchKeys[i].length).put(batchKeys[i]).flip();
+		}
+		batchValueByteBuffer = ByteBuffer.allocateDirect(TestData.BATCH_VALUE.length).put(TestData.BATCH_VALUE).flip();
+
+		// --- batch: MemorySegment tier ---
+		batchKeysMemorySegment = new MemorySegment[TestData.WRITE_BATCH_SIZE];
+		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
+			batchKeysMemorySegment[i] = arenaMemorySegment.allocateFrom(ValueLayout.JAVA_BYTE, batchKeys[i]);
+		}
+		batchValueMemorySegment = arenaMemorySegment.allocateFrom(ValueLayout.JAVA_BYTE, TestData.BATCH_VALUE);
 	}
 
 	@TearDown(Level.Trial)
@@ -190,6 +208,30 @@ public class FfmBenchmark {
 			}
 			db.write(arena, batch);
 		}
+	}
+
+	// ---- batch (ByteBuffer keys, zero-copy) --------------------------------
+
+	@Benchmark
+	public void batchWritesByteBuffer() {
+		batch.clear();
+		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
+			batchKeysByteBuffer[i].rewind();
+			batchValueByteBuffer.rewind();
+			batch.put(batchKeysByteBuffer[i], batchValueByteBuffer);
+		}
+		db.write(batch);
+	}
+
+	// ---- batch (MemorySegment keys, zero-copy) -----------------------------
+
+	@Benchmark
+	public void batchWritesMemorySegment() {
+		batch.clear();
+		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
+			batch.put(batchKeysMemorySegment[i], batchValueMemorySegment);
+		}
+		db.write(batch);
 	}
 
 	static void main() throws Exception {

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/JniBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/JniBenchmark.java
@@ -54,6 +54,7 @@ public class JniBenchmark {
 
 	private WriteBatch batch;
 	private byte[][] batchKeys;
+	private byte[][] batchValues;
 
 	@Setup(Level.Trial)
 	public void setup() throws Exception {
@@ -81,6 +82,7 @@ public class JniBenchmark {
 		db.put(TestData.READ_KEY_BYTES, TestData.READ_VALUE_BYTES);
 
 		batchKeys = TestData.batchKeys();
+		batchValues = TestData.batchValues();
 		batch = new WriteBatch();
 	}
 
@@ -128,7 +130,7 @@ public class JniBenchmark {
 	public void batchWrites() throws Exception {
 		batch.clear();
 		for (int i = 0; i < TestData.WRITE_BATCH_SIZE; i++) {
-			batch.put(batchKeys[i], TestData.BATCH_VALUE);
+			batch.put(batchKeys[i], batchValues[i]);
 		}
 		db.write(writeOptions, batch);
 	}

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/TestData.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/TestData.java
@@ -5,6 +5,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Random;
 import java.util.stream.Stream;
 
 /// Shared constants and helpers used by both [FfmBenchmark] and [JniBenchmark].
@@ -12,18 +13,44 @@ final class TestData {
 
 	static final int WRITE_BATCH_SIZE = 100;
 
+	/// Typical RocksDB key/value sizes, not placeholder-sized ASCII strings —
+	/// large enough that the byte[] copy cost actually shows up against the
+	/// fixed per-call overhead.
+	static final int BATCH_KEY_SIZE = 16;
+	static final int BATCH_VALUE_SIZE = 1024;
+
 	static final byte[] READ_KEY_BYTES = "read-key".getBytes();
 	static final byte[] READ_VALUE_BYTES = "read-value-data-0123456789".getBytes();
 	static final byte[] WRITE_KEY_BYTES = "bench-key".getBytes();
 	static final byte[] WRITE_VALUE_BYTES = "bench-value-data-0123456789".getBytes();
-	static final byte[] BATCH_VALUE = "batch-value-data-0123456789".getBytes();
+
+	// Fixed seed: reproducible benchmark runs, not cryptographic randomness.
+	private static final Random RANDOM = new Random(42);
 
 	static byte[][] batchKeys() {
-		byte[][] keys = new byte[WRITE_BATCH_SIZE][];
-		for (int i = 0; i < WRITE_BATCH_SIZE; i++) {
-			keys[i] = ("batch-key-" + i).getBytes();
+		return batchKeys(WRITE_BATCH_SIZE);
+	}
+
+	static byte[][] batchKeys(int count) {
+		return randomBytes(count, BATCH_KEY_SIZE);
+	}
+
+	static byte[][] batchValues() {
+		return batchValues(WRITE_BATCH_SIZE);
+	}
+
+	static byte[][] batchValues(int count) {
+		return randomBytes(count, BATCH_VALUE_SIZE);
+	}
+
+	private static byte[][] randomBytes(int count, int size) {
+		byte[][] result = new byte[count][];
+		for (int i = 0; i < count; i++) {
+			byte[] bytes = new byte[size];
+			RANDOM.nextBytes(bytes);
+			result[i] = bytes;
 		}
-		return keys;
+		return result;
 	}
 
 	static void deleteDir(Path root) throws IOException {

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/WriteBatchSizeBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/WriteBatchSizeBenchmark.java
@@ -1,0 +1,143 @@
+package io.github.dfa1.rocksdbffm.benchmark;
+
+import io.github.dfa1.rocksdbffm.ReadWriteDB;
+import io.github.dfa1.rocksdbffm.RocksDB;
+import io.github.dfa1.rocksdbffm.WriteBatch;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/// Measures [WriteBatch] put throughput (one commit per batch) across a range
+/// of batch sizes and the byte[]/ByteBuffer/MemorySegment tiers.
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 1, jvmArgsPrepend = {"--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow"})
+public class WriteBatchSizeBenchmark {
+
+	@Param({"1", "10", "20", "50", "100", "200", "400"})
+	private int batchSize;
+
+	private ReadWriteDB db;
+	private Path dbPath;
+	private WriteBatch batch;
+	private Arena arena;
+
+	private byte[][] batchKeys;
+	private byte[][] batchValues;
+	private ByteBuffer[] batchKeysByteBuffer;
+	private ByteBuffer[] batchValuesByteBuffer;
+	private MemorySegment[] batchKeysMemorySegment;
+	private MemorySegment[] batchValuesMemorySegment;
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		dbPath = Files.createTempDirectory("bench-writebatch-");
+		db = RocksDB.openReadWrite(dbPath);
+		batch = WriteBatch.create();
+		arena = Arena.ofConfined();
+
+		batchKeys = TestData.batchKeys(batchSize);
+		batchValues = TestData.batchValues(batchSize);
+
+		batchKeysByteBuffer = new ByteBuffer[batchSize];
+		batchValuesByteBuffer = new ByteBuffer[batchSize];
+		for (int i = 0; i < batchSize; i++) {
+			batchKeysByteBuffer[i] = ByteBuffer.allocateDirect(batchKeys[i].length).put(batchKeys[i]).flip();
+			batchValuesByteBuffer[i] = ByteBuffer.allocateDirect(batchValues[i].length).put(batchValues[i]).flip();
+		}
+
+		batchKeysMemorySegment = new MemorySegment[batchSize];
+		batchValuesMemorySegment = new MemorySegment[batchSize];
+		for (int i = 0; i < batchSize; i++) {
+			batchKeysMemorySegment[i] = arena.allocateFrom(ValueLayout.JAVA_BYTE, batchKeys[i]);
+			batchValuesMemorySegment[i] = arena.allocateFrom(ValueLayout.JAVA_BYTE, batchValues[i]);
+		}
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() throws IOException {
+		batch.close();
+		db.close();
+		arena.close();
+		TestData.deleteDir(dbPath);
+	}
+
+	// ---- byte[] tier ---------------------------------------------------
+
+	@Benchmark
+	public void batchWrites() {
+		batch.clear();
+		for (int i = 0; i < batchSize; i++) {
+			batch.put(batchKeys[i], batchValues[i]);
+		}
+		db.write(batch);
+	}
+
+	@Benchmark
+	public void batchWritesArena() {
+		batch.clear();
+		try (Arena txArena = Arena.ofConfined()) {
+			for (int i = 0; i < batchSize; i++) {
+				batch.put(txArena, batchKeys[i], batchValues[i]);
+			}
+			db.write(txArena, batch);
+		}
+	}
+
+	// ---- ByteBuffer tier (zero-copy) ------------------------------------
+
+	@Benchmark
+	public void batchWritesByteBuffer() {
+		batch.clear();
+		for (int i = 0; i < batchSize; i++) {
+			batchKeysByteBuffer[i].rewind();
+			batchValuesByteBuffer[i].rewind();
+			batch.put(batchKeysByteBuffer[i], batchValuesByteBuffer[i]);
+		}
+		db.write(batch);
+	}
+
+	// ---- MemorySegment tier (zero-copy) ----------------------------------
+
+	@Benchmark
+	public void batchWritesMemorySegment() {
+		batch.clear();
+		for (int i = 0; i < batchSize; i++) {
+			batch.put(batchKeysMemorySegment[i], batchValuesMemorySegment[i]);
+		}
+		db.write(batch);
+	}
+
+	static void main() throws Exception {
+		org.openjdk.jmh.runner.options.Options opt = new OptionsBuilder()
+				.addProfiler(GCProfiler.class)
+				.include(WriteBatchSizeBenchmark.class.getSimpleName())
+				.build();
+
+		new org.openjdk.jmh.runner.Runner(opt).run();
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
@@ -200,6 +200,30 @@ public final class OptimisticTransactionDB extends NativeObject {
 		RocksDB.deleteSegment(baseDb, writeOpts.ptr(), key, key.byteSize());
 	}
 
+	/// Direct range delete [`startKey`, `endKey`), bypassing any active transaction. Slow path.
+	///
+	/// @param startKey inclusive start of the deleted range
+	/// @param endKey   exclusive end of the deleted range
+	public void deleteRange(byte[] startKey, byte[] endKey) {
+		RocksDB.deleteRangeCfBytes(baseDb, writeOpts.ptr(), startKey, endKey);
+	}
+
+	/// Zero-copy deleteRange for direct [ByteBuffer]s.
+	///
+	/// @param startKey direct [ByteBuffer] with the inclusive start key
+	/// @param endKey   direct [ByteBuffer] with the exclusive end key
+	public void deleteRange(ByteBuffer startKey, ByteBuffer endKey) {
+		RocksDB.deleteRangeCfBuffer(baseDb, writeOpts.ptr(), startKey, endKey);
+	}
+
+	/// Zero-copy deleteRange for [MemorySegment]s.
+	///
+	/// @param startKey native segment with the inclusive start key
+	/// @param endKey   native segment with the exclusive end key
+	public void deleteRange(MemorySegment startKey, MemorySegment endKey) {
+		RocksDB.deleteRangeCfSegment(baseDb, writeOpts.ptr(), startKey, endKey);
+	}
+
 	// -----------------------------------------------------------------------
 	// Column family management
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileWriter.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileWriter.java
@@ -5,6 +5,7 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 
 /// FFM wrapper for `rocksdb_sstfilewriter_t`.
@@ -165,6 +166,23 @@ public final class SstFileWriter extends NativeObject {
 		}
 	}
 
+	/// Zero-copy [ByteBuffer] overload of [#put(byte\[\], byte\[\])].
+	///
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the value
+	public void put(ByteBuffer key, ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_PUT.invokeExact(ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining(),
+					err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("sstfilewriter put failed", t);
+		}
+	}
+
 	/// Appends a delete tombstone entry. Keys must be added in strictly ascending order.
 	///
 	/// @param key key bytes to delete
@@ -192,6 +210,19 @@ public final class SstFileWriter extends NativeObject {
 		}
 	}
 
+	/// Zero-copy [ByteBuffer] overload of [#delete(byte\[\])].
+	///
+	/// @param key direct [ByteBuffer] containing the key to delete
+	public void delete(ByteBuffer key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_DELETE.invokeExact(ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("sstfilewriter delete failed", t);
+		}
+	}
+
 	/// Appends a delete-range tombstone covering `[beginKey, endKey)`.
 	/// Keys must be added in strictly ascending order.
 	///
@@ -205,6 +236,40 @@ public final class SstFileWriter extends NativeObject {
 			MH_DELETE_RANGE.invokeExact(ptr(),
 					beginNative, (long) beginKey.length,
 					endNative, (long) endKey.length,
+					err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("sstfilewriter deleteRange failed", t);
+		}
+	}
+
+	/// Zero-copy [ByteBuffer] overload of [#deleteRange(byte\[\], byte\[\])].
+	///
+	/// @param beginKey direct [ByteBuffer] with the inclusive start of the deleted range
+	/// @param endKey   direct [ByteBuffer] with the exclusive end of the deleted range
+	public void deleteRange(ByteBuffer beginKey, ByteBuffer endKey) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_DELETE_RANGE.invokeExact(ptr(),
+					MemorySegment.ofBuffer(beginKey), (long) beginKey.remaining(),
+					MemorySegment.ofBuffer(endKey), (long) endKey.remaining(),
+					err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("sstfilewriter deleteRange failed", t);
+		}
+	}
+
+	/// Zero-copy [MemorySegment] overload of [#deleteRange(byte\[\], byte\[\])].
+	///
+	/// @param beginKey native segment with the inclusive start of the deleted range
+	/// @param endKey   native segment with the exclusive end of the deleted range
+	public void deleteRange(MemorySegment beginKey, MemorySegment endKey) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_DELETE_RANGE.invokeExact(ptr(),
+					beginKey, beginKey.byteSize(),
+					endKey, endKey.byteSize(),
 					err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -5,6 +5,7 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
 
 /// FFM wrapper for `rocksdb_transaction_t`.
 ///
@@ -164,6 +165,36 @@ public final class Transaction extends NativeObject {
 		}
 	}
 
+	/// Stages a put inside this transaction. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the value
+	public void put(ByteBuffer key, ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_PUT.invokeExact(ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Stages a put inside this transaction. Zero-copy for [MemorySegment]s.
+	///
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the value
+	public void put(MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_PUT.invokeExact(ptr(), key, key.byteSize(), value, value.byteSize(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
 	/// Stages a delete inside this transaction. Slow path: allocates native memory for key.
 	///
 	/// @param key key bytes to delete
@@ -172,6 +203,32 @@ public final class Transaction extends NativeObject {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment k = RocksDB.toNative(arena, key);
 			MH_DELETE.invokeExact(ptr(), k, (long) key.length, err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Stages a delete inside this transaction. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param key direct [ByteBuffer] containing the key to delete
+	public void delete(ByteBuffer key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_DELETE.invokeExact(ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Stages a delete inside this transaction. Zero-copy for [MemorySegment]s.
+	///
+	/// @param key native segment containing the key to delete
+	public void delete(MemorySegment key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_DELETE.invokeExact(ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -215,6 +272,71 @@ public final class Transaction extends NativeObject {
 		}
 	}
 
+	/// Single-copy get within this transaction into a direct [ByteBuffer], via PinnableSlice.
+	/// Copies nothing into `value` when its remaining capacity is too small.
+	///
+	/// @param readOptions read options for this read
+	/// @param key         direct [ByteBuffer] containing the key
+	/// @param value       direct [ByteBuffer] to write the value into
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ReadOptions readOptions, ByteBuffer key, ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
+					ptr(), readOptions.ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(pin)) {
+				return new CopyResult.NotFound();
+			}
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.remaining()) {
+				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+			value.position(value.position() + (int) valLen);
+			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Single-copy get within this transaction into a caller-supplied native segment, via
+	/// PinnableSlice. Copies nothing into `value` when its capacity is too small.
+	///
+	/// @param readOptions read options for this read
+	/// @param key         native segment containing the key
+	/// @param value       native segment to write the value into
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ReadOptions readOptions, MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
+					ptr(), readOptions.ptr(), key, key.byteSize(), err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(pin)) {
+				return new CopyResult.NotFound();
+			}
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.byteSize()) {
+				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			value.copyFrom(valPtr.reinterpret(valLen));
+			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
 	/// Reads the value for `key` and acquires a pessimistic lock on it for
 	/// the duration of this transaction. Returns `null` if not found.
 	///
@@ -247,6 +369,75 @@ public final class Transaction extends NativeObject {
 		}
 	}
 
+	/// Reads `key` into a direct [ByteBuffer] and acquires a pessimistic lock on it for the
+	/// duration of this transaction. Copies nothing into `value` when its remaining capacity
+	/// is too small.
+	///
+	/// @param readOptions read options for this read
+	/// @param key         direct [ByteBuffer] containing the key
+	/// @param value       direct [ByteBuffer] to write the value into
+	/// @param exclusive   if `true`, acquires an exclusive (write) lock; otherwise a shared (read) lock
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult getForUpdate(ReadOptions readOptions, ByteBuffer key, ByteBuffer value, boolean exclusive) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_GET_FOR_UPDATE.invokeExact(
+					ptr(), readOptions.ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(),
+					valLenSeg, exclusive ? (byte) 1 : (byte) 0, err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(valPtr)) {
+				return new CopyResult.NotFound();
+			}
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.remaining()) {
+				RocksDB.free(valPtr);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+			value.position(value.position() + (int) valLen);
+			RocksDB.free(valPtr);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Reads `key` into a caller-supplied native segment and acquires a pessimistic lock on it
+	/// for the duration of this transaction. Copies nothing into `value` when its capacity is
+	/// too small.
+	///
+	/// @param readOptions read options for this read
+	/// @param key         native segment containing the key
+	/// @param value       native segment to write the value into
+	/// @param exclusive   if `true`, acquires an exclusive (write) lock; otherwise a shared (read) lock
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult getForUpdate(ReadOptions readOptions, MemorySegment key, MemorySegment value, boolean exclusive) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_GET_FOR_UPDATE.invokeExact(
+					ptr(), readOptions.ptr(), key, key.byteSize(),
+					valLenSeg, exclusive ? (byte) 1 : (byte) 0, err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(valPtr)) {
+				return new CopyResult.NotFound();
+			}
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.byteSize()) {
+				RocksDB.free(valPtr);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			value.copyFrom(valPtr.reinterpret(valLen));
+			RocksDB.free(valPtr);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
 	// -----------------------------------------------------------------------
 	// Write operations — column family overloads
 	// -----------------------------------------------------------------------
@@ -268,6 +459,38 @@ public final class Transaction extends NativeObject {
 		}
 	}
 
+	/// Stages a put into `cf` inside this transaction. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param cf    target column family
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the value
+	public void put(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_PUT_CF.invokeExact(ptr(), cf.ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Stages a put into `cf` inside this transaction. Zero-copy for [MemorySegment]s.
+	///
+	/// @param cf    target column family
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the value
+	public void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_PUT_CF.invokeExact(ptr(), cf.ptr(), key, key.byteSize(), value, value.byteSize(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
 	/// Stages a delete of `key` from `cf` inside this transaction. Slow path.
 	///
 	/// @param cf  target column family
@@ -277,6 +500,35 @@ public final class Transaction extends NativeObject {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(),
 					RocksDB.toNative(arena, key), (long) key.length, err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Stages a delete of `key` from `cf` inside this transaction. Zero-copy for direct
+	/// [ByteBuffer]s.
+	///
+	/// @param cf  target column family
+	/// @param key direct [ByteBuffer] containing the key to delete
+	public void delete(ColumnFamilyHandle cf, ByteBuffer key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Stages a delete of `key` from `cf` inside this transaction. Zero-copy for [MemorySegment]s.
+	///
+	/// @param cf  target column family
+	/// @param key native segment containing the key to delete
+	public void delete(ColumnFamilyHandle cf, MemorySegment key) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -314,6 +566,74 @@ public final class Transaction extends NativeObject {
 		}
 	}
 
+	/// Single-copy get from `cf` within this transaction into a direct [ByteBuffer], via
+	/// PinnableSlice. Copies nothing into `value` when its remaining capacity is too small.
+	///
+	/// @param cf          column family to read from
+	/// @param readOptions read options for this read
+	/// @param key         direct [ByteBuffer] containing the key
+	/// @param value       direct [ByteBuffer] to write the value into
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ColumnFamilyHandle cf, ReadOptions readOptions, ByteBuffer key, ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					ptr(), readOptions.ptr(), cf.ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(pin)) {
+				return new CopyResult.NotFound();
+			}
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.remaining()) {
+				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+			value.position(value.position() + (int) valLen);
+			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Single-copy get from `cf` within this transaction into a caller-supplied native segment,
+	/// via PinnableSlice. Copies nothing into `value` when its capacity is too small.
+	///
+	/// @param cf          column family to read from
+	/// @param readOptions read options for this read
+	/// @param key         native segment containing the key
+	/// @param value       native segment to write the value into
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					ptr(), readOptions.ptr(), cf.ptr(), key, key.byteSize(), err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(pin)) {
+				return new CopyResult.NotFound();
+			}
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.byteSize()) {
+				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			value.copyFrom(valPtr.reinterpret(valLen));
+			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
 	/// Reads `key` from `cf` and acquires a lock for the duration of this transaction.
 	/// Returns `null` if not found.
 	///
@@ -338,6 +658,80 @@ public final class Transaction extends NativeObject {
 			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			RocksDB.free(valPtr);
 			return result;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Reads `key` from `cf` into a direct [ByteBuffer] and acquires a pessimistic lock on it
+	/// for the duration of this transaction. Copies nothing into `value` when its remaining
+	/// capacity is too small.
+	///
+	/// @param cf          column family to read from
+	/// @param readOptions read options for this read
+	/// @param key         direct [ByteBuffer] containing the key
+	/// @param value       direct [ByteBuffer] to write the value into
+	/// @param exclusive   if `true`, acquires an exclusive (write) lock; otherwise a shared (read) lock
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult getForUpdate(ColumnFamilyHandle cf, ReadOptions readOptions,
+	                                ByteBuffer key, ByteBuffer value, boolean exclusive) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_GET_FOR_UPDATE_CF.invokeExact(
+					ptr(), readOptions.ptr(), cf.ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					valLenSeg, exclusive ? (byte) 1 : (byte) 0, err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(valPtr)) {
+				return new CopyResult.NotFound();
+			}
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.remaining()) {
+				RocksDB.free(valPtr);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+			value.position(value.position() + (int) valLen);
+			RocksDB.free(valPtr);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("Native call failed", t);
+		}
+	}
+
+	/// Reads `key` from `cf` into a caller-supplied native segment and acquires a pessimistic
+	/// lock on it for the duration of this transaction. Copies nothing into `value` when its
+	/// capacity is too small.
+	///
+	/// @param cf          column family to read from
+	/// @param readOptions read options for this read
+	/// @param key         native segment containing the key
+	/// @param value       native segment to write the value into
+	/// @param exclusive   if `true`, acquires an exclusive (write) lock; otherwise a shared (read) lock
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult getForUpdate(ColumnFamilyHandle cf, ReadOptions readOptions,
+	                                MemorySegment key, MemorySegment value, boolean exclusive) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_GET_FOR_UPDATE_CF.invokeExact(
+					ptr(), readOptions.ptr(), cf.ptr(), key, key.byteSize(),
+					valLenSeg, exclusive ? (byte) 1 : (byte) 0, err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(valPtr)) {
+				return new CopyResult.NotFound();
+			}
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.byteSize()) {
+				RocksDB.free(valPtr);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			value.copyFrom(valPtr.reinterpret(valLen));
+			RocksDB.free(valPtr);
+			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -643,6 +643,72 @@ public final class TransactionDB extends NativeObject {
 		}
 	}
 
+	/// Single-copy get from `cf` into a direct [java.nio.ByteBuffer], via PinnableSlice.
+	/// Copies nothing into `value` when its remaining capacity is too small.
+	///
+	/// @param cf    target column family
+	/// @param key   direct [java.nio.ByteBuffer] containing the key
+	/// @param value direct [java.nio.ByteBuffer] to write the value into
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ColumnFamilyHandle cf, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					ptr(), readOpts.ptr(), cf.ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(pin)) {
+				return new CopyResult.NotFound();
+			}
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.remaining()) {
+				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+			value.position(value.position() + (int) valLen);
+			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("get failed", t);
+		}
+	}
+
+	/// Single-copy get from `cf` into a caller-supplied native segment, via PinnableSlice.
+	/// Copies nothing into `value` when its capacity is too small.
+	///
+	/// @param cf    target column family
+	/// @param key   native segment containing the key
+	/// @param value native segment to write the value into
+	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
+	/// small, or [CopyResult.NotFound] if the key is absent
+	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
+					ptr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
+			RocksDB.checkError(err);
+			if (MemorySegment.NULL.equals(pin)) {
+				return new CopyResult.NotFound();
+			}
+			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
+			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+			if (valLen > value.byteSize()) {
+				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+				return new CopyResult.NotEnoughCapacity(valLen);
+			}
+			value.copyFrom(valPtr.reinterpret(valLen));
+			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
+			return new CopyResult.Copied();
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("get failed", t);
+		}
+	}
+
 	// -----------------------------------------------------------------------
 	// Delete — column family overloads
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WriteBatch.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WriteBatch.java
@@ -134,6 +134,32 @@ public final class WriteBatch extends NativeObject {
 		}
 	}
 
+	/// Queues a put. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the value
+	public void put(ByteBuffer key, ByteBuffer value) {
+		try {
+			MH_PUT.invokeExact(ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining());
+		} catch (Throwable t) {
+			throw new RocksDBException("writebatch put failed", t);
+		}
+	}
+
+	/// Queues a put. Zero-copy for [MemorySegment]s.
+	///
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the value
+	public void put(MemorySegment key, MemorySegment value) {
+		try {
+			MH_PUT.invokeExact(ptr(), key, key.byteSize(), value, value.byteSize());
+		} catch (Throwable t) {
+			throw new RocksDBException("writebatch put failed", t);
+		}
+	}
+
 	/// Queues a delete tombstone. Slow path: copies the key into native memory.
 	///
 	/// @param key key bytes to delete
@@ -141,6 +167,28 @@ public final class WriteBatch extends NativeObject {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment k = RocksDB.toNative(arena, key);
 			MH_DELETE.invokeExact(ptr(), k, (long) key.length);
+		} catch (Throwable t) {
+			throw new RocksDBException("writebatch delete failed", t);
+		}
+	}
+
+	/// Queues a delete tombstone. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param key direct [ByteBuffer] containing the key to delete
+	public void delete(ByteBuffer key) {
+		try {
+			MH_DELETE.invokeExact(ptr(), MemorySegment.ofBuffer(key), (long) key.remaining());
+		} catch (Throwable t) {
+			throw new RocksDBException("writebatch delete failed", t);
+		}
+	}
+
+	/// Queues a delete tombstone. Zero-copy for [MemorySegment]s.
+	///
+	/// @param key native segment containing the key to delete
+	public void delete(MemorySegment key) {
+		try {
+			MH_DELETE.invokeExact(ptr(), key, key.byteSize());
 		} catch (Throwable t) {
 			throw new RocksDBException("writebatch delete failed", t);
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/NullSafetyTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/NullSafetyTest.java
@@ -254,7 +254,7 @@ class NullSafetyTest {
 	@Test
 	void writeBatch_delete_nullKey() {
 		try (var batch = WriteBatch.create()) {
-			assertThatThrownBy(() -> batch.delete(null))
+			assertThatThrownBy(() -> batch.delete((byte[]) null))
 					.isInstanceOf(RuntimeException.class);
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
@@ -308,6 +308,64 @@ class OptimisticTransactionDBTest {
 	}
 
 	@Test
+	void deleteRange_removesKeyRange(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+			db.put("c".getBytes(), "3".getBytes());
+
+			// When
+			db.deleteRange("a".getBytes(), "c".getBytes());
+
+			// Then
+			assertThat(db.get("a".getBytes())).isNull();
+			assertThat(db.get("b".getBytes())).isNull();
+			assertThat(db.get("c".getBytes())).isEqualTo("3".getBytes());
+		}
+	}
+
+	@Test
+	void deleteRange_byteBuffer_removesKeyRange(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+			var start = ByteBuffer.allocateDirect(1).put((byte) 'a').flip();
+			var end = ByteBuffer.allocateDirect(1).put((byte) 'b').flip();
+
+			// When
+			db.deleteRange(start, end);
+
+			// Then
+			assertThat(db.get("a".getBytes())).isNull();
+			assertThat(db.get("b".getBytes())).isEqualTo("2".getBytes());
+		}
+	}
+
+	@Test
+	void deleteRange_memorySegment_removesKeyRange(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir);
+		     Arena arena = Arena.ofConfined()) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+			var start = arena.allocateFrom("a");
+			var end = arena.allocateFrom("b");
+
+			// When
+			db.deleteRange(start.asSlice(0, 1), end.asSlice(0, 1));
+
+			// Then
+			assertThat(db.get("a".getBytes())).isNull();
+			assertThat(db.get("b".getBytes())).isEqualTo("2".getBytes());
+		}
+	}
+
+	@Test
 	void deleteRange_columnFamily_removesKeyRange(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RocksDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RocksDBTest.java
@@ -3,6 +3,9 @@ package io.github.dfa1.rocksdbffm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -125,6 +128,80 @@ class RocksDBTest {
 			// Then
 			assertThat(db.get("k1".getBytes())).isNull();
 			assertThat(db.get("k2".getBytes())).isNull();
+		}
+	}
+
+	@Test
+	void write_commitsBatchedPuts_byteBuffer(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var batch = WriteBatch.create()) {
+
+			var key = ByteBuffer.allocateDirect(2).put("k1".getBytes()).flip();
+			var value = ByteBuffer.allocateDirect(2).put("v1".getBytes()).flip();
+			batch.put(key, value);
+
+			// When
+			db.write(batch);
+
+			// Then
+			assertThat(db.get("k1".getBytes())).isEqualTo("v1".getBytes());
+		}
+	}
+
+	@Test
+	void write_commitsBatchedPuts_memorySegment(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var batch = WriteBatch.create();
+		     var arena = Arena.ofConfined()) {
+
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k1".getBytes());
+			var value = arena.allocateFrom(ValueLayout.JAVA_BYTE, "v1".getBytes());
+			batch.put(key, value);
+
+			// When
+			db.write(batch);
+
+			// Then
+			assertThat(db.get("k1".getBytes())).isEqualTo("v1".getBytes());
+		}
+	}
+
+	@Test
+	void write_commitsBatchedDeletes_byteBuffer(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var batch = WriteBatch.create()) {
+
+			db.put("k1".getBytes(), "v1".getBytes());
+			var key = ByteBuffer.allocateDirect(2).put("k1".getBytes()).flip();
+			batch.delete(key);
+
+			// When
+			db.write(batch);
+
+			// Then
+			assertThat(db.get("k1".getBytes())).isNull();
+		}
+	}
+
+	@Test
+	void write_commitsBatchedDeletes_memorySegment(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var batch = WriteBatch.create();
+		     var arena = Arena.ofConfined()) {
+
+			db.put("k1".getBytes(), "v1".getBytes());
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k1".getBytes());
+			batch.delete(key);
+
+			// When
+			db.write(batch);
+
+			// Then
+			assertThat(db.get("k1".getBytes())).isNull();
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SstFileWriterTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SstFileWriterTest.java
@@ -3,6 +3,9 @@ package io.github.dfa1.rocksdbffm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -135,6 +138,239 @@ class SstFileWriterTest {
 
 			// Then
 			assertThat(writer.fileSize()).isGreaterThan(MemorySize.ZERO);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// SstFileWriter — put tiers
+	// -----------------------------------------------------------------------
+
+	@Test
+	void put_byteBuffer_valueIsIngestable(@TempDir Path dir) {
+		// Given
+		Path sstPath = dir.resolve("data.sst");
+		Path dbPath = dir.resolve("db");
+
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var writer = SstFileWriter.newSstFileWriter(opts)) {
+			writer.open(sstPath);
+			var key = ByteBuffer.allocateDirect(3).put("key".getBytes()).flip();
+			var value = ByteBuffer.allocateDirect(5).put("value".getBytes()).flip();
+			writer.put(key, value);
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.ingestExternalFile(sstPath);
+
+			// Then
+			assertThat(db.get("key".getBytes())).isEqualTo("value".getBytes());
+		}
+	}
+
+	@Test
+	void put_memorySegment_valueIsIngestable(@TempDir Path dir) {
+		// Given
+		Path sstPath = dir.resolve("data.sst");
+		Path dbPath = dir.resolve("db");
+
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var writer = SstFileWriter.newSstFileWriter(opts);
+		     var arena = Arena.ofConfined()) {
+			writer.open(sstPath);
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "key".getBytes());
+			var value = arena.allocateFrom(ValueLayout.JAVA_BYTE, "value".getBytes());
+			writer.put(key, value);
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.ingestExternalFile(sstPath);
+
+			// Then
+			assertThat(db.get("key".getBytes())).isEqualTo("value".getBytes());
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// SstFileWriter — delete tiers
+	// -----------------------------------------------------------------------
+
+	@Test
+	void delete_removesKeyAfterIngest(@TempDir Path dir) {
+		// Given — key already present in the DB
+		Path sstPath = dir.resolve("data.sst");
+		Path dbPath = dir.resolve("db");
+
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.put("key".getBytes(), "value".getBytes());
+		}
+
+		try (var opts = Options.newOptions();
+		     var writer = SstFileWriter.newSstFileWriter(opts)) {
+			writer.open(sstPath);
+			writer.delete("key".getBytes());
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.ingestExternalFile(sstPath);
+
+			// Then
+			assertThat(db.get("key".getBytes())).isNull();
+		}
+	}
+
+	@Test
+	void delete_byteBuffer_removesKeyAfterIngest(@TempDir Path dir) {
+		// Given — key already present in the DB
+		Path sstPath = dir.resolve("data.sst");
+		Path dbPath = dir.resolve("db");
+
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.put("key".getBytes(), "value".getBytes());
+		}
+
+		try (var opts = Options.newOptions();
+		     var writer = SstFileWriter.newSstFileWriter(opts)) {
+			writer.open(sstPath);
+			var key = ByteBuffer.allocateDirect(3).put("key".getBytes()).flip();
+			writer.delete(key);
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.ingestExternalFile(sstPath);
+
+			// Then
+			assertThat(db.get("key".getBytes())).isNull();
+		}
+	}
+
+	@Test
+	void delete_memorySegment_removesKeyAfterIngest(@TempDir Path dir) {
+		// Given — key already present in the DB
+		Path sstPath = dir.resolve("data.sst");
+		Path dbPath = dir.resolve("db");
+
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.put("key".getBytes(), "value".getBytes());
+		}
+
+		try (var opts = Options.newOptions();
+		     var writer = SstFileWriter.newSstFileWriter(opts);
+		     var arena = Arena.ofConfined()) {
+			writer.open(sstPath);
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "key".getBytes());
+			writer.delete(key);
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.ingestExternalFile(sstPath);
+
+			// Then
+			assertThat(db.get("key".getBytes())).isNull();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// SstFileWriter — deleteRange tiers
+	// -----------------------------------------------------------------------
+
+	@Test
+	void deleteRange_removesKeyRangeAfterIngest(@TempDir Path dir) {
+		// Given — keys a, b, c already present in the DB
+		Path sstPath = dir.resolve("data.sst");
+		Path dbPath = dir.resolve("db");
+
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+			db.put("c".getBytes(), "3".getBytes());
+		}
+
+		try (var opts = Options.newOptions();
+		     var writer = SstFileWriter.newSstFileWriter(opts)) {
+			writer.open(sstPath);
+			writer.deleteRange("a".getBytes(), "c".getBytes());
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.ingestExternalFile(sstPath);
+
+			// Then — [a, c) is gone, c survives
+			assertThat(db.get("a".getBytes())).isNull();
+			assertThat(db.get("b".getBytes())).isNull();
+			assertThat(db.get("c".getBytes())).isEqualTo("3".getBytes());
+		}
+	}
+
+	@Test
+	void deleteRange_byteBuffer_removesKeyRangeAfterIngest(@TempDir Path dir) {
+		// Given — keys a, b already present in the DB
+		Path sstPath = dir.resolve("data.sst");
+		Path dbPath = dir.resolve("db");
+
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+		}
+
+		try (var opts = Options.newOptions();
+		     var writer = SstFileWriter.newSstFileWriter(opts)) {
+			writer.open(sstPath);
+			var start = ByteBuffer.allocateDirect(1).put((byte) 'a').flip();
+			var end = ByteBuffer.allocateDirect(1).put((byte) 'b').flip();
+			writer.deleteRange(start, end);
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.ingestExternalFile(sstPath);
+
+			// Then
+			assertThat(db.get("a".getBytes())).isNull();
+			assertThat(db.get("b".getBytes())).isEqualTo("2".getBytes());
+		}
+	}
+
+	@Test
+	void deleteRange_memorySegment_removesKeyRangeAfterIngest(@TempDir Path dir) {
+		// Given — keys a, b already present in the DB
+		Path sstPath = dir.resolve("data.sst");
+		Path dbPath = dir.resolve("db");
+
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+		}
+
+		try (var opts = Options.newOptions();
+		     var writer = SstFileWriter.newSstFileWriter(opts);
+		     var arena = Arena.ofConfined()) {
+			writer.open(sstPath);
+			var start = arena.allocateFrom(ValueLayout.JAVA_BYTE, "a".getBytes());
+			var end = arena.allocateFrom(ValueLayout.JAVA_BYTE, "b".getBytes());
+			writer.deleteRange(start, end);
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dbPath)) {
+			db.ingestExternalFile(sstPath);
+
+			// Then
+			assertThat(db.get("a".getBytes())).isNull();
+			assertThat(db.get("b".getBytes())).isEqualTo("2".getBytes());
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
@@ -471,6 +471,63 @@ class TransactionDBTest {
 	}
 
 	@Test
+	void directGet_columnFamily_byteBuffer_returnsValue(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles)) {
+			var cf = handles.get(0);
+			db.put(cf, "k".getBytes(), "v".getBytes());
+			var key = ByteBuffer.allocateDirect(1).put("k".getBytes()).flip();
+			var value = ByteBuffer.allocateDirect(64);
+
+			// When
+			CopyResult result = db.get(cf, key, value);
+
+			// Then
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	@Test
+	void directGet_columnFamily_byteBuffer_returnsNotFound_whenKeyAbsent(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles)) {
+			var cf = handles.get(0);
+			var key = ByteBuffer.allocateDirect(1).put("k".getBytes()).flip();
+			var value = ByteBuffer.allocateDirect(64);
+
+			// When
+			CopyResult result = db.get(cf, key, value);
+
+			// Then
+			assertThat(result).isEqualTo(new CopyResult.NotFound());
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	@Test
+	void directGet_columnFamily_memorySegment_returnsValue(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles);
+		     Arena arena = Arena.ofConfined()) {
+			var cf = handles.get(0);
+			db.put(cf, "k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom("k");
+			var value = arena.allocate(64);
+
+			// When
+			CopyResult result = db.get(cf, key.asSlice(0, 1), value);
+
+			// Then
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	@Test
 	void directPut_get_columnFamily_byteBuffer(@TempDir Path dir) {
 		// Given
 		List<ColumnFamilyHandle> handles = new ArrayList<>();

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionTest.java
@@ -1,0 +1,325 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Covers the ByteBuffer/MemorySegment tiers of [Transaction] — the byte[] tier
+/// is already exercised via [TransactionDBTest].
+class TransactionTest {
+
+	private static TransactionDB openDb(Path path) {
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var txnDbOpts = TransactionDBOptions.newTransactionDBOptions()) {
+			return RocksDB.openTransaction(opts, txnDbOpts, path);
+		}
+	}
+
+	private static TransactionDB openDbWithCf(Path path, List<ColumnFamilyHandle> handles) {
+		var db = openDb(path);
+		handles.add(db.createColumnFamily(ColumnFamilyDescriptor.of("cf1")));
+		return db;
+	}
+
+	// -----------------------------------------------------------------------
+	// put / get — ByteBuffer tier
+	// -----------------------------------------------------------------------
+
+	@Test
+	void put_get_byteBuffer(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo)) {
+			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+			var value = ByteBuffer.allocateDirect(1).put((byte) 'v').flip();
+
+			// When
+			txn.put(key, value);
+
+			// Then
+			var out = ByteBuffer.allocateDirect(64);
+			CopyResult result = txn.get(ro, ByteBuffer.allocateDirect(1).put((byte) 'k').flip(), out);
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			txn.commit();
+		}
+	}
+
+	@Test
+	void get_byteBuffer_returnsNotFound_whenAbsent(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo)) {
+			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+			var out = ByteBuffer.allocateDirect(64);
+
+			// When
+			CopyResult result = txn.get(ro, key, out);
+
+			// Then
+			assertThat(result).isEqualTo(new CopyResult.NotFound());
+		}
+	}
+
+	@Test
+	void delete_byteBuffer_removesKeyWithinTransaction(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo)) {
+			txn.put("k".getBytes(), "v".getBytes());
+			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+
+			// When
+			txn.delete(key);
+
+			// Then
+			assertThat(txn.get(ro, "k".getBytes())).isNull();
+		}
+	}
+
+	@Test
+	void getForUpdate_byteBuffer_locksAndReturnsValue(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo)) {
+			txn.put("k".getBytes(), "v".getBytes());
+			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+			var out = ByteBuffer.allocateDirect(64);
+
+			// When
+			CopyResult result = txn.getForUpdate(ro, key, out, true);
+
+			// Then
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			txn.commit();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// put / get — MemorySegment tier
+	// -----------------------------------------------------------------------
+
+	@Test
+	void put_get_memorySegment(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo);
+		     var arena = Arena.ofConfined()) {
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+			var value = arena.allocateFrom(ValueLayout.JAVA_BYTE, "v".getBytes());
+
+			// When
+			txn.put(key, value);
+
+			// Then
+			var out = arena.allocate(64);
+			CopyResult result = txn.get(ro, key, out);
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			txn.commit();
+		}
+	}
+
+	@Test
+	void delete_memorySegment_removesKeyWithinTransaction(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo);
+		     var arena = Arena.ofConfined()) {
+			txn.put("k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+
+			// When
+			txn.delete(key);
+
+			// Then
+			assertThat(txn.get(ro, "k".getBytes())).isNull();
+		}
+	}
+
+	@Test
+	void getForUpdate_memorySegment_locksAndReturnsValue(@TempDir Path dir) {
+		// Given
+		try (var db = openDb(dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo);
+		     var arena = Arena.ofConfined()) {
+			txn.put("k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+			var out = arena.allocate(64);
+
+			// When
+			CopyResult result = txn.getForUpdate(ro, key, out, true);
+
+			// Then
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			txn.commit();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// put / get / delete — column family, ByteBuffer tier
+	// -----------------------------------------------------------------------
+
+	@Test
+	void put_get_columnFamily_byteBuffer(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo)) {
+			var cf = handles.get(0);
+			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+			var value = ByteBuffer.allocateDirect(1).put((byte) 'v').flip();
+
+			// When
+			txn.put(cf, key, value);
+
+			// Then
+			var out = ByteBuffer.allocateDirect(64);
+			CopyResult result = txn.get(cf, ro, ByteBuffer.allocateDirect(1).put((byte) 'k').flip(), out);
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			txn.commit();
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	@Test
+	void delete_columnFamily_byteBuffer_removesKey(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo)) {
+			var cf = handles.get(0);
+			txn.put(cf, "k".getBytes(), "v".getBytes());
+			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+
+			// When
+			txn.delete(cf, key);
+
+			// Then
+			assertThat(txn.get(cf, ro, "k".getBytes())).isNull();
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	@Test
+	void getForUpdate_columnFamily_byteBuffer_locksAndReturnsValue(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo)) {
+			var cf = handles.get(0);
+			txn.put(cf, "k".getBytes(), "v".getBytes());
+			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+			var out = ByteBuffer.allocateDirect(64);
+
+			// When
+			CopyResult result = txn.getForUpdate(cf, ro, key, out, true);
+
+			// Then
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			txn.commit();
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// put / get / delete — column family, MemorySegment tier
+	// -----------------------------------------------------------------------
+
+	@Test
+	void put_get_columnFamily_memorySegment(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo);
+		     var arena = Arena.ofConfined()) {
+			var cf = handles.get(0);
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+			var value = arena.allocateFrom(ValueLayout.JAVA_BYTE, "v".getBytes());
+
+			// When
+			txn.put(cf, key, value);
+
+			// Then
+			var out = arena.allocate(64);
+			CopyResult result = txn.get(cf, ro, key, out);
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			txn.commit();
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	@Test
+	void delete_columnFamily_memorySegment_removesKey(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo);
+		     var arena = Arena.ofConfined()) {
+			var cf = handles.get(0);
+			txn.put(cf, "k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+
+			// When
+			txn.delete(cf, key);
+
+			// Then
+			assertThat(txn.get(cf, ro, "k".getBytes())).isNull();
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	@Test
+	void getForUpdate_columnFamily_memorySegment_locksAndReturnsValue(@TempDir Path dir) {
+		// Given
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var db = openDbWithCf(dir, handles);
+		     var wo = WriteOptions.newWriteOptions();
+		     var ro = ReadOptions.newReadOptions();
+		     var txn = db.beginTransaction(wo);
+		     var arena = Arena.ofConfined()) {
+			var cf = handles.get(0);
+			txn.put(cf, "k".getBytes(), "v".getBytes());
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+			var out = arena.allocate(64);
+
+			// When
+			CopyResult result = txn.getForUpdate(cf, ro, key, out, true);
+
+			// Then
+			assertThat(result).isEqualTo(new CopyResult.Copied());
+			txn.commit();
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes all 5 items from #68 — every access tier (`byte[]`/`ByteBuffer`/`MemorySegment`) gap the issue identified.

- **`WriteBatch`**: no-CF `put(ByteBuffer, ByteBuffer)`, `put(MemorySegment, MemorySegment)`, `delete(ByteBuffer)`, `delete(MemorySegment)` — the CF-scoped overloads and `deleteRange` already had all three tiers; the no-CF `put`/`delete` didn't.
- **`TransactionDB`**: CF-scoped `get(ColumnFamilyHandle, ByteBuffer, ByteBuffer)` and `get(ColumnFamilyHandle, MemorySegment, MemorySegment)`, routed through `rocksdb_transactiondb_get_pinned_cf` like the existing CF `byte[]` get.
- **`OptimisticTransactionDB`**: no-CF `deleteRange` in all three tiers — only the CF-scoped version existed, routed through `baseDb` like the rest of the class's direct ops.
- **`SstFileWriter`**: `put(ByteBuffer, ByteBuffer)`, `delete(ByteBuffer)`, `deleteRange(ByteBuffer, ByteBuffer)`, `deleteRange(MemorySegment, MemorySegment)`. Also added tests for the pre-existing but previously-untested `put(MemorySegment,...)`/`delete`/`deleteRange` tiers.
- **`Transaction`**: the largest gap — the whole class was `byte[]`-only. Added `ByteBuffer`/`MemorySegment` tiers for `put`, `delete`, `get`, `getForUpdate`, both no-CF and CF-scoped (16 new overloads). `get`/`getForUpdate` route through the pinned-slice / malloc'd-value APIs respectively, mirroring `TransactionDB`'s own tiers.

Also on this branch (earlier commits, unrelated to #68 but same PR):
- `WriteBatchSizeBenchmark` — sweeps batch size (1–400) across all 4 write tiers.
- Realistic (16-byte key / 1KB value, random, unique-per-entry) benchmark data instead of tiny repeated placeholder strings.
- Coverage for the previously-untested `open*` factory overloads (rebased in from #70, already merged).

## Test plan
- [x] `./mvnw test -pl core -am` — 605/605 tests pass
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] `./mvnw test-compile -pl integration-tests -am` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)