### PR TITLE
Normalize RocksDB open* factory names, fold column families into overloads

### DIFF
--- a/.github/smoke/src/test/java/SmokeTest.java
+++ b/.github/smoke/src/test/java/SmokeTest.java
@@ -41,7 +41,7 @@ class SmokeTest {
 
 	@Test
 	void byteArrayRoundTrip(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("key".getBytes(StandardCharsets.UTF_8), "value".getBytes(StandardCharsets.UTF_8));
 
 			byte[] value = db.get("key".getBytes(StandardCharsets.UTF_8));
@@ -54,7 +54,7 @@ class SmokeTest {
 
 	@Test
 	void byteBufferRoundTrip(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			ByteBuffer key = ByteBuffer.allocateDirect(3);
 			key.put("bbk".getBytes(StandardCharsets.UTF_8)).flip();
 			ByteBuffer value = ByteBuffer.allocateDirect(3);
@@ -74,7 +74,7 @@ class SmokeTest {
 
 	@Test
 	void zeroCopyMemorySegmentRoundTrip(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     Arena arena = Arena.ofConfined()) {
 			MemorySegment key = toNative(arena, "msk".getBytes(StandardCharsets.UTF_8));
 			MemorySegment value = toNative(arena, "msv".getBytes(StandardCharsets.UTF_8));
@@ -91,7 +91,7 @@ class SmokeTest {
 
 	@Test
 	void iteratorSeesAllPuts(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			for (int i = 0; i < 10; i++) {
 				db.put(("k" + i).getBytes(StandardCharsets.UTF_8), ("v" + i).getBytes(StandardCharsets.UTF_8));
 			}
@@ -108,7 +108,7 @@ class SmokeTest {
 
 	@Test
 	void snapshotIsolatesReads(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(StandardCharsets.UTF_8), "v1".getBytes(StandardCharsets.UTF_8));
 
 			try (Snapshot snapshot = db.getSnapshot()) {
@@ -127,7 +127,7 @@ class SmokeTest {
 
 	@Test
 	void writeBatchAppliesAtomically(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     WriteBatch batch = WriteBatch.create()) {
 			batch.put("a".getBytes(StandardCharsets.UTF_8), "1".getBytes(StandardCharsets.UTF_8));
 			batch.put("b".getBytes(StandardCharsets.UTF_8), "2".getBytes(StandardCharsets.UTF_8));
@@ -141,7 +141,7 @@ class SmokeTest {
 
 	@Test
 	void flushPersistsData(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var flushOptions = io.github.dfa1.rocksdbffm.FlushOptions.newFlushOptions().setWait(true)) {
 			db.put("k".getBytes(StandardCharsets.UTF_8), "v".getBytes(StandardCharsets.UTF_8));
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ instance method listed below lives on the DB type (`ReadWriteDB`, `TtlDB`, …),
 | Rate Limiter            | `RateLimiter.java`; `Options.setRateLimiter`                                                                              |
 | SST File Manager        | `SstFileManager.java`, `Env.java`; `Options.setSstFileManager`, `Options.setEnv`                                          |
 | Backup Engine           | `BackupEngine.java`, `BackupEngineOptions.java`, `RestoreOptions.java`, `BackupInfo.java`, `BackupId.java`                |
-| Column Families         | `ColumnFamilyHandle.java`, `ColumnFamilyDescriptor.java`; `RocksDB.open`, `listColumnFamilies`; CF overloads on `ReadWriteDB` and `WriteBatch`; CF overloads on `ReadOnlyDB`, `TtlDB`, `TransactionDB`, `OptimisticTransactionDB`; `Transaction` CF put/delete/get/getForUpdate/newIterator; multi-CF open for all DB types |
+| Column Families         | `ColumnFamilyHandle.java`, `ColumnFamilyDescriptor.java`; `RocksDB.openReadWrite`, `listColumnFamilies`; CF overloads on `ReadWriteDB` and `WriteBatch`; CF overloads on `ReadOnlyDB`, `TtlDB`, `TransactionDB`, `OptimisticTransactionDB`; `Transaction` CF put/delete/get/getForUpdate/newIterator; multi-CF open for all DB types |
 | Perf Context            | `PerfContext.java`, `PerfLevel.java`, `PerfMetric.java`; thread-local; `setPerfLevel`, `reset`, `metric`, `report`       |
 
 ## Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,14 +171,14 @@ instance method listed below lives on the DB type (`ReadWriteDB`, `TtlDB`, …),
 | SST File Ingest         | `SstFileWriter.java`, `IngestExternalFileOptions.java`; `ReadWriteDB.ingestExternalFile`                                     |
 | WAL Iterator            | `WalIterator.java`, `WalBatchResult.java`; `ReadWriteDB.getUpdatesSince`, `getLatestSequenceNumber`                          |
 | Read-only DB            | `ReadOnlyDB.java`                                                                                                         |
-| TTL DB                  | `TtlDB.java`; `RocksDB.openWithTtl(Path, Duration)`                                                                       |
+| TTL DB                  | `TtlDB.java`; `RocksDB.openTtl(Path, Duration)`                                                                       |
 | Logger                  | `Logger.java`, `LogLevel.java`; `Logger.newStderrLogger`, `Logger.newCallbackLogger`                                      |
 | Secondary DB            | `SecondaryDB.java`                                                                                                        |
-| Blob DB                 | `BlobDB.java`; blob options in `Options.java`; `PrepopulateBlobCache.java`; `RocksDB.openWithBlobFiles`                   |
+| Blob DB                 | `BlobDB.java`; blob options in `Options.java`; `PrepopulateBlobCache.java`; `RocksDB.openBlob`                   |
 | Rate Limiter            | `RateLimiter.java`; `Options.setRateLimiter`                                                                              |
 | SST File Manager        | `SstFileManager.java`, `Env.java`; `Options.setSstFileManager`, `Options.setEnv`                                          |
 | Backup Engine           | `BackupEngine.java`, `BackupEngineOptions.java`, `RestoreOptions.java`, `BackupInfo.java`, `BackupId.java`                |
-| Column Families         | `ColumnFamilyHandle.java`, `ColumnFamilyDescriptor.java`; `RocksDB.openWithColumnFamilies`, `listColumnFamilies`; CF overloads on `ReadWriteDB` and `WriteBatch`; CF overloads on `ReadOnlyDB`, `TtlDB`, `TransactionDB`, `OptimisticTransactionDB`; `Transaction` CF put/delete/get/getForUpdate/newIterator; multi-CF open for all DB types |
+| Column Families         | `ColumnFamilyHandle.java`, `ColumnFamilyDescriptor.java`; `RocksDB.open`, `listColumnFamilies`; CF overloads on `ReadWriteDB` and `WriteBatch`; CF overloads on `ReadOnlyDB`, `TtlDB`, `TransactionDB`, `OptimisticTransactionDB`; `Transaction` CF put/delete/get/getForUpdate/newIterator; multi-CF open for all DB types |
 | Perf Context            | `PerfContext.java`, `PerfLevel.java`, `PerfMetric.java`; thread-local; `setPerfLevel`, `reset`, `metric`, `report`       |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Import the BOM, then depend on `rocksdbffm-core` plus one native artifact per pl
 ```
 
 ```java
-try (var db = RocksDB.open(Path.of("/tmp/demo-db"))) {
+try (var db = RocksDB.openReadWrite(Path.of("/tmp/demo-db"))) {
     db.put("user:1".getBytes(), "alice".getBytes());
     byte[] value = db.get("user:1".getBytes());   // null if absent
     db.delete("user:1".getBytes());

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
@@ -63,7 +63,7 @@ public class FfmBenchmark {
 	@Setup(Level.Trial)
 	public void setup() throws Exception {
 		dbPath = Files.createTempDirectory("bench-ffm-");
-		db = RocksDB.open(dbPath);
+		db = RocksDB.openReadWrite(dbPath);
 
 		// --- byte[] tier ---
 		writeKeyBytes = TestData.WRITE_KEY_BYTES.clone();

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngine.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngine.java
@@ -20,7 +20,7 @@ import java.util.List;
 ///
 /// // Create a backup
 /// try (var opts   = Options.newOptions().setCreateIfMissing(true);
-///      var db     = RocksDB.open(opts, dbDir);
+///      var db     = RocksDB.openReadWrite(opts, dbDir);
 ///      var engine = BackupEngine.open(opts, backupDir)) {
 ///     db.put("k".getBytes(), "v".getBytes());
 ///     engine.createNewBackup(db);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
@@ -14,14 +14,14 @@ import java.util.OptionalLong;
 /// Large values (≥ [Options#setMinBlobSize]) are stored in separate blob files
 /// rather than inline in SSTs, reducing write amplification for value-heavy workloads.
 ///
-/// Obtain via [RocksDB#openWithBlobFiles]:
+/// Obtain via [RocksDB#openBlob]:
 ///
 /// ```
 /// try (Options opts = Options.newOptions()
 ///         .setCreateIfMissing(true)
 ///         .setEnableBlobFiles(true)
 ///         .setMinBlobSize(MemorySize.ofKB(4))) {
-///     try (var db = RocksDB.openWithBlobFiles(opts, path)) {
+///     try (var db = RocksDB.openBlob(opts, path)) {
 ///         db.put("key".getBytes(), largeValue);
 ///     }
 /// }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Checkpoint.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Checkpoint.java
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 /// database that can be opened read-only without any recovery.
 ///
 /// ```
-/// try (var db = RocksDB.open(dir);
+/// try (var db = RocksDB.openReadWrite(dir);
 ///      var cp = Checkpoint.create(db)) {
 ///     cp.exportTo(checkpointDir1);
 ///     db.put("k".getBytes(), "v2".getBytes());

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ColumnFamilyHandle.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ColumnFamilyHandle.java
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets;
 
 /// FFM wrapper for `rocksdb_column_family_handle_t`.
 ///
-/// Obtained via [RocksDB#openWithColumnFamilies] or [ReadWriteDB#createColumnFamily].
+/// Obtained via [RocksDB#open] or [ReadWriteDB#createColumnFamily].
 /// Must be closed after use to release the native handle.
 ///
 /// ```

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ColumnFamilyHandle.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ColumnFamilyHandle.java
@@ -9,11 +9,11 @@ import java.nio.charset.StandardCharsets;
 
 /// FFM wrapper for `rocksdb_column_family_handle_t`.
 ///
-/// Obtained via [RocksDB#open] or [ReadWriteDB#createColumnFamily].
+/// Obtained via [RocksDB#openReadWrite] or [ReadWriteDB#createColumnFamily].
 /// Must be closed after use to release the native handle.
 ///
 /// ```
-/// try (var db = RocksDB.open(path);
+/// try (var db = RocksDB.openReadWrite(path);
 ///      var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 ///     db.put(cf, "key".getBytes(), "value".getBytes());
 /// }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
@@ -11,11 +11,11 @@ import java.lang.invoke.MethodHandle;
 ///
 /// ```
 /// try (Options opts = Options.newOptions().setCreateIfMissing(true)) {
-///     RocksDB db = RocksDB.open(opts, path);
+///     RocksDB db = RocksDB.openReadWrite(opts, path);
 /// }
 /// ```
 ///
-/// Note: the Options object must remain open until after RocksDB.open() returns;
+/// Note: the Options object must remain open until after RocksDB.openReadWrite() returns;
 /// it can be closed immediately after that call.
 public final class Options extends NativeObject {
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RateLimiter.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RateLimiter.java
@@ -14,7 +14,7 @@ import java.lang.invoke.MethodHandle;
 ///      var opts = Options.newOptions()
 ///          .setCreateIfMissing(true)
 ///          .setRateLimiter(limiter)) {
-///     var db = RocksDB.open(opts, path);
+///     var db = RocksDB.openReadWrite(opts, path);
 /// }
 /// ```
 ///

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -10,7 +10,7 @@ import java.util.OptionalLong;
 
 /// FFM wrapper for a read-write `rocksdb_t*` instance.
 ///
-/// Obtain via [RocksDB#open] or [RocksDB#openWithTtl].
+/// Obtain via [RocksDB#open] or [RocksDB#openTtl].
 ///
 /// ```
 /// try (var db = RocksDB.open(path)) {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -10,10 +10,10 @@ import java.util.OptionalLong;
 
 /// FFM wrapper for a read-write `rocksdb_t*` instance.
 ///
-/// Obtain via [RocksDB#open] or [RocksDB#openTtl].
+/// Obtain via [RocksDB#openReadWrite] or [RocksDB#openTtl].
 ///
 /// ```
-/// try (var db = RocksDB.open(path)) {
+/// try (var db = RocksDB.openReadWrite(path)) {
 ///     db.put("key".getBytes(), "value".getBytes());
 ///     byte[] value = db.get("key".getBytes());
 /// }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -436,7 +436,7 @@ public final class RocksDB {
 	/// @param options the database options
 	/// @param path directory where the database files are stored
 	/// @return a new [ReadWriteDB] instance
-	public static ReadWriteDB open(Options options, Path path) {
+	public static ReadWriteDB openReadWrite(Options options, Path path) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment pathSeg = arena.allocateFrom(path.toString());
@@ -444,17 +444,17 @@ public final class RocksDB {
 			checkError(err);
 			return new ReadWriteDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("open failed", t);
+			throw RocksDBException.wrap("openReadWrite failed", t);
 		}
 	}
 
-	/// Equivalent to `open(options, path)` with `createIfMissing = true`.
+	/// Equivalent to `openReadWrite(options, path)` with `createIfMissing = true`.
 	///
 	/// @param path directory where the database files are stored
 	/// @return a new [ReadWriteDB] instance
-	public static ReadWriteDB open(Path path) {
+	public static ReadWriteDB openReadWrite(Path path) {
 		try (Options opts = Options.newOptions().setCreateIfMissing(true)) {
-			return open(opts, path);
+			return openReadWrite(opts, path);
 		}
 	}
 
@@ -1089,9 +1089,9 @@ public final class RocksDB {
 	/// @param descriptors one descriptor per column family (must include `"default"`)
 	/// @param handles output list populated with one handle per descriptor
 	/// @return a new [ReadWriteDB] instance
-	public static ReadWriteDB open(Options options, Path path,
-	                                List<ColumnFamilyDescriptor> descriptors,
-	                                List<ColumnFamilyHandle> handles) {
+	public static ReadWriteDB openReadWrite(Options options, Path path,
+	                                        List<ColumnFamilyDescriptor> descriptors,
+	                                        List<ColumnFamilyHandle> handles) {
 		int n = descriptors.size();
 		List<Options> tempOptions = new ArrayList<>();
 		try (Arena arena = Arena.ofConfined()) {
@@ -1125,7 +1125,7 @@ public final class RocksDB {
 
 			return new ReadWriteDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("open failed", t);
+			throw RocksDBException.wrap("openReadWrite failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -22,7 +22,7 @@ import java.util.OptionalLong;
 /// |---|---|
 /// | [#open] | [ReadWriteDB] |
 /// | [#openReadOnly] | [ReadOnlyDB] |
-/// | [#openWithTtl] | [TtlDB] |
+/// | [#openTtl] | [TtlDB] |
 /// | [#openSecondary] | [SecondaryDB] |
 /// | [#openTransaction] | [TransactionDB] |
 /// | [#openOptimistic] | [OptimisticTransactionDB] |
@@ -467,7 +467,7 @@ public final class RocksDB {
 	/// @param path directory where the database files are stored
 	/// @param ttl time-to-live for keys; [Duration#ZERO] disables expiry
 	/// @return a new [TtlDB] instance
-	public static TtlDB openWithTtl(Options options, Path path, Duration ttl) {
+	public static TtlDB openTtl(Options options, Path path, Duration ttl) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment pathSeg = arena.allocateFrom(path.toString());
@@ -476,18 +476,18 @@ public final class RocksDB {
 			checkError(err);
 			return new TtlDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions(), ttl);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openWithTtl failed", t);
+			throw RocksDBException.wrap("openTtl failed", t);
 		}
 	}
 
-	/// Equivalent to `openWithTtl(options, path, ttl)` with `createIfMissing = true`.
+	/// Equivalent to `openTtl(options, path, ttl)` with `createIfMissing = true`.
 	///
 	/// @param path directory where the database files are stored
 	/// @param ttl time-to-live for keys; [Duration#ZERO] disables expiry
 	/// @return a new [TtlDB] instance
-	public static TtlDB openWithTtl(Path path, Duration ttl) {
+	public static TtlDB openTtl(Path path, Duration ttl) {
 		try (Options opts = Options.newOptions().setCreateIfMissing(true)) {
-			return openWithTtl(opts, path, ttl);
+			return openTtl(opts, path, ttl);
 		}
 	}
 
@@ -501,7 +501,7 @@ public final class RocksDB {
 	/// @param options the database options (must have blob files enabled)
 	/// @param path directory where the database files are stored
 	/// @return a new [BlobDB] instance
-	public static BlobDB openWithBlobFiles(Options options, Path path) {
+	public static BlobDB openBlob(Options options, Path path) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment pathSeg = arena.allocateFrom(path.toString());
@@ -509,18 +509,18 @@ public final class RocksDB {
 			checkError(err);
 			return new BlobDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openWithBlobFiles failed", t);
+			throw RocksDBException.wrap("openBlob failed", t);
 		}
 	}
 
-	/// Equivalent to `openWithBlobFiles(options, path)` with `createIfMissing = true`
+	/// Equivalent to `openBlob(options, path)` with `createIfMissing = true`
 	/// and `enableBlobFiles = true`.
 	///
 	/// @param path directory where the database files are stored
 	/// @return a new [BlobDB] instance
-	public static BlobDB openWithBlobFiles(Path path) {
+	public static BlobDB openBlob(Path path) {
 		try (Options opts = Options.newOptions().setCreateIfMissing(true).setEnableBlobFiles(true)) {
-			return openWithBlobFiles(opts, path);
+			return openBlob(opts, path);
 		}
 	}
 
@@ -1089,9 +1089,9 @@ public final class RocksDB {
 	/// @param descriptors one descriptor per column family (must include `"default"`)
 	/// @param handles output list populated with one handle per descriptor
 	/// @return a new [ReadWriteDB] instance
-	public static ReadWriteDB openWithColumnFamilies(Options options, Path path,
-	                                                 List<ColumnFamilyDescriptor> descriptors,
-	                                                 List<ColumnFamilyHandle> handles) {
+	public static ReadWriteDB open(Options options, Path path,
+	                                List<ColumnFamilyDescriptor> descriptors,
+	                                List<ColumnFamilyHandle> handles) {
 		int n = descriptors.size();
 		List<Options> tempOptions = new ArrayList<>();
 		try (Arena arena = Arena.ofConfined()) {
@@ -1125,7 +1125,7 @@ public final class RocksDB {
 
 			return new ReadWriteDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openWithColumnFamilies failed", t);
+			throw RocksDBException.wrap("open failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1142,10 +1142,10 @@ public final class RocksDB {
 	/// @param descriptors one descriptor per column family (must include `"default"`)
 	/// @param handles output list populated with one handle per descriptor
 	/// @return a new [ReadOnlyDB] instance
-	public static ReadOnlyDB openReadOnlyWithColumnFamilies(Options options, Path path,
-	                                                        List<ColumnFamilyDescriptor> descriptors,
-	                                                        List<ColumnFamilyHandle> handles) {
-		return openReadOnlyWithColumnFamilies(options, path, descriptors, handles, false);
+	public static ReadOnlyDB openReadOnly(Options options, Path path,
+	                                      List<ColumnFamilyDescriptor> descriptors,
+	                                      List<ColumnFamilyHandle> handles) {
+		return openReadOnly(options, path, descriptors, handles, false);
 	}
 
 	/// Opens a read-only database at `path` with multiple column families.
@@ -1156,10 +1156,10 @@ public final class RocksDB {
 	/// @param handles output list populated with one handle per descriptor
 	/// @param errorIfWalFileExists if `true`, fails when unrecovered WAL files are present
 	/// @return a new [ReadOnlyDB] instance
-	public static ReadOnlyDB openReadOnlyWithColumnFamilies(Options options, Path path,
-	                                                        List<ColumnFamilyDescriptor> descriptors,
-	                                                        List<ColumnFamilyHandle> handles,
-	                                                        boolean errorIfWalFileExists) {
+	public static ReadOnlyDB openReadOnly(Options options, Path path,
+	                                      List<ColumnFamilyDescriptor> descriptors,
+	                                      List<ColumnFamilyHandle> handles,
+	                                      boolean errorIfWalFileExists) {
 		int n = descriptors.size();
 		List<Options> tempOptions = new ArrayList<>();
 		try (Arena arena = Arena.ofConfined()) {
@@ -1189,7 +1189,7 @@ public final class RocksDB {
 			}
 			return new ReadOnlyDB(ptr, ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openReadOnlyWithColumnFamilies failed", t);
+			throw RocksDBException.wrap("openReadOnly failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1209,10 +1209,10 @@ public final class RocksDB {
 	/// @param ttls        per-column-family TTLs, index-aligned with `descriptors`
 	/// @param handles     output list; cleared and filled with one handle per descriptor
 	/// @return an open [TtlDB] instance; caller must close it
-	public static TtlDB openWithColumnFamiliesAndTtl(Options options, Path path,
-	                                                  List<ColumnFamilyDescriptor> descriptors,
-	                                                  List<Duration> ttls,
-	                                                  List<ColumnFamilyHandle> handles) {
+	public static TtlDB openTtl(Options options, Path path,
+	                            List<ColumnFamilyDescriptor> descriptors,
+	                            List<Duration> ttls,
+	                            List<ColumnFamilyHandle> handles) {
 		int n = descriptors.size();
 		List<Options> tempOptions = new ArrayList<>();
 		try (Arena arena = Arena.ofConfined()) {
@@ -1244,7 +1244,7 @@ public final class RocksDB {
 			Duration globalTtl = ttls.isEmpty() ? Duration.ZERO : ttls.getFirst();
 			return new TtlDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions(), globalTtl);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openWithColumnFamiliesAndTtl failed", t);
+			throw RocksDBException.wrap("openTtl failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1262,11 +1262,11 @@ public final class RocksDB {
 	/// @param descriptors   column family descriptors (name + optional per-CF options)
 	/// @param handles       output list; cleared and filled with one handle per descriptor
 	/// @return an open [TransactionDB] instance; caller must close it
-	public static TransactionDB openTransactionWithColumnFamilies(Options options,
-	                                                               TransactionDBOptions txnDbOptions,
-	                                                               Path path,
-	                                                               List<ColumnFamilyDescriptor> descriptors,
-	                                                               List<ColumnFamilyHandle> handles) {
+	public static TransactionDB openTransaction(Options options,
+	                                            TransactionDBOptions txnDbOptions,
+	                                            Path path,
+	                                            List<ColumnFamilyDescriptor> descriptors,
+	                                            List<ColumnFamilyHandle> handles) {
 		int n = descriptors.size();
 		List<Options> tempOptions = new ArrayList<>();
 		try (Arena arena = Arena.ofConfined()) {
@@ -1296,7 +1296,7 @@ public final class RocksDB {
 			MemorySegment baseDb = (MemorySegment) MH_TRANSACTION_GET_BASE_DB.invokeExact(ptr);
 			return new TransactionDB(ptr, baseDb, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openTransactionWithColumnFamilies failed", t);
+			throw RocksDBException.wrap("openTransaction failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1313,9 +1313,9 @@ public final class RocksDB {
 	/// @param descriptors column family descriptors (name + optional per-CF options)
 	/// @param handles     output list; cleared and filled with one handle per descriptor
 	/// @return an open [OptimisticTransactionDB] instance; caller must close it
-	public static OptimisticTransactionDB openOptimisticWithColumnFamilies(Options options, Path path,
-	                                                                        List<ColumnFamilyDescriptor> descriptors,
-	                                                                        List<ColumnFamilyHandle> handles) {
+	public static OptimisticTransactionDB openOptimistic(Options options, Path path,
+	                                                     List<ColumnFamilyDescriptor> descriptors,
+	                                                     List<ColumnFamilyHandle> handles) {
 		int n = descriptors.size();
 		List<Options> tempOptions = new ArrayList<>();
 		try (Arena arena = Arena.ofConfined()) {
@@ -1345,7 +1345,7 @@ public final class RocksDB {
 			MemorySegment baseDb = (MemorySegment) MH_GET_BASE_DB.invokeExact(ptr);
 			return new OptimisticTransactionDB(ptr, baseDb, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openOptimisticWithColumnFamilies failed", t);
+			throw RocksDBException.wrap("openOptimistic failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileManager.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileManager.java
@@ -18,7 +18,7 @@ import java.lang.invoke.MethodHandle;
 ///      Options opts = Options.newOptions()
 ///          .setCreateIfMissing(true)
 ///          .setSstFileManager(sfm)) {
-///     var db = RocksDB.open(opts, path);
+///     var db = RocksDB.openReadWrite(opts, path);
 /// }
 /// ```
 ///

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
@@ -11,13 +11,13 @@ import java.util.OptionalLong;
 
 /// FFM wrapper for a TTL-aware read-write `rocksdb_t*` instance.
 ///
-/// Obtain via [RocksDB#openWithTtl].
+/// Obtain via [RocksDB#openTtl].
 ///
 /// Keys are lazily expired during the next compaction that covers their range.
 /// A [Duration#ZERO] TTL disables expiry entirely.
 ///
 /// ```
-/// try (var db = RocksDB.openWithTtl(path, Duration.ofSeconds(60))) {
+/// try (var db = RocksDB.openTtl(path, Duration.ofSeconds(60))) {
 ///     db.put("key".getBytes(), "value".getBytes());
 ///     byte[] value = db.get("key".getBytes());
 /// }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BackgroundJobsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BackgroundJobsTest.java
@@ -18,7 +18,7 @@ class BackgroundJobsTest {
 	@Test
 	void cancelAllBackgroundWork_noWait_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -31,7 +31,7 @@ class BackgroundJobsTest {
 	@Test
 	void cancelAllBackgroundWork_wait_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -48,7 +48,7 @@ class BackgroundJobsTest {
 	@Test
 	void disableAndEnableManualCompaction_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 
 			// When
 			assertThatNoException().isThrownBy(() -> {
@@ -63,7 +63,7 @@ class BackgroundJobsTest {
 	@Test
 	void disableManualCompaction_doesNotPreventReads(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 			db.disableManualCompaction();
 
@@ -84,7 +84,7 @@ class BackgroundJobsTest {
 	@Test
 	void waitForCompact_defaultOptions_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var opts = WaitForCompactOptions.create()) {
 
 			db.put("k".getBytes(), "v".getBytes());
@@ -99,7 +99,7 @@ class BackgroundJobsTest {
 	@Test
 	void waitForCompact_withFlush_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var opts = WaitForCompactOptions.create().setFlush(true)) {
 
 			db.put("k".getBytes(), "v".getBytes());
@@ -114,7 +114,7 @@ class BackgroundJobsTest {
 	@Test
 	void waitForCompact_withTimeout_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var opts = WaitForCompactOptions.create().setTimeout(Duration.ofSeconds(5))) {
 
 			db.put("k".getBytes(), "v".getBytes());

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineTest.java
@@ -15,7 +15,7 @@ class BackupEngineTest {
 	void createNewBackup_isVisibleInGetBackupInfo(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var db = RocksDB.openReadWrite(opts, dir.resolve("db"));
 		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
 
 			db.put("k".getBytes(), "v".getBytes());
@@ -35,7 +35,7 @@ class BackupEngineTest {
 	void getBackupInfo_isEmptyForFreshEngine(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var db = RocksDB.openReadWrite(opts, dir.resolve("db"));
 		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
 
 			// When
@@ -50,7 +50,7 @@ class BackupEngineTest {
 	void verifyBackup_succeedsForValidBackup(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var db = RocksDB.openReadWrite(opts, dir.resolve("db"));
 		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
 
 			db.put("k".getBytes(), "v".getBytes());
@@ -65,7 +65,7 @@ class BackupEngineTest {
 	void verifyBackup_throwsForUnknownBackupId(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var db = RocksDB.openReadWrite(opts, dir.resolve("db"));
 		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
 
 			engine.createNewBackup(db);
@@ -82,7 +82,7 @@ class BackupEngineTest {
 	void purgeOldBackups_keepsOnlyMostRecent(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir.resolve("db"));
+		     var db = RocksDB.openReadWrite(opts, dir.resolve("db"));
 		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
 
 			engine.createNewBackup(db);
@@ -107,7 +107,7 @@ class BackupEngineTest {
 
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var engine = BackupEngine.open(opts, backupDir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
@@ -121,7 +121,7 @@ class BackupEngineTest {
 
 		// Then
 		try (var opts = Options.newOptions();
-		     var restored = RocksDB.open(opts, restoreDir)) {
+		     var restored = RocksDB.openReadWrite(opts, restoreDir)) {
 			assertThat(restored.get("k".getBytes())).isEqualTo("v".getBytes());
 		}
 	}
@@ -135,7 +135,7 @@ class BackupEngineTest {
 
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var engine = BackupEngine.open(opts, backupDir)) {
 
 			// flushBeforeBackup=true: the value must land in an SST file rather than
@@ -152,7 +152,7 @@ class BackupEngineTest {
 
 		// Then
 		try (var opts = Options.newOptions();
-		     var restored = RocksDB.open(opts, restoreDir)) {
+		     var restored = RocksDB.openReadWrite(opts, restoreDir)) {
 			assertThat(restored.get("k".getBytes())).isEqualTo("v".getBytes());
 		}
 	}
@@ -165,7 +165,7 @@ class BackupEngineTest {
 
 		// Given — two backups with different content
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var engine = BackupEngine.open(opts, backupDir)) {
 
 			db.put("k".getBytes(), "first".getBytes());
@@ -182,7 +182,7 @@ class BackupEngineTest {
 
 		// Then
 		try (var opts = Options.newOptions();
-		     var restored = RocksDB.open(opts, restoreDir)) {
+		     var restored = RocksDB.openReadWrite(opts, restoreDir)) {
 			assertThat(restored.get("k".getBytes())).isEqualTo("first".getBytes());
 		}
 	}
@@ -194,7 +194,7 @@ class BackupEngineTest {
 
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var env = Env.defaultEnv();
 		     var beOpts = BackupEngineOptions.create(backupDir)) {
 
@@ -214,7 +214,7 @@ class BackupEngineTest {
 	void close_isIdempotent(@TempDir Path dir) {
 		// Given
 		var opts = Options.newOptions().setCreateIfMissing(true);
-		var db = RocksDB.open(opts, dir.resolve("db"));
+		var db = RocksDB.openReadWrite(opts, dir.resolve("db"));
 		var engine = BackupEngine.open(opts, dir.resolve("backup"));
 
 		// When

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BlobDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BlobDBTest.java
@@ -20,7 +20,7 @@ class BlobDBTest {
 	@Test
 	void put_get_roundtrip(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 
 			// When
 			db.put("key".getBytes(), "value".getBytes());
@@ -33,7 +33,7 @@ class BlobDBTest {
 	@Test
 	void put_withArena_isVisibleViaGet(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     Arena arena = Arena.ofConfined()) {
 
 			// When
@@ -47,7 +47,7 @@ class BlobDBTest {
 	@Test
 	void get_withReadOptions_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     var ro = ReadOptions.newReadOptions()) {
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -62,7 +62,7 @@ class BlobDBTest {
 	@Test
 	void delete_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -80,7 +80,7 @@ class BlobDBTest {
 	@Test
 	void put_get_memorySegment_roundtrip(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     Arena arena = Arena.ofConfined()) {
 			var key = arena.allocateFrom("seg-k");
 			var value = arena.allocateFrom("seg-v");
@@ -96,7 +96,7 @@ class BlobDBTest {
 	@Test
 	void get_memorySegment_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     Arena arena = Arena.ofConfined()) {
 			db.put("k".getBytes(), "v".getBytes());
 			var key = arena.allocateFrom("k");
@@ -114,7 +114,7 @@ class BlobDBTest {
 	@Test
 	void delete_memorySegment_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     Arena arena = Arena.ofConfined()) {
 			db.put("k".getBytes(), "v".getBytes());
 			var key = arena.allocateFrom("k");
@@ -134,7 +134,7 @@ class BlobDBTest {
 	@Test
 	void delete_byteBuffer_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 			var key = ByteBuffer.allocateDirect(1);
 			key.put("k".getBytes()).flip();
@@ -154,7 +154,7 @@ class BlobDBTest {
 	@Test
 	void write_appliesBatchAtomically(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     var batch = WriteBatch.create()) {
 			batch.put("k1".getBytes(), "v1".getBytes());
 			batch.put("k2".getBytes(), "v2".getBytes());
@@ -175,7 +175,7 @@ class BlobDBTest {
 	@Test
 	void getSnapshot_isolatesReads(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("k".getBytes(), "v1".getBytes());
 
 			// When — take snapshot, then overwrite
@@ -199,7 +199,7 @@ class BlobDBTest {
 	@Test
 	void newIterator_iteratesData(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -217,7 +217,7 @@ class BlobDBTest {
 	@Test
 	void newIterator_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     var ro = ReadOptions.newReadOptions()) {
 			db.put("x".getBytes(), "y".getBytes());
 
@@ -239,7 +239,7 @@ class BlobDBTest {
 	@Test
 	void flush_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     var fo = FlushOptions.newFlushOptions().setWait(true)) {
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -253,7 +253,7 @@ class BlobDBTest {
 	@Test
 	void flushWal_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -270,7 +270,7 @@ class BlobDBTest {
 	@Test
 	void getProperty_blobStats_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -284,7 +284,7 @@ class BlobDBTest {
 	@Test
 	void getLongProperty_numBlobFiles_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -314,7 +314,7 @@ class BlobDBTest {
 		}
 
 		// When
-		try (var db = RocksDB.openWithBlobFiles(dbPath);
+		try (var db = RocksDB.openBlob(dbPath);
 		     var ingestOpts = IngestExternalFileOptions.newIngestExternalFileOptions()) {
 			db.ingestExternalFile(List.of(sstPath), ingestOpts);
 
@@ -327,7 +327,7 @@ class BlobDBTest {
 	@Test
 	void ingestExternalFile_emptyFileList_isNoOp(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir);
+		try (var db = RocksDB.openBlob(dir);
 		     var ingestOpts = IngestExternalFileOptions.newIngestExternalFileOptions()) {
 
 			// When
@@ -344,7 +344,7 @@ class BlobDBTest {
 	@Test
 	void get_byteBuffer_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("key".getBytes(), "value".getBytes());
 
 			var key = ByteBuffer.allocateDirect(3);
@@ -366,7 +366,7 @@ class BlobDBTest {
 	@Test
 	void get_byteBuffer_returnsNotFound_whenKeyAbsent(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("seed".getBytes(), "val".getBytes());
 
 			var key = ByteBuffer.allocateDirect(7);
@@ -384,7 +384,7 @@ class BlobDBTest {
 	@Test
 	void get_byteBuffer_returnsNotEnoughCapacity_whenValueDoesNotFit(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("key".getBytes(), "value".getBytes());
 
 			var key = ByteBuffer.allocateDirect(3);

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/CheckpointTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/CheckpointTest.java
@@ -17,7 +17,7 @@ class CheckpointTest {
 	void exportTo_createsReadableSnapshot(@TempDir Path dir) {
 		// Given
 		var cpDir = dir.resolve("checkpoint");
-		try (var db = RocksDB.open(dir.resolve("db"))) {
+		try (var db = RocksDB.openReadWrite(dir.resolve("db"))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -36,7 +36,7 @@ class CheckpointTest {
 	void snapshot_isIsolatedFromSubsequentWrites(@TempDir Path dir) {
 		// Given
 		var cpDir = dir.resolve("checkpoint");
-		try (var db = RocksDB.open(dir.resolve("db"))) {
+		try (var db = RocksDB.openReadWrite(dir.resolve("db"))) {
 			db.put("k".getBytes(), "before".getBytes());
 
 			try (var cp = Checkpoint.newCheckpoint(db)) {
@@ -63,7 +63,7 @@ class CheckpointTest {
 		var cp1Dir = dir.resolve("checkpoint-1");
 		var cp2Dir = dir.resolve("checkpoint-2");
 
-		try (var db = RocksDB.open(dir.resolve("db"));
+		try (var db = RocksDB.openReadWrite(dir.resolve("db"));
 		     var cp = Checkpoint.newCheckpoint(db)) {
 
 			db.put("k".getBytes(), "v1".getBytes());
@@ -91,7 +91,7 @@ class CheckpointTest {
 	void snapshot_returnsNull_forKeyAbsentAtCheckpointTime(@TempDir Path dir) {
 		// Given
 		var cpDir = dir.resolve("checkpoint");
-		try (var db = RocksDB.open(dir.resolve("db"))) {
+		try (var db = RocksDB.openReadWrite(dir.resolve("db"))) {
 			// checkpoint taken before any write
 			try (var cp = Checkpoint.newCheckpoint(db)) {
 				cp.exportTo(cpDir);
@@ -115,7 +115,7 @@ class CheckpointTest {
 	void snapshot_preservesDeletedKey_thatWasDeletedAfterCheckpoint(@TempDir Path dir) {
 		// Given
 		var cpDir = dir.resolve("checkpoint");
-		try (var db = RocksDB.open(dir.resolve("db"))) {
+		try (var db = RocksDB.openReadWrite(dir.resolve("db"))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			try (var cp = Checkpoint.newCheckpoint(db)) {

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyTest.java
@@ -21,7 +21,7 @@ class ColumnFamilyTest {
 	void listColumnFamilies_returnsDefaultOnly_onNewDb(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			// When
 			List<byte[]> families = RocksDB.listColumnFamilies(opts, dir);
 
@@ -38,7 +38,7 @@ class ColumnFamilyTest {
 	@Test
 	void createColumnFamily_canPutAndGetInNewFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 
 			// When
@@ -52,7 +52,7 @@ class ColumnFamilyTest {
 	@Test
 	void createColumnFamily_isolatedFromDefaultFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put("key".getBytes(), "default-value".getBytes());
 			db.put(cf, "key".getBytes(), "cf-value".getBytes());
@@ -70,7 +70,7 @@ class ColumnFamilyTest {
 	@Test
 	void dropColumnFamily_removesFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("to-drop"));
 			db.put(cf, "key".getBytes(), "value".getBytes());
 
@@ -97,7 +97,7 @@ class ColumnFamilyTest {
 	void open_persistsAndReadsAcrossReopens(@TempDir Path dir) {
 		// Given — create a DB with a non-default CF and write data
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("users"))) {
 			db.put(cf, "alice".getBytes(), "data".getBytes());
 		}
@@ -105,7 +105,7 @@ class ColumnFamilyTest {
 		// When — reopen with both CFs
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions().setCreateIfMissing(false);
-		     var db = RocksDB.open(opts, dir,
+		     var db = RocksDB.openReadWrite(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("users")),
 				     handles)) {
@@ -127,7 +127,7 @@ class ColumnFamilyTest {
 	@Test
 	void columnFamilyHandle_returnsCorrectName(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("my-cf"))) {
 
 			// When
@@ -143,7 +143,7 @@ class ColumnFamilyTest {
 		// Given
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir,
+		     var db = RocksDB.openReadWrite(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default")),
 				     handles)) {
 
@@ -163,7 +163,7 @@ class ColumnFamilyTest {
 	@Test
 	void delete_removesKeyFromColumnFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 
@@ -182,7 +182,7 @@ class ColumnFamilyTest {
 	@Test
 	void deleteRange_removesKeyRangeFromColumnFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "a".getBytes(), "1".getBytes());
 			db.put(cf, "b".getBytes(), "2".getBytes());
@@ -205,7 +205,7 @@ class ColumnFamilyTest {
 	@Test
 	void keyMayExist_returnsTrueForPresentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 
@@ -220,7 +220,7 @@ class ColumnFamilyTest {
 	@Test
 	void keyMayExist_returnsFalseForAbsentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 
 			// When
@@ -238,7 +238,7 @@ class ColumnFamilyTest {
 	@Test
 	void put_get_byteBuffer_overload(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			ByteBuffer key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
 			ByteBuffer val = ByteBuffer.allocateDirect(1).put((byte) 'v').flip();
@@ -257,7 +257,7 @@ class ColumnFamilyTest {
 	@Test
 	void get_byteBuffer_returnsNotEnoughCapacity_whenValueDoesNotFit(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			ByteBuffer key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
 			ByteBuffer val = ByteBuffer.allocateDirect(5).put("value".getBytes()).flip();
@@ -282,7 +282,7 @@ class ColumnFamilyTest {
 	@Test
 	void newIterator_scansKeysInColumnFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "a".getBytes(), "1".getBytes());
 			db.put(cf, "b".getBytes(), "2".getBytes());
@@ -304,7 +304,7 @@ class ColumnFamilyTest {
 	@Test
 	void newIterator_doesNotSeeKeysFromOtherFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put("default-key".getBytes(), "x".getBytes());
 			db.put(cf, "cf-key".getBytes(), "y".getBytes());
@@ -329,7 +329,7 @@ class ColumnFamilyTest {
 	@Test
 	void writeBatch_putAndDelete_inColumnFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     var batch = WriteBatch.create()) {
 
@@ -348,7 +348,7 @@ class ColumnFamilyTest {
 	@Test
 	void writeBatch_deleteRange_inColumnFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     var batch = WriteBatch.create()) {
 			db.put(cf, "a".getBytes(), "1".getBytes());
@@ -373,7 +373,7 @@ class ColumnFamilyTest {
 	@Test
 	void flush_columnFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     var flushOpts = FlushOptions.newFlushOptions().setWait(true)) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
@@ -388,7 +388,7 @@ class ColumnFamilyTest {
 	@Test
 	void getProperty_columnFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 
 			// When

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyTest.java
@@ -90,11 +90,11 @@ class ColumnFamilyTest {
 	}
 
 	// -----------------------------------------------------------------------
-	// openWithColumnFamilies
+	// open
 	// -----------------------------------------------------------------------
 
 	@Test
-	void openWithColumnFamilies_persistsAndReadsAcrossReopens(@TempDir Path dir) {
+	void open_persistsAndReadsAcrossReopens(@TempDir Path dir) {
 		// Given — create a DB with a non-default CF and write data
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
 		     var db = RocksDB.open(opts, dir);
@@ -105,7 +105,7 @@ class ColumnFamilyTest {
 		// When — reopen with both CFs
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions().setCreateIfMissing(false);
-		     var db = RocksDB.openWithColumnFamilies(opts, dir,
+		     var db = RocksDB.open(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("users")),
 				     handles)) {
@@ -143,7 +143,7 @@ class ColumnFamilyTest {
 		// Given
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithColumnFamilies(opts, dir,
+		     var db = RocksDB.open(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default")),
 				     handles)) {
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/CompactionControlTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/CompactionControlTest.java
@@ -18,7 +18,7 @@ class CompactionControlTest {
 	void compactRange_noArgs_doesNotThrow(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -39,7 +39,7 @@ class CompactionControlTest {
 	void compactRange_byteArray_fullRange(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("z".getBytes(), "2".getBytes());
 
@@ -56,7 +56,7 @@ class CompactionControlTest {
 	void compactRange_byteArray_nullBounds(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When — null means open-ended
@@ -75,7 +75,7 @@ class CompactionControlTest {
 	void compactRange_byteBuffer(@TempDir Path dir) {
 		// Given — ByteBuffer tier requires direct buffers
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -96,7 +96,7 @@ class CompactionControlTest {
 	void compactRange_byteBuffer_nullBounds(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -115,7 +115,7 @@ class CompactionControlTest {
 	void compactRange_withOptions_fullRange(@TempDir Path dir) {
 		// Given
 		try (var dbOpts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(dbOpts, dir);
+		     var db = RocksDB.openReadWrite(dbOpts, dir);
 		     var compact = CompactOptions.newCompactOptions()
 					 .setExclusiveManualCompaction(false)
 					 .setBottommostLevelCompaction(true)) {
@@ -136,7 +136,7 @@ class CompactionControlTest {
 	void compactRange_withOptions_changeLevel(@TempDir Path dir) {
 		// Given
 		try (var dbOpts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(dbOpts, dir);
+		     var db = RocksDB.openReadWrite(dbOpts, dir);
 		     var compact = CompactOptions.newCompactOptions()
 					 .setChangeLevel(true)
 					 .setTargetLevel(-1)) {  // -1 = bottommost
@@ -191,7 +191,7 @@ class CompactionControlTest {
 	void suggestCompactRange_doesNotThrow(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("z".getBytes(), "2".getBytes());
 
@@ -206,7 +206,7 @@ class CompactionControlTest {
 	void suggestCompactRange_nullBounds(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -224,7 +224,7 @@ class CompactionControlTest {
 	void disableAndEnableFileDeletions_doesNotThrow(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When — disable, do some work, re-enable

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/CompressionTypeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/CompressionTypeTest.java
@@ -35,7 +35,7 @@ class CompressionTypeTest {
 		try (Options opts = Options.newOptions()
 				.setCreateIfMissing(true)
 				.setCompression(CompressionType.NO_COMPRESSION);
-		     ReadWriteDB db = RocksDB.open(opts, dir)) {
+		     ReadWriteDB db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/DeleteRangeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/DeleteRangeTest.java
@@ -19,7 +19,7 @@ class DeleteRangeTest {
 	@Test
 	void deleteRange_removesKeysInRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 			db.put("c".getBytes(), "3".getBytes());
@@ -39,7 +39,7 @@ class DeleteRangeTest {
 	@Test
 	void deleteRange_emptyRange_deletesNothing(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 
 			// When — start == end is an empty range
@@ -53,7 +53,7 @@ class DeleteRangeTest {
 	@Test
 	void deleteRange_rangeExceedsExistingKeys_deletesOnlyPresent(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("b".getBytes(), "2".getBytes());
 
 			// When — range extends beyond existing keys
@@ -71,7 +71,7 @@ class DeleteRangeTest {
 	@Test
 	void deleteRange_byteBuffer_removesKeysInRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 			db.put("c".getBytes(), "3".getBytes());
@@ -96,7 +96,7 @@ class DeleteRangeTest {
 	@Test
 	void deleteRange_memorySegment_removesKeysInRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var arena = Arena.ofConfined()) {
 
 			db.put("a".getBytes(), "1".getBytes());
@@ -123,7 +123,7 @@ class DeleteRangeTest {
 	@Test
 	void writeBatch_deleteRange_removesKeysInRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var batch = WriteBatch.create()) {
 
 			db.put("a".getBytes(), "1".getBytes());
@@ -147,7 +147,7 @@ class DeleteRangeTest {
 	@Test
 	void writeBatch_deleteRange_combinedWithPuts(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var batch = WriteBatch.create()) {
 
 			db.put("b".getBytes(), "old".getBytes());
@@ -172,7 +172,7 @@ class DeleteRangeTest {
 	@Test
 	void writeBatch_deleteRange_byteBuffer(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var batch = WriteBatch.create()) {
 
 			db.put("b".getBytes(), "2".getBytes());
@@ -199,7 +199,7 @@ class DeleteRangeTest {
 	@Test
 	void writeBatch_deleteRange_memorySegment(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var batch = WriteBatch.create();
 		     var arena = Arena.ofConfined()) {
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/EnvTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/EnvTest.java
@@ -118,7 +118,7 @@ class EnvTest {
 
 			// When
 			assertThatNoException().isThrownBy(() -> {
-				try (var db = RocksDB.open(opts, dir)) {
+				try (var db = RocksDB.openReadWrite(opts, dir)) {
 					db.put("k".getBytes(), "v".getBytes());
 					byte[] result = db.get("k".getBytes());
 					assertThat(result).isEqualTo("v".getBytes());
@@ -142,7 +142,7 @@ class EnvTest {
 
 			// When
 			assertThatNoException().isThrownBy(() -> {
-				try (var db = RocksDB.open(opts, dir)) {
+				try (var db = RocksDB.openReadWrite(opts, dir)) {
 					db.put("key".getBytes(), "value".getBytes());
 					byte[] result = db.get("key".getBytes());
 					assertThat(result).isEqualTo("value".getBytes());

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/FlushTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/FlushTest.java
@@ -43,7 +43,7 @@ class FlushTest {
 	@Test
 	void flush_dataIsReadableAfterFlush(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var fo = FlushOptions.newFlushOptions().setWait(true)) {
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -58,7 +58,7 @@ class FlushTest {
 	@Test
 	void flush_multipleKeys(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			for (int i = 0; i < 100; i++) {
 				db.put(("key" + i).getBytes(), ("val" + i).getBytes());
@@ -76,7 +76,7 @@ class FlushTest {
 	@Test
 	void flushWal_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/HyperClockCacheTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/HyperClockCacheTest.java
@@ -87,7 +87,7 @@ class HyperClockCacheTest {
 					 .setCacheIndexAndFilterBlocks(true)
 					 .setFilterPolicy(filter);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			for (int i = 0; i < 100; i++) {
 				db.put(("key-" + i).getBytes(), ("val-" + i).getBytes());
 			}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/KeyMayExistTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/KeyMayExistTest.java
@@ -292,7 +292,7 @@ class KeyMayExistTest {
 		// Given — TtlDB Bloom filter configuration does not guarantee false for absent keys;
 		// the contract is that false means "definitely absent", true means "may exist".
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60))) {
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60))) {
 
 			// When
 			var result = db.keyMayExist("ghost".getBytes());
@@ -306,7 +306,7 @@ class KeyMayExistTest {
 	void keyMayExist_ttlDb_byteArray_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60))) {
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -321,7 +321,7 @@ class KeyMayExistTest {
 	void keyMayExist_ttlDb_byteBuffer_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60))) {
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60))) {
 			db.put("hello".getBytes(), "world".getBytes());
 			ByteBuffer key = ByteBuffer.allocateDirect(5);
 			key.put("hello".getBytes()).flip();
@@ -338,7 +338,7 @@ class KeyMayExistTest {
 	void keyMayExist_ttlDb_memorySegment_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60));
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60));
 		     Arena arena = Arena.ofConfined()) {
 			db.put("hi".getBytes(), "there".getBytes());
 			MemorySegment key = arena.allocate(2);
@@ -361,7 +361,7 @@ class KeyMayExistTest {
 	void keyMayExist_ttlDb_cf_doesNotThrow_forAbsentKey(@TempDir Path dir) {
 		// Given — same Bloom filter caveat as non-CF TtlDB variant
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60));
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"))) {
 
 			// When
@@ -376,7 +376,7 @@ class KeyMayExistTest {
 	void keyMayExist_ttlDb_cf_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60));
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 
@@ -392,7 +392,7 @@ class KeyMayExistTest {
 	void keyMayExist_ttlDb_cf_byteBuffer_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60));
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"))) {
 			db.put(cf, "hello".getBytes(), "world".getBytes());
 			ByteBuffer key = ByteBuffer.allocateDirect(5);
@@ -410,7 +410,7 @@ class KeyMayExistTest {
 	void keyMayExist_ttlDb_cf_memorySegment_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60));
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"));
 		     Arena arena = Arena.ofConfined()) {
 			db.put(cf, "hi".getBytes(), "there".getBytes());

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/KeyMayExistTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/KeyMayExistTest.java
@@ -21,7 +21,7 @@ class KeyMayExistTest {
 	@Test
 	void keyMayExist_returnsFalse_forAbsentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 
 			// When
 			var result = db.keyMayExist("ghost".getBytes());
@@ -34,7 +34,7 @@ class KeyMayExistTest {
 	@Test
 	void keyMayExist_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -49,7 +49,7 @@ class KeyMayExistTest {
 	void keyMayExist_mayReturnTrue_afterDelete(@TempDir Path dir) {
 		// Given — Bloom filters are additive; a deleted key may still pass the filter.
 		// This test just asserts no exception is thrown and the result is a boolean.
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 			db.delete("k".getBytes());
 
@@ -67,7 +67,7 @@ class KeyMayExistTest {
 	@Test
 	void keyMayExist_withReadOptions_snapshot(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			try (Snapshot snap = db.getSnapshot();
 			     ReadOptions ro = ReadOptions.newReadOptions().setSnapshot(snap)) {
 
@@ -91,7 +91,7 @@ class KeyMayExistTest {
 	@Test
 	void keyMayExist_byteBuffer_returnsFalse_forAbsentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			ByteBuffer key = ByteBuffer.allocateDirect(5);
 			key.put("ghost".getBytes()).flip();
 
@@ -106,7 +106,7 @@ class KeyMayExistTest {
 	@Test
 	void keyMayExist_byteBuffer_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("hello".getBytes(), "world".getBytes());
 			ByteBuffer key = ByteBuffer.allocateDirect(5);
 			key.put("hello".getBytes()).flip();
@@ -126,7 +126,7 @@ class KeyMayExistTest {
 	@Test
 	void keyMayExist_memorySegment_returnsFalse_forAbsentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     Arena arena = Arena.ofConfined()) {
 			MemorySegment key = arena.allocateFrom("ghost");
 			// allocateFrom adds a null terminator — use reinterpret to strip it
@@ -143,7 +143,7 @@ class KeyMayExistTest {
 	@Test
 	void keyMayExist_memorySegment_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     Arena arena = Arena.ofConfined()) {
 			db.put("hi".getBytes(), "there".getBytes());
 			MemorySegment key = arena.allocate(2);
@@ -166,7 +166,7 @@ class KeyMayExistTest {
 	void keyMayExist_cf_byteArray_returnsFalse_forAbsentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"))) {
 
 			// When
@@ -181,7 +181,7 @@ class KeyMayExistTest {
 	void keyMayExist_cf_byteArray_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 
@@ -197,7 +197,7 @@ class KeyMayExistTest {
 	void keyMayExist_cf_withReadOptions_doesNotThrow(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"));
 		     var snap = db.getSnapshot();
 		     var ro = ReadOptions.newReadOptions().setSnapshot(snap)) {
@@ -215,7 +215,7 @@ class KeyMayExistTest {
 	void keyMayExist_cf_byteBuffer_returnsFalse_forAbsentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"))) {
 			ByteBuffer key = ByteBuffer.allocateDirect(5);
 			key.put("ghost".getBytes()).flip();
@@ -232,7 +232,7 @@ class KeyMayExistTest {
 	void keyMayExist_cf_byteBuffer_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"))) {
 			db.put(cf, "hello".getBytes(), "world".getBytes());
 			ByteBuffer key = ByteBuffer.allocateDirect(5);
@@ -250,7 +250,7 @@ class KeyMayExistTest {
 	void keyMayExist_cf_memorySegment_returnsFalse_forAbsentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"));
 		     Arena arena = Arena.ofConfined()) {
 			MemorySegment key = arena.allocateFrom("ghost").reinterpret(5);
@@ -267,7 +267,7 @@ class KeyMayExistTest {
 	void keyMayExist_cf_memorySegment_returnsTrue_forPresentKey(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("test"));
 		     Arena arena = Arena.ofConfined()) {
 			db.put(cf, "hi".getBytes(), "there".getBytes());

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/LRUCacheTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/LRUCacheTest.java
@@ -53,7 +53,7 @@ class LRUCacheTest {
 					 .setCacheIndexAndFilterBlocks(true)
 					 .setFilterPolicy(filter);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			for (int i = 0; i < 100; i++) {
 				db.put(("key-" + i).getBytes(), ("val-" + i).getBytes());
 			}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/LoggerTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/LoggerTest.java
@@ -38,7 +38,7 @@ class LoggerTest {
 			System.out.println(level + ": " + msg);
 		});
 		     var opts = Options.newOptions().setCreateIfMissing(true).setInfoLog(logger);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When — trigger at least one internal log message via a flush
 			db.put("k".getBytes(), "v".getBytes());
@@ -72,7 +72,7 @@ class LoggerTest {
 			logger.close(); // safe: RocksDB still holds a shared_ptr reference
 
 			// When
-			try (var db = RocksDB.open(opts, dir)) {
+			try (var db = RocksDB.openReadWrite(opts, dir)) {
 				db.put("k".getBytes(), "v".getBytes());
 			}
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/NullSafetyTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/NullSafetyTest.java
@@ -22,14 +22,14 @@ class NullSafetyTest {
 
 	@Test
 	void open_nullOptions(@TempDir Path dir) {
-		assertThatThrownBy(() -> RocksDB.open(null, dir))
+		assertThatThrownBy(() -> RocksDB.openReadWrite(null, dir))
 				.isInstanceOf(RuntimeException.class);
 	}
 
 	@Test
 	void open_nullPath() {
 		try (var opts = Options.newOptions()) {
-			assertThatThrownBy(() -> RocksDB.open(opts, null))
+			assertThatThrownBy(() -> RocksDB.openReadWrite(opts, null))
 					.isInstanceOf(RuntimeException.class);
 		}
 	}
@@ -54,7 +54,7 @@ class NullSafetyTest {
 
 	@Test
 	void put_nullKey(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.put(null, "v".getBytes()))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -62,7 +62,7 @@ class NullSafetyTest {
 
 	@Test
 	void put_nullValue(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.put("k".getBytes(), null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -70,7 +70,7 @@ class NullSafetyTest {
 
 	@Test
 	void get_nullKey(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.get((byte[]) null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -78,7 +78,7 @@ class NullSafetyTest {
 
 	@Test
 	void get_nullReadOptions(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.get((ReadOptions) null, "k".getBytes()))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -86,7 +86,7 @@ class NullSafetyTest {
 
 	@Test
 	void get_nullKeyWithReadOptions(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var ro = ReadOptions.newReadOptions()) {
 			assertThatThrownBy(() -> db.get(ro, null))
 					.isInstanceOf(RuntimeException.class);
@@ -95,7 +95,7 @@ class NullSafetyTest {
 
 	@Test
 	void delete_nullKey(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.delete((byte[]) null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -107,7 +107,7 @@ class NullSafetyTest {
 
 	@Test
 	void put_nullKeyBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			var value = ByteBuffer.allocateDirect(4).put("v".getBytes()).flip();
 			assertThatThrownBy(() -> db.put((ByteBuffer) null, value))
 					.isInstanceOf(RuntimeException.class);
@@ -116,7 +116,7 @@ class NullSafetyTest {
 
 	@Test
 	void put_nullValueBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			var key = ByteBuffer.allocateDirect(4).put("k".getBytes()).flip();
 			assertThatThrownBy(() -> db.put(key, (ByteBuffer) null))
 					.isInstanceOf(RuntimeException.class);
@@ -125,7 +125,7 @@ class NullSafetyTest {
 
 	@Test
 	void get_nullKeyBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			var value = ByteBuffer.allocateDirect(128);
 			assertThatThrownBy(() -> db.get((ByteBuffer) null, value))
 					.isInstanceOf(RuntimeException.class);
@@ -134,7 +134,7 @@ class NullSafetyTest {
 
 	@Test
 	void get_nullValueBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 			var key = ByteBuffer.allocateDirect(4).put("k".getBytes()).flip();
 			assertThatThrownBy(() -> db.get(key, (ByteBuffer) null))
@@ -148,7 +148,7 @@ class NullSafetyTest {
 
 	@Test
 	void keyMayExist_nullByteArray(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.keyMayExist((byte[]) null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -156,7 +156,7 @@ class NullSafetyTest {
 
 	@Test
 	void keyMayExist_nullReadOptions(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.keyMayExist((ReadOptions) null, "k".getBytes()))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -164,7 +164,7 @@ class NullSafetyTest {
 
 	@Test
 	void keyMayExist_nullKeyWithReadOptions(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var ro = ReadOptions.newReadOptions()) {
 			assertThatThrownBy(() -> db.keyMayExist(ro, null))
 					.isInstanceOf(RuntimeException.class);
@@ -173,7 +173,7 @@ class NullSafetyTest {
 
 	@Test
 	void keyMayExist_nullByteBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.keyMayExist((ByteBuffer) null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -181,7 +181,7 @@ class NullSafetyTest {
 
 	@Test
 	void keyMayExist_nullMemorySegment(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.keyMayExist((MemorySegment) null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -193,7 +193,7 @@ class NullSafetyTest {
 
 	@Test
 	void newIterator_nullReadOptions(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.newIterator((ReadOptions) null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -201,7 +201,7 @@ class NullSafetyTest {
 
 	@Test
 	void flush_nullFlushOptions(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.flush(null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -209,7 +209,7 @@ class NullSafetyTest {
 
 	@Test
 	void write_nullBatch(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.write(null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -217,7 +217,7 @@ class NullSafetyTest {
 
 	@Test
 	void getProperty_null(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.getProperty(null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -225,7 +225,7 @@ class NullSafetyTest {
 
 	@Test
 	void getLongProperty_null(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThatThrownBy(() -> db.getLongProperty(null))
 					.isInstanceOf(RuntimeException.class);
 		}
@@ -265,7 +265,7 @@ class NullSafetyTest {
 
 	@Test
 	void iterator_seek_nullByteArray(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var it = db.newIterator()) {
 			assertThatThrownBy(() -> it.seek((byte[]) null))
 					.isInstanceOf(RuntimeException.class);
@@ -274,7 +274,7 @@ class NullSafetyTest {
 
 	@Test
 	void iterator_seek_nullByteBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var it = db.newIterator()) {
 			assertThatThrownBy(() -> it.seek((ByteBuffer) null))
 					.isInstanceOf(RuntimeException.class);
@@ -283,7 +283,7 @@ class NullSafetyTest {
 
 	@Test
 	void iterator_seek_nullMemorySegment(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var it = db.newIterator()) {
 			assertThatThrownBy(() -> it.seek((MemorySegment) null))
 					.isInstanceOf(RuntimeException.class);
@@ -292,7 +292,7 @@ class NullSafetyTest {
 
 	@Test
 	void iterator_seekForPrev_nullByteArray(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var it = db.newIterator()) {
 			assertThatThrownBy(() -> it.seekForPrev((byte[]) null))
 					.isInstanceOf(RuntimeException.class);
@@ -301,7 +301,7 @@ class NullSafetyTest {
 
 	@Test
 	void iterator_seekForPrev_nullByteBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var it = db.newIterator()) {
 			assertThatThrownBy(() -> it.seekForPrev((ByteBuffer) null))
 					.isInstanceOf(RuntimeException.class);
@@ -310,7 +310,7 @@ class NullSafetyTest {
 
 	@Test
 	void iterator_seekForPrev_nullMemorySegment(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var it = db.newIterator()) {
 			assertThatThrownBy(() -> it.seekForPrev((MemorySegment) null))
 					.isInstanceOf(RuntimeException.class);
@@ -323,7 +323,7 @@ class NullSafetyTest {
 
 	@Test
 	void iterator_key_nullBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var it = db.newIterator()) {
 			db.put("k".getBytes(), "v".getBytes());
 			it.seekToFirst();
@@ -334,7 +334,7 @@ class NullSafetyTest {
 
 	@Test
 	void iterator_value_nullBuffer(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var it = db.newIterator()) {
 			db.put("k".getBytes(), "v".getBytes());
 			it.seekToFirst();

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
@@ -475,6 +475,33 @@ class OptimisticTransactionDBTest {
 	}
 
 	// -----------------------------------------------------------------------
+	// openOptimistic — column families (opened at startup, not created later)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void openOptimistic_withColumnFamilies_reopensExistingFamily(@TempDir Path dir) {
+		// Given — create a DB with a custom CF, then close it
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+			db.put(cf, "k".getBytes(), "v".getBytes());
+		}
+
+		// When — reopen with both CFs via the CF-aware factory overload
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var opts = Options.newOptions();
+		     var db = RocksDB.openOptimistic(opts, dir,
+				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
+				     handles)) {
+			var cf = handles.get(1);
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isEqualTo("v".getBytes());
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	// -----------------------------------------------------------------------
 	// Iterator
 	// -----------------------------------------------------------------------
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PerfContextTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PerfContextTest.java
@@ -20,7 +20,7 @@ class PerfContextTest {
 		// Given — accumulate some activity, then start a fresh measurement window
 		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
 			try (var warmup = PerfContext.newPerfContext()) {
@@ -41,7 +41,7 @@ class PerfContextTest {
 		// Given
 		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			try (var warmup = PerfContext.newPerfContext()) {
 				db.put("k".getBytes(), "v".getBytes());
@@ -62,7 +62,7 @@ class PerfContextTest {
 		// Given
 		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var sut = PerfContext.newPerfContext()) {
 
 			db.put("k".getBytes(), "v".getBytes());
@@ -82,7 +82,7 @@ class PerfContextTest {
 		// Given
 		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var sut = PerfContext.newPerfContext()) {
 
 			db.put("k".getBytes(), "v".getBytes());
@@ -101,7 +101,7 @@ class PerfContextTest {
 		// Given
 		PerfContext.setPerfLevel(PerfLevel.ENABLE_COUNT);
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var sut = PerfContext.newPerfContext()) {
 
 			db.put("k".getBytes(), "v".getBytes());

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PerfMetricTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PerfMetricTest.java
@@ -37,7 +37,7 @@ class PerfMetricTest {
 		// Given
 		PerfContext.setPerfLevel(PerfLevel.ENABLE_TIME);
 		try (Options options = Options.newOptions().setCreateIfMissing(true);
-		     ReadWriteDB db = RocksDB.open(options, dir);
+		     ReadWriteDB db = RocksDB.openReadWrite(options, dir);
 		     PerfContext ctx = PerfContext.newPerfContext()) {
 
 			db.put("key".getBytes(), "value".getBytes());

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PropertyTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PropertyTest.java
@@ -18,7 +18,7 @@ class PropertyTest {
 	@Test
 	void getProperty_stats_isPresent(@TempDir Path dir) {
 		// Given / When
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			Optional<String> stats = db.getProperty(Property.STATS);
 
 			// Then
@@ -29,14 +29,14 @@ class PropertyTest {
 
 	@Test
 	void getProperty_levelStats_isPresent(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThat(db.getProperty(Property.LEVEL_STATS)).isPresent();
 		}
 	}
 
 	@Test
 	void getProperty_numFilesAtLevelL0_isPresent(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			// Given
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -56,7 +56,7 @@ class PropertyTest {
 	@Test
 	void getLongProperty_estimateNumKeys_isPresent(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k1".getBytes(), "v1".getBytes());
 			db.put("k2".getBytes(), "v2".getBytes());
 
@@ -71,7 +71,7 @@ class PropertyTest {
 
 	@Test
 	void getLongProperty_numRunningFlushes_isPresent(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			OptionalLong flushes = db.getLongProperty(Property.NUM_RUNNING_FLUSHES);
 
 			assertThat(flushes).isPresent();
@@ -81,7 +81,7 @@ class PropertyTest {
 
 	@Test
 	void getLongProperty_numRunningCompactions_isPresent(@TempDir Path dir) {
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			assertThat(db.getLongProperty(Property.NUM_RUNNING_COMPACTIONS)).isPresent();
 		}
 	}
@@ -89,7 +89,7 @@ class PropertyTest {
 	@Test
 	void getLongProperty_numSnapshots_incrementsWithSnapshot(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			long before = db.getLongProperty(Property.NUM_SNAPSHOTS).orElseThrow();
 
 			// When

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterTest.java
@@ -14,7 +14,7 @@ class RateLimiterTest {
 		// Given
 		try (var sut = RateLimiter.create(MemorySize.ofMB(100));
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("k".getBytes(), "v".getBytes());
@@ -29,7 +29,7 @@ class RateLimiterTest {
 		// Given
 		try (var sut = RateLimiter.create(MemorySize.ofMB(100), 50_000L, 5);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When / Then — DB opens successfully with the limiter attached
 			assertThat(db).isNotNull();
@@ -41,7 +41,7 @@ class RateLimiterTest {
 		// Given
 		try (var sut = RateLimiter.createAutoTuned(MemorySize.ofMB(100));
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When / Then
 			assertThat(db).isNotNull();
@@ -53,7 +53,7 @@ class RateLimiterTest {
 		// Given
 		try (var sut = RateLimiter.createAutoTuned(MemorySize.ofMB(100), 100_000L, 10);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When / Then
 			assertThat(db).isNotNull();
@@ -66,7 +66,7 @@ class RateLimiterTest {
 		try (var sut = RateLimiter.createWithMode(
 				MemorySize.ofMB(100), 100_000L, 10, RateLimiter.Mode.READS_ONLY, false);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When / Then
 			assertThat(db).isNotNull();
@@ -79,7 +79,7 @@ class RateLimiterTest {
 		try (var sut = RateLimiter.createWithMode(
 				MemorySize.ofMB(100), 100_000L, 10, RateLimiter.Mode.ALL_IO, true);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When / Then
 			assertThat(db).isNotNull();

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
@@ -21,7 +21,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_returnsStoredValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("k".getBytes(), "v".getBytes());
 		}
 
@@ -37,7 +37,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_returnsNull_whenKeyAbsent(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("seed".getBytes(), "val".getBytes());
 		}
 
@@ -54,7 +54,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("k".getBytes(), "v".getBytes());
 		}
 
@@ -76,7 +76,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_byteBuffer_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("key".getBytes(), "value".getBytes());
 		}
 
@@ -100,7 +100,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_byteBuffer_returnsNotFound_whenKeyAbsent(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("seed".getBytes(), "val".getBytes());
 		}
 
@@ -120,7 +120,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_byteBuffer_returnsNotEnoughCapacity_whenValueDoesNotFit(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("key".getBytes(), "value".getBytes());
 		}
 
@@ -145,7 +145,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_memorySegment_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("key".getBytes(), "value".getBytes());
 		}
 
@@ -171,7 +171,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_columnFamily_returnsStoredValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 			rw.put(cf, "k".getBytes(), "v".getBytes());
 			cf.close();
@@ -196,7 +196,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_columnFamily_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 			rw.put(cf, "k".getBytes(), "v".getBytes());
 			cf.close();
@@ -222,7 +222,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_columnFamily_byteBuffer_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 			rw.put(cf, "key".getBytes(), "value".getBytes());
 			cf.close();
@@ -250,7 +250,7 @@ class ReadOnlyDBTest {
 	@Test
 	void get_columnFamily_memorySegment_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 			rw.put(cf, "key".getBytes(), "value".getBytes());
 			cf.close();
@@ -284,7 +284,7 @@ class ReadOnlyDBTest {
 	@Test
 	void newIterator_columnFamily_scansKeys(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 			rw.put(cf, "a".getBytes(), "1".getBytes());
 			rw.put(cf, "b".getBytes(), "2".getBytes());
@@ -313,7 +313,7 @@ class ReadOnlyDBTest {
 	@Test
 	void newIterator_columnFamily_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 			rw.put(cf, "x".getBytes(), "y".getBytes());
 			cf.close();
@@ -346,7 +346,7 @@ class ReadOnlyDBTest {
 	@Test
 	void getProperty_columnFamily_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 			rw.put(cf, "k".getBytes(), "v".getBytes());
 			cf.close();
@@ -371,7 +371,7 @@ class ReadOnlyDBTest {
 	@Test
 	void getLongProperty_columnFamily_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 			rw.put(cf, "k".getBytes(), "v".getBytes());
 			cf.close();
@@ -400,7 +400,7 @@ class ReadOnlyDBTest {
 	@Test
 	void newIterator_iteratesData(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("a".getBytes(), "1".getBytes());
 			rw.put("b".getBytes(), "2".getBytes());
 		}
@@ -424,7 +424,7 @@ class ReadOnlyDBTest {
 	@Test
 	void newIterator_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("x".getBytes(), "y".getBytes());
 		}
 
@@ -449,7 +449,7 @@ class ReadOnlyDBTest {
 	@Test
 	void getSnapshot_allowsSnapshotRead(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("k".getBytes(), "v".getBytes());
 		}
 
@@ -472,7 +472,7 @@ class ReadOnlyDBTest {
 	@Test
 	void getLongProperty_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("k".getBytes(), "v".getBytes());
 		}
 
@@ -489,7 +489,7 @@ class ReadOnlyDBTest {
 	@Test
 	void getProperty_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("k".getBytes(), "v".getBytes());
 		}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
@@ -179,7 +179,7 @@ class ReadOnlyDBTest {
 
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var ro = RocksDB.openReadOnlyWithColumnFamilies(opts, dir,
+		     var ro = RocksDB.openReadOnly(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
 				     handles)) {
 			var cf = handles.get(1);
@@ -204,7 +204,7 @@ class ReadOnlyDBTest {
 
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var ro = RocksDB.openReadOnlyWithColumnFamilies(opts, dir,
+		     var ro = RocksDB.openReadOnly(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
 				     handles);
 		     var readOpts = ReadOptions.newReadOptions()) {
@@ -230,7 +230,7 @@ class ReadOnlyDBTest {
 
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var ro = RocksDB.openReadOnlyWithColumnFamilies(opts, dir,
+		     var ro = RocksDB.openReadOnly(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
 				     handles)) {
 			var cf = handles.get(1);
@@ -258,7 +258,7 @@ class ReadOnlyDBTest {
 
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var ro = RocksDB.openReadOnlyWithColumnFamilies(opts, dir,
+		     var ro = RocksDB.openReadOnly(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
 				     handles);
 		     Arena arena = Arena.ofConfined()) {
@@ -293,7 +293,7 @@ class ReadOnlyDBTest {
 
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var ro = RocksDB.openReadOnlyWithColumnFamilies(opts, dir,
+		     var ro = RocksDB.openReadOnly(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
 				     handles)) {
 			var cf = handles.get(1);
@@ -321,7 +321,7 @@ class ReadOnlyDBTest {
 
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var ro = RocksDB.openReadOnlyWithColumnFamilies(opts, dir,
+		     var ro = RocksDB.openReadOnly(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
 				     handles);
 		     var readOpts = ReadOptions.newReadOptions()) {
@@ -354,7 +354,7 @@ class ReadOnlyDBTest {
 
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var ro = RocksDB.openReadOnlyWithColumnFamilies(opts, dir,
+		     var ro = RocksDB.openReadOnly(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
 				     handles)) {
 			var cf = handles.get(1);
@@ -379,7 +379,7 @@ class ReadOnlyDBTest {
 
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var ro = RocksDB.openReadOnlyWithColumnFamilies(opts, dir,
+		     var ro = RocksDB.openReadOnly(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
 				     handles)) {
 			var cf = handles.get(1);

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
@@ -502,4 +502,51 @@ class ReadOnlyDBTest {
 			assertThat(result).isPresent();
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// openReadOnly — errorIfWalFileExists overload
+	// -----------------------------------------------------------------------
+
+	@Test
+	void openReadOnly_errorIfWalFileExistsFalse_allowsOpenWithWal(@TempDir Path dir) {
+		// Given
+		try (var rw = RocksDB.openReadWrite(dir)) {
+			rw.put("k".getBytes(), "v".getBytes());
+		}
+
+		// When
+		try (var opts = Options.newOptions();
+		     var ro = RocksDB.openReadOnly(opts, dir, false)) {
+			var result = ro.get("k".getBytes());
+
+			// Then
+			assertThat(result).isEqualTo("v".getBytes());
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// openReadOnly — column families with errorIfWalFileExists overload
+	// -----------------------------------------------------------------------
+
+	@Test
+	void openReadOnly_columnFamilies_errorIfWalFileExistsFalse(@TempDir Path dir) {
+		// Given — create a DB with a custom CF, then close it
+		try (var rw = RocksDB.openReadWrite(dir);
+		     var cf = rw.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+			rw.put(cf, "k".getBytes(), "v".getBytes());
+		}
+
+		// When — reopen read-only with both CFs via the 5-arg factory overload
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var opts = Options.newOptions();
+		     var ro = RocksDB.openReadOnly(opts, dir,
+				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
+				     handles, false)) {
+			var cf = handles.get(1);
+
+			// Then
+			assertThat(ro.get(cf, "k".getBytes())).isEqualTo("v".getBytes());
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RocksDBInvariantTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RocksDBInvariantTest.java
@@ -97,7 +97,7 @@ class RocksDBInvariantTest {
 	@MethodSource("cases")
 	void put_thenGet_roundTripsUnchanged(Case testCase, @TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put(testCase.key(), testCase.value());
 
 			// When
@@ -112,7 +112,7 @@ class RocksDBInvariantTest {
 	@MethodSource("cases")
 	void put_thenGet_roundTripsUnchanged_afterFlush(Case testCase, @TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put(testCase.key(), testCase.value());
 			flush(db);
 
@@ -128,7 +128,7 @@ class RocksDBInvariantTest {
 	@MethodSource("cases")
 	void get_returnsNull_afterDelete(Case testCase, @TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put(testCase.key(), testCase.value());
 			db.delete(testCase.key());
 
@@ -145,7 +145,7 @@ class RocksDBInvariantTest {
 	void put_overwritesExistingKey(Case testCase, @TempDir Path dir) {
 		// Given
 		byte[] replacement = filled(testCase.value().length + 1, 'z');
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put(testCase.key(), testCase.value());
 
 			// When
@@ -165,7 +165,7 @@ class RocksDBInvariantTest {
 	@MethodSource("cases")
 	void putSegment_thenGetSegment_roundTripsUnchanged(Case testCase, @TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir); Arena arena = Arena.ofConfined()) {
+		try (var db = RocksDB.openReadWrite(dir); Arena arena = Arena.ofConfined()) {
 			MemorySegment key = arena.allocateFrom(ValueLayout.JAVA_BYTE, testCase.key());
 			MemorySegment value = arena.allocateFrom(ValueLayout.JAVA_BYTE, testCase.value());
 			db.put(key, value);
@@ -207,7 +207,7 @@ class RocksDBInvariantTest {
 		var expected = new TreeSet<byte[]>(Arrays::compareUnsigned);
 		expected.addAll(keys);
 
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			for (byte[] key : keys) {
 				db.put(key, "v".getBytes());
 			}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RocksDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RocksDBTest.java
@@ -17,7 +17,7 @@ class RocksDBTest {
 	@Test
 	void get_returnsStoredValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("hello".getBytes(), "world".getBytes());
 
 			// When
@@ -31,7 +31,7 @@ class RocksDBTest {
 	@Test
 	void get_returnsNull_whenKeyAbsent(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 
 			// When
 			var result = db.get("nonexistent".getBytes());
@@ -44,7 +44,7 @@ class RocksDBTest {
 	@Test
 	void get_returnsNull_afterDelete(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -58,7 +58,7 @@ class RocksDBTest {
 	@Test
 	void put_overwritesExistingKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v1".getBytes());
 
 			// When
@@ -75,7 +75,7 @@ class RocksDBTest {
 		var key = new byte[]{0x00, 0x01, (byte) 0xFF};
 		var value = new byte[]{0x42, 0x00, 0x43};
 
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			// When
 			db.put(key, value);
 
@@ -91,7 +91,7 @@ class RocksDBTest {
 	@Test
 	void write_commitsBatchedPuts(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var batch = WriteBatch.create()) {
 
 			batch.put("k1".getBytes(), "v1".getBytes());
@@ -111,7 +111,7 @@ class RocksDBTest {
 	@Test
 	void write_commitsBatchedDeletes(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var batch = WriteBatch.create()) {
 
 			db.put("k1".getBytes(), "v1".getBytes());
@@ -131,7 +131,7 @@ class RocksDBTest {
 	@Test
 	void writeBatch_countReflectsQueuedOperations(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var batch = WriteBatch.create()) {
 
 			for (int i = 0; i < 50; i++) {
@@ -165,7 +165,7 @@ class RocksDBTest {
 
 		try (var opts = Options.newOptions().setCreateIfMissing(false)) {
 			// When
-			var thrown = assertThatThrownBy(() -> RocksDB.open(opts, dbPath));
+			var thrown = assertThatThrownBy(() -> RocksDB.openReadWrite(opts, dbPath));
 
 			// Then
 			thrown.isInstanceOf(RocksDBException.class);
@@ -178,7 +178,7 @@ class RocksDBTest {
 		var dbPath = dir.resolve("newdb");
 
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbPath)) {
+		     var db = RocksDB.openReadWrite(opts, dbPath)) {
 
 			// When
 			db.put("k".getBytes(), "v".getBytes());
@@ -213,7 +213,7 @@ class RocksDBTest {
 	@Test
 	void openReadOnly_allowsReads(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("k".getBytes(), "v".getBytes());
 		}
 
@@ -229,7 +229,7 @@ class RocksDBTest {
 	@Test
 	void openReadOnly_withExplicitOptions(@TempDir Path dir) {
 		// Given
-		try (var rw = RocksDB.open(dir)) {
+		try (var rw = RocksDB.openReadWrite(dir)) {
 			rw.put("hello".getBytes(), "world".getBytes());
 		}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RocksIteratorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RocksIteratorTest.java
@@ -19,7 +19,7 @@ class RocksIteratorTest {
 	@Test
 	void seekToFirst_iteratesAllKeysInOrder(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("b".getBytes(), "2".getBytes());
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("c".getBytes(), "3".getBytes());
@@ -41,7 +41,7 @@ class RocksIteratorTest {
 	@Test
 	void seekToLast_iteratesAllKeysInReverseOrder(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 			db.put("c".getBytes(), "3".getBytes());
@@ -67,7 +67,7 @@ class RocksIteratorTest {
 	@Test
 	void seek_positionsAtFirstKeyGreaterOrEqual(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("c".getBytes(), "3".getBytes());
 			db.put("e".getBytes(), "5".getBytes());
@@ -87,7 +87,7 @@ class RocksIteratorTest {
 	@Test
 	void seek_exactMatch(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -105,7 +105,7 @@ class RocksIteratorTest {
 	@Test
 	void seek_pastLastKey_isInvalid(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 
 			// When
@@ -121,7 +121,7 @@ class RocksIteratorTest {
 	@Test
 	void seekForPrev_positionsAtLastKeyLessOrEqual(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("c".getBytes(), "3".getBytes());
 			db.put("e".getBytes(), "5".getBytes());
@@ -144,7 +144,7 @@ class RocksIteratorTest {
 	@Test
 	void seek_withDirectByteBuffer(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -168,7 +168,7 @@ class RocksIteratorTest {
 	@Test
 	void key_value_byteBuffer_variant(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("hello".getBytes(), "world".getBytes());
 
 			try (RocksIterator it = db.newIterator()) {
@@ -201,7 +201,7 @@ class RocksIteratorTest {
 	@Test
 	void key_value_byteBuffer_returnsNotEnoughCapacity_whenTooSmall(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("hello".getBytes(), "world".getBytes());
 
 			try (RocksIterator it = db.newIterator()) {
@@ -233,7 +233,7 @@ class RocksIteratorTest {
 	@Test
 	void keySegment_valueSegment_zeroCopy(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			try (RocksIterator it = db.newIterator()) {
@@ -260,7 +260,7 @@ class RocksIteratorTest {
 	@Test
 	void seekToFirst_onEmptyDb_isInvalid(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 
 			// When
 			try (RocksIterator it = db.newIterator()) {
@@ -280,7 +280,7 @@ class RocksIteratorTest {
 	@Test
 	void newIterator_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     var readOptions = ReadOptions.newReadOptions()) {
 			db.put("x".getBytes(), "y".getBytes());
 
@@ -303,7 +303,7 @@ class RocksIteratorTest {
 	@Test
 	void error_returnsEmptyWhenNoError(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			try (RocksIterator it = db.newIterator()) {
@@ -321,7 +321,7 @@ class RocksIteratorTest {
 	@Test
 	void error_returnsEmptyAfterFullIteration(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -346,7 +346,7 @@ class RocksIteratorTest {
 	@Test
 	void refresh_notCalled_doesNotSeeWritesMadeAfterIteratorCreation(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 
 			try (RocksIterator it = db.newIterator()) {
@@ -364,7 +364,7 @@ class RocksIteratorTest {
 	@Test
 	void refresh_seesWritesMadeAfterIteratorCreation(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 
 			try (RocksIterator it = db.newIterator()) {
@@ -385,7 +385,7 @@ class RocksIteratorTest {
 	@Test
 	void refresh_seesDeletesMadeAfterIteratorCreation(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -407,7 +407,7 @@ class RocksIteratorTest {
 		// Given — matches Iterator::Refresh()'s documented contract (iterator_base.h):
 		// the iterator is invalidated by the call itself, independent of whether the DB
 		// changed or whether the previously-current key still exists.
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			try (RocksIterator it = db.newIterator()) {

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
@@ -20,7 +20,7 @@ class SecondaryDBTest {
 	void open_closesCleanly(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given — primary must exist before opening a secondary
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir)) {
+		     var primary = RocksDB.openReadWrite(opts, primaryDir)) {
 			primary.put("seed".getBytes(), "value".getBytes());
 		}
 
@@ -41,7 +41,7 @@ class SecondaryDBTest {
 	void tryCatchUpWithPrimary_doesNotThrow(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir)) {
+		     var primary = RocksDB.openReadWrite(opts, primaryDir)) {
 			primary.put("k".getBytes(), "v".getBytes());
 		}
 
@@ -60,7 +60,7 @@ class SecondaryDBTest {
 			@TempDir Path primaryDir, @TempDir Path secondaryDir) throws Exception {
 		// Given — write initial data to primary and flush so secondary can read it
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			primary.put("k1".getBytes(), "v1".getBytes());
 			primary.flush(fo); // flush to SST so secondary can find it
@@ -75,7 +75,7 @@ class SecondaryDBTest {
 
 			// When — primary writes more data and flushes
 			try (var popts = Options.newOptions();
-			     var primary = RocksDB.open(popts, primaryDir);
+			     var primary = RocksDB.openReadWrite(popts, primaryDir);
 			     var fo = FlushOptions.newFlushOptions()) {
 				primary.put("k2".getBytes(), "v2".getBytes());
 				primary.flush(fo);
@@ -95,7 +95,7 @@ class SecondaryDBTest {
 	void get_returnsNull_whenKeyMissing(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir)) {
+		     var primary = RocksDB.openReadWrite(opts, primaryDir)) {
 			primary.put("seed".getBytes(), "x".getBytes());
 		}
 
@@ -115,7 +115,7 @@ class SecondaryDBTest {
 	void get_withReadOptions(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given — write and flush
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			primary.put("k".getBytes(), "v".getBytes());
 			primary.flush(fo);
@@ -138,7 +138,7 @@ class SecondaryDBTest {
 	void get_byteBuffer_returnsValue(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			primary.put("k".getBytes(), "v".getBytes());
 			primary.flush(fo);
@@ -168,7 +168,7 @@ class SecondaryDBTest {
 	void get_memorySegment_returnsValue(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			primary.put("k".getBytes(), "v".getBytes());
 			primary.flush(fo);
@@ -199,7 +199,7 @@ class SecondaryDBTest {
 	void newIterator_iteratesData(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			primary.put("a".getBytes(), "1".getBytes());
 			primary.put("b".getBytes(), "2".getBytes());
@@ -228,7 +228,7 @@ class SecondaryDBTest {
 	void newIterator_withReadOptions(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			primary.put("x".getBytes(), "y".getBytes());
 			primary.flush(fo);
@@ -255,7 +255,7 @@ class SecondaryDBTest {
 	void getSnapshot_allowsSnapshotRead(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given — write and flush so secondary can catch up
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			primary.put("k".getBytes(), "v".getBytes());
 			primary.flush(fo);
@@ -283,7 +283,7 @@ class SecondaryDBTest {
 	void getLongProperty_returnsValue(@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var primary = RocksDB.open(opts, primaryDir);
+		     var primary = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			primary.put("k".getBytes(), "v".getBytes());
 			primary.flush(fo);

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SnapshotTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SnapshotTest.java
@@ -16,7 +16,7 @@ class SnapshotTest {
 	@Test
 	void snapshot_readsDoNotSeeWritesAfterSnapshot(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("key".getBytes(), "before".getBytes());
 
 			// When — take snapshot, then overwrite the key
@@ -36,7 +36,7 @@ class SnapshotTest {
 	@Test
 	void snapshot_readsDoNotSeeDeletesAfterSnapshot(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("key".getBytes(), "value".getBytes());
 
 			// When
@@ -55,7 +55,7 @@ class SnapshotTest {
 	@Test
 	void snapshot_sequenceNumberIsNonNegative(@TempDir Path dir) {
 		// Given / When
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 			try (Snapshot snap = db.getSnapshot()) {
 
@@ -68,7 +68,7 @@ class SnapshotTest {
 	@Test
 	void snapshot_sequenceNumberIncreasesWithWrites(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			try (Snapshot snap1 = db.getSnapshot()) {
 				db.put("k".getBytes(), "v".getBytes());
 				try (Snapshot snap2 = db.getSnapshot()) {
@@ -87,7 +87,7 @@ class SnapshotTest {
 	@Test
 	void setSnapshot_null_clearsSnapshot(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir);
+		try (var db = RocksDB.openReadWrite(dir);
 		     ReadOptions ro = ReadOptions.newReadOptions()) {
 			db.put("key".getBytes(), "v1".getBytes());
 
@@ -114,7 +114,7 @@ class SnapshotTest {
 	@Test
 	void snapshot_iteratorDoesNotSeeWritesAfterSnapshot(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -169,7 +169,7 @@ class SnapshotTest {
 	@Test
 	void snapshot_double_close(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			final Snapshot snap = db.getSnapshot();
 			snap.close();
 			// normally this would trigger a JVM crash

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SstFileManagerTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SstFileManagerTest.java
@@ -15,7 +15,7 @@ class SstFileManagerTest {
 		try (var env = Env.defaultEnv();
 		     var sut = SstFileManager.create(env);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
 			try (var flushOptions = FlushOptions.newFlushOptions().setWait(true)) {
@@ -38,7 +38,7 @@ class SstFileManagerTest {
 				     .setMaxAllowedSpaceUsage(MemorySize.ofGB(10))
 				     .setCompactionBufferSize(MemorySize.ofMB(512));
 		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("k".getBytes(), "v".getBytes());
@@ -55,7 +55,7 @@ class SstFileManagerTest {
 		try (var env = Env.defaultEnv();
 		     var sut = SstFileManager.create(env).setMaxAllowedSpaceUsage(MemorySize.ZERO);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("k".getBytes(), "v".getBytes());
@@ -75,7 +75,7 @@ class SstFileManagerTest {
 		     var sut = SstFileManager.create(env)
 				     .setDeleteRateBytesPerSecond(MemorySize.ofMB(64).toBytes());
 		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			var result = sut.getDeleteRateBytesPerSecond();
@@ -91,7 +91,7 @@ class SstFileManagerTest {
 		try (var env = Env.defaultEnv();
 		     var sut = SstFileManager.create(env).setMaxTrashDbRatio(0.5);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			var result = sut.getMaxTrashDbRatio();
@@ -107,7 +107,7 @@ class SstFileManagerTest {
 		try (var env = Env.defaultEnv();
 		     var sut = SstFileManager.create(env);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setSstFileManager(sut);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -130,7 +130,7 @@ class SstFileManagerTest {
 			sut.close();
 
 			// Then — Options (and the underlying shared_ptr) is still valid
-			try (var db = RocksDB.open(opts, dir)) {
+			try (var db = RocksDB.openReadWrite(opts, dir)) {
 				db.put("k".getBytes(), "v".getBytes());
 				assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
 			}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SstFileWriterTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SstFileWriterTest.java
@@ -31,7 +31,7 @@ class SstFileWriterTest {
 		}
 
 		// When
-		try (var db = RocksDB.open(dbPath)) {
+		try (var db = RocksDB.openReadWrite(dbPath)) {
 			db.ingestExternalFile(sstPath);
 
 			// Then
@@ -62,7 +62,7 @@ class SstFileWriterTest {
 		}
 
 		// When
-		try (var db = RocksDB.open(dbPath)) {
+		try (var db = RocksDB.openReadWrite(dbPath)) {
 			db.ingestExternalFile(List.of(sst1, sst2));
 
 			// Then
@@ -87,7 +87,7 @@ class SstFileWriterTest {
 		}
 
 		// When
-		try (var db = RocksDB.open(dbPath);
+		try (var db = RocksDB.openReadWrite(dbPath);
 		     var ingestOpts = IngestExternalFileOptions.newIngestExternalFileOptions().setMoveFiles(true)) {
 			db.ingestExternalFile(sstPath, ingestOpts);
 
@@ -110,7 +110,7 @@ class SstFileWriterTest {
 		}
 
 		// When
-		try (var db = RocksDB.open(dbPath)) {
+		try (var db = RocksDB.openReadWrite(dbPath)) {
 			db.put("existing".getBytes(), "original".getBytes());
 			db.ingestExternalFile(sstPath);
 
@@ -172,7 +172,7 @@ class SstFileWriterTest {
 	@Test
 	void ingest_emptyFileList_isNoOp(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			// When
 			db.ingestExternalFile(List.of());
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/StatisticsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/StatisticsTest.java
@@ -21,7 +21,7 @@ class StatisticsTest {
 
 			assertThat(options.getStatisticsLevel()).isEqualTo(StatsLevel.ALL);
 
-			try (ReadWriteDB db = RocksDB.open(options, tempDir)) {
+			try (ReadWriteDB db = RocksDB.openReadWrite(options, tempDir)) {
 				db.put("key1".getBytes(), "value1".getBytes());
 				db.get("key1".getBytes());
 				db.get("key2".getBytes()); // miss

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TableOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TableOptionsTest.java
@@ -18,7 +18,7 @@ class TableOptionsTest {
 		// Given
 		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig();
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -35,7 +35,7 @@ class TableOptionsTest {
 		// Given
 		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig().setBlockSize(MemorySize.ofKB(16));
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("key".getBytes(), "value".getBytes());
 
@@ -57,7 +57,7 @@ class TableOptionsTest {
 		try (var filter = FilterPolicy.newBloom(10);
 		     var tbl = BlockBasedTableOptions.newBlockBasedConfig().setFilterPolicy(filter);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("bloom-key".getBytes(), "bloom-value".getBytes());
 
@@ -81,7 +81,7 @@ class TableOptionsTest {
 		try (var filter = FilterPolicy.newRibbon(10);
 		     var tbl = BlockBasedTableOptions.newBlockBasedConfig().setFilterPolicy(filter);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("ribbon-key".getBytes(), "ribbon-value".getBytes());
 
@@ -109,7 +109,7 @@ class TableOptionsTest {
 					 .setCacheIndexAndFilterBlocks(true)
 					 .setFilterPolicy(filter);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			for (int i = 0; i < 100; i++) {
 				db.put(("key-" + i).getBytes(), ("val-" + i).getBytes());
@@ -130,7 +130,7 @@ class TableOptionsTest {
 		// Given
 		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig().setNoBlockCache(true);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -155,7 +155,7 @@ class TableOptionsTest {
 					 .setPartitionFilters(true)
 					 .setFilterPolicy(filter);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -176,7 +176,7 @@ class TableOptionsTest {
 		// Given
 		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig().setFormatVersion(5);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TickerTypeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TickerTypeTest.java
@@ -38,7 +38,7 @@ class TickerTypeTest {
 				.setCreateIfMissing(true)
 				.enableStatistics()
 				.setStatisticsLevel(StatsLevel.ALL);
-		     ReadWriteDB db = RocksDB.open(options, dir)) {
+		     ReadWriteDB db = RocksDB.openReadWrite(options, dir)) {
 
 			db.put("key".getBytes(), "value".getBytes());
 			db.get("key".getBytes());
@@ -60,7 +60,7 @@ class TickerTypeTest {
 		try (Options options = Options.newOptions()
 				.setCreateIfMissing(true)
 				.enableStatistics();
-		     ReadWriteDB db = RocksDB.open(options, dir)) {
+		     ReadWriteDB db = RocksDB.openReadWrite(options, dir)) {
 
 			db.put("key".getBytes(), "value".getBytes());
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
@@ -658,6 +658,33 @@ class TransactionDBTest {
 	}
 
 	// -----------------------------------------------------------------------
+	// openTransaction — column families (opened at startup, not created later)
+	// -----------------------------------------------------------------------
+
+	@Test
+	void openTransaction_withColumnFamilies_reopensExistingFamily(@TempDir Path dir) {
+		// Given — create a DB with a custom CF, then close it
+		try (var db = openDb(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+			db.put(cf, "k".getBytes(), "v".getBytes());
+		}
+
+		// When — reopen with both CFs via the CF-aware factory overload
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var opts = Options.newOptions();
+		     var txnDbOpts = TransactionDBOptions.newTransactionDBOptions();
+		     var db = RocksDB.openTransaction(opts, txnDbOpts, dir,
+				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
+				     handles)) {
+			var cf = handles.get(1);
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isEqualTo("v".getBytes());
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	// -----------------------------------------------------------------------
 	// TransactionOptions
 	// -----------------------------------------------------------------------
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
@@ -1038,4 +1038,54 @@ class TtlDBTest {
 			assertThat(result).isPresent();
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// openTtl — column families with per-CF TTL
+	// -----------------------------------------------------------------------
+
+	@Test
+	void openTtl_withColumnFamilies_reopensWithPerCfTtl(@TempDir Path dir) {
+		// Given — create a DB with a custom CF, then close it
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+			db.put(cf, "k".getBytes(), "v".getBytes());
+		}
+
+		// When — reopen with both CFs, each given its own TTL
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var opts = Options.newOptions();
+		     var db = RocksDB.openTtl(opts, dir,
+				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
+				     List.of(Duration.ofSeconds(60), Duration.ZERO),
+				     handles)) {
+			var cf = handles.get(1);
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isEqualTo("v".getBytes());
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
+
+	@Test
+	void openTtl_withColumnFamilies_populatesHandlesInDescriptorOrder(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
+			db.createColumnFamily(ColumnFamilyDescriptor.of("cf1")).close();
+		}
+
+		// When
+		List<ColumnFamilyHandle> handles = new ArrayList<>();
+		try (var opts = Options.newOptions();
+		     var db = RocksDB.openTtl(opts, dir,
+				     List.of(ColumnFamilyDescriptor.of("default"), ColumnFamilyDescriptor.of("cf1")),
+				     List.of(Duration.ZERO, Duration.ZERO),
+				     handles)) {
+
+			// Then
+			assertThat(handles).hasSize(2);
+			assertThat(handles.get(0).getName()).isEqualTo("default");
+			assertThat(handles.get(1).getName()).isEqualTo("cf1");
+			handles.forEach(ColumnFamilyHandle::close);
+		}
+	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
@@ -21,9 +21,9 @@ class TtlDBTest {
 	// -----------------------------------------------------------------------
 
 	@Test
-	void openWithTtl_storesAndRetrievesValues(@TempDir Path dir) {
+	void openTtl_storesAndRetrievesValues(@TempDir Path dir) {
 		// Given / When
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// Then — key is readable immediately (TTL not yet elapsed)
@@ -32,10 +32,10 @@ class TtlDBTest {
 	}
 
 	@Test
-	void openWithTtl_withExplicitOptions(@TempDir Path dir) {
+	void openTtl_withExplicitOptions(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofMinutes(1))) {
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofMinutes(1))) {
 
 			db.put("key".getBytes(), "value".getBytes());
 
@@ -48,9 +48,9 @@ class TtlDBTest {
 	}
 
 	@Test
-	void openWithTtl_zeroTtl_disablesExpiry(@TempDir Path dir) {
+	void openTtl_zeroTtl_disablesExpiry(@TempDir Path dir) {
 		// Given — TTL=0 means no expiry
-		try (var db = RocksDB.openWithTtl(dir, Duration.ZERO)) {
+		try (var db = RocksDB.openTtl(dir, Duration.ZERO)) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// Then — key survives indefinitely
@@ -63,9 +63,9 @@ class TtlDBTest {
 	// -----------------------------------------------------------------------
 
 	@Test
-	void openWithTtl_supportsDelete(@TempDir Path dir) {
+	void openTtl_supportsDelete(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -77,9 +77,9 @@ class TtlDBTest {
 	}
 
 	@Test
-	void openWithTtl_supportsWriteBatch(@TempDir Path dir) {
+	void openTtl_supportsWriteBatch(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var batch = WriteBatch.create()) {
 
 			batch.put("k1".getBytes(), "v1".getBytes());
@@ -95,9 +95,9 @@ class TtlDBTest {
 	}
 
 	@Test
-	void openWithTtl_supportsIterator(@TempDir Path dir) {
+	void openTtl_supportsIterator(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -113,14 +113,14 @@ class TtlDBTest {
 	}
 
 	@Test
-	void openWithTtl_surviveReopenWithSameTtl(@TempDir Path dir) {
+	void openTtl_surviveReopenWithSameTtl(@TempDir Path dir) {
 		// Given — write, close, reopen, verify data persists
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("persistent".getBytes(), "yes".getBytes());
 		}
 
 		// When
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 
 			// Then
 			assertThat(db.get("persistent".getBytes())).isEqualTo("yes".getBytes());
@@ -130,7 +130,7 @@ class TtlDBTest {
 	@Test
 	void getTtl_returnsConfiguredDuration(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 
 			// When
 			var ttl = db.getTtl();
@@ -147,7 +147,7 @@ class TtlDBTest {
 	@Test
 	void put_withArena_isVisibleViaGet(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     Arena arena = Arena.ofConfined()) {
 
 			// When
@@ -161,7 +161,7 @@ class TtlDBTest {
 	@Test
 	void put_byteBuffer_isVisibleViaGet(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			var key = ByteBuffer.allocateDirect(3);
 			key.put("key".getBytes()).flip();
 			var value = ByteBuffer.allocateDirect(5);
@@ -178,7 +178,7 @@ class TtlDBTest {
 	@Test
 	void put_memorySegment_isVisibleViaGet(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     Arena arena = Arena.ofConfined()) {
 			var key = arena.allocateFrom("seg-k");
 			var value = arena.allocateFrom("seg-v");
@@ -194,7 +194,7 @@ class TtlDBTest {
 	@Test
 	void put_arena_memorySegment_isVisibleViaGet(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     Arena arena = Arena.ofConfined()) {
 			var key = arena.allocateFrom("seg-k2");
 			var value = arena.allocateFrom("seg-v2");
@@ -214,7 +214,7 @@ class TtlDBTest {
 	@Test
 	void get_withReadOptions_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var ro = ReadOptions.newReadOptions()) {
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -229,7 +229,7 @@ class TtlDBTest {
 	@Test
 	void get_byteBuffer_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("key".getBytes(), "value".getBytes());
 			var key = ByteBuffer.allocateDirect(3);
 			key.put("key".getBytes()).flip();
@@ -246,7 +246,7 @@ class TtlDBTest {
 	@Test
 	void get_memorySegment_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     Arena arena = Arena.ofConfined()) {
 			db.put("k".getBytes(), "v".getBytes());
 			var key = arena.allocateFrom("k");
@@ -268,7 +268,7 @@ class TtlDBTest {
 	@Test
 	void delete_byteBuffer_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v".getBytes());
 			var key = ByteBuffer.allocateDirect(1);
 			key.put("k".getBytes()).flip();
@@ -284,7 +284,7 @@ class TtlDBTest {
 	@Test
 	void delete_memorySegment_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     Arena arena = Arena.ofConfined()) {
 			db.put("k".getBytes(), "v".getBytes());
 			var key = arena.allocateFrom("k");
@@ -304,7 +304,7 @@ class TtlDBTest {
 	@Test
 	void deleteRange_removesKeyRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 			db.put("c".getBytes(), "3".getBytes());
@@ -322,7 +322,7 @@ class TtlDBTest {
 	@Test
 	void deleteRange_byteBuffer_removesKeyRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 			var start = ByteBuffer.allocateDirect(1).put((byte) 'a').flip();
@@ -340,7 +340,7 @@ class TtlDBTest {
 	@Test
 	void deleteRange_memorySegment_removesKeyRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     Arena arena = Arena.ofConfined()) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
@@ -363,7 +363,7 @@ class TtlDBTest {
 	@Test
 	void write_withArena_appliesBatchAtomically(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var batch = WriteBatch.create();
 		     Arena arena = Arena.ofConfined()) {
 			batch.put("k1".getBytes(), "v1".getBytes());
@@ -385,7 +385,7 @@ class TtlDBTest {
 	@Test
 	void getSnapshot_isolatesReads(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v1".getBytes());
 
 			// When — take snapshot, then overwrite
@@ -409,7 +409,7 @@ class TtlDBTest {
 	@Test
 	void newIterator_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var ro = ReadOptions.newReadOptions()) {
 			db.put("x".getBytes(), "y".getBytes());
 
@@ -431,7 +431,7 @@ class TtlDBTest {
 	@Test
 	void flush_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var fo = FlushOptions.newFlushOptions().setWait(true)) {
 			db.put("k".getBytes(), "v".getBytes());
 
@@ -445,7 +445,7 @@ class TtlDBTest {
 	@Test
 	void flushWal_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -462,7 +462,7 @@ class TtlDBTest {
 	@Test
 	void getProperty_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -476,7 +476,7 @@ class TtlDBTest {
 	@Test
 	void getLongProperty_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When
@@ -494,7 +494,7 @@ class TtlDBTest {
 	@Test
 	void compactRange_noArgs_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 
@@ -510,7 +510,7 @@ class TtlDBTest {
 	@Test
 	void compactRange_byteArray_fullRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("z".getBytes(), "2".getBytes());
 
@@ -526,7 +526,7 @@ class TtlDBTest {
 	@Test
 	void compactRange_byteBuffer(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 			var start = ByteBuffer.allocateDirect(1).put((byte) 'a').flip();
@@ -543,7 +543,7 @@ class TtlDBTest {
 	@Test
 	void compactRange_memorySegment(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     Arena arena = Arena.ofConfined()) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
@@ -561,7 +561,7 @@ class TtlDBTest {
 	@Test
 	void compactRange_withOptions_fullRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var compact = CompactOptions.newCompactOptions()
 					 .setExclusiveManualCompaction(false)
 					 .setBottommostLevelCompaction(true)) {
@@ -580,7 +580,7 @@ class TtlDBTest {
 	@Test
 	void suggestCompactRange_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("z".getBytes(), "2".getBytes());
 
@@ -598,7 +598,7 @@ class TtlDBTest {
 	@Test
 	void disableAndEnableFileDeletions_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			db.put("k".getBytes(), "v".getBytes());
 
 			// When — disable, do some work, re-enable
@@ -633,7 +633,7 @@ class TtlDBTest {
 		}
 
 		// When
-		try (var db = RocksDB.openWithTtl(dbPath, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dbPath, Duration.ofSeconds(60))) {
 			db.ingestExternalFile(sstPath);
 
 			// Then — no exception means the ingest call itself succeeded
@@ -654,7 +654,7 @@ class TtlDBTest {
 		}
 
 		// When
-		try (var db = RocksDB.openWithTtl(dbPath, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dbPath, Duration.ofSeconds(60));
 		     var ingestOpts = IngestExternalFileOptions.newIngestExternalFileOptions().setMoveFiles(true)) {
 			db.ingestExternalFile(sstPath, ingestOpts);
 
@@ -665,7 +665,7 @@ class TtlDBTest {
 	@Test
 	void ingestExternalFile_emptyFileList_isNoOp(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var ingestOpts = IngestExternalFileOptions.newIngestExternalFileOptions()) {
 
 			// When
@@ -682,7 +682,7 @@ class TtlDBTest {
 	@Test
 	void createColumnFamily_canPutAndGetInNewFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 
 			// When
@@ -696,7 +696,7 @@ class TtlDBTest {
 	@Test
 	void dropColumnFamily_removesFamily(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60))) {
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
 			var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("to-drop"));
 			db.put(cf, "k".getBytes(), "v".getBytes());
 
@@ -715,7 +715,7 @@ class TtlDBTest {
 	@Test
 	void get_columnFamily_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     var ro = ReadOptions.newReadOptions()) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
@@ -731,7 +731,7 @@ class TtlDBTest {
 	@Test
 	void put_get_columnFamily_byteBuffer(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
 			var value = ByteBuffer.allocateDirect(1).put((byte) 'v').flip();
@@ -750,7 +750,7 @@ class TtlDBTest {
 	@Test
 	void put_get_columnFamily_memorySegment(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     Arena arena = Arena.ofConfined()) {
 			var key = arena.allocateFrom("seg-k");
@@ -771,7 +771,7 @@ class TtlDBTest {
 	@Test
 	void delete_columnFamily_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 
@@ -786,7 +786,7 @@ class TtlDBTest {
 	@Test
 	void delete_columnFamily_byteBuffer_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
@@ -802,7 +802,7 @@ class TtlDBTest {
 	@Test
 	void delete_columnFamily_memorySegment_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     Arena arena = Arena.ofConfined()) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
@@ -823,7 +823,7 @@ class TtlDBTest {
 	@Test
 	void deleteRange_columnFamily_removesKeyRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "a".getBytes(), "1".getBytes());
 			db.put(cf, "b".getBytes(), "2".getBytes());
@@ -842,7 +842,7 @@ class TtlDBTest {
 	@Test
 	void deleteRange_columnFamily_byteBuffer_removesKeyRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "a".getBytes(), "1".getBytes());
 			db.put(cf, "b".getBytes(), "2".getBytes());
@@ -861,7 +861,7 @@ class TtlDBTest {
 	@Test
 	void deleteRange_columnFamily_memorySegment_removesKeyRange(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     Arena arena = Arena.ofConfined()) {
 			db.put(cf, "a".getBytes(), "1".getBytes());
@@ -885,7 +885,7 @@ class TtlDBTest {
 	@Test
 	void keyMayExist_columnFamily_returnsTrueForPresentKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 
@@ -900,7 +900,7 @@ class TtlDBTest {
 	@Test
 	void keyMayExist_columnFamily_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     var ro = ReadOptions.newReadOptions()) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
@@ -916,7 +916,7 @@ class TtlDBTest {
 	@Test
 	void keyMayExist_columnFamily_byteBuffer(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 			var key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
@@ -932,7 +932,7 @@ class TtlDBTest {
 	@Test
 	void keyMayExist_columnFamily_memorySegment(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     Arena arena = Arena.ofConfined()) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
@@ -953,7 +953,7 @@ class TtlDBTest {
 	@Test
 	void newIterator_columnFamily_scansKeys(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "a".getBytes(), "1".getBytes());
 			db.put(cf, "b".getBytes(), "2".getBytes());
@@ -974,7 +974,7 @@ class TtlDBTest {
 	@Test
 	void newIterator_columnFamily_withReadOptions(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     var ro = ReadOptions.newReadOptions()) {
 			db.put(cf, "x".getBytes(), "y".getBytes());
@@ -997,7 +997,7 @@ class TtlDBTest {
 	@Test
 	void flush_columnFamily_doesNotThrow(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     var fo = FlushOptions.newFlushOptions().setWait(true)) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
@@ -1012,7 +1012,7 @@ class TtlDBTest {
 	@Test
 	void getProperty_columnFamily_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 
@@ -1027,7 +1027,7 @@ class TtlDBTest {
 	@Test
 	void getLongProperty_columnFamily_returnsValue(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithTtl(dir, Duration.ofSeconds(60));
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60));
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
 			db.put(cf, "k".getBytes(), "v".getBytes());
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/WalIteratorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/WalIteratorTest.java
@@ -14,7 +14,7 @@ class WalIteratorTest {
 	@Test
 	void getLatestSequenceNumber_advancesAfterWrites(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			SequenceNumber before = db.getLatestSequenceNumber();
 
 			// When
@@ -29,7 +29,7 @@ class WalIteratorTest {
 	@Test
 	void getUpdatesSince_yieldsWrittenBatches(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			SequenceNumber start = db.getLatestSequenceNumber();
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
@@ -58,7 +58,7 @@ class WalIteratorTest {
 	@Test
 	void getUpdatesSince_batchContainsExpectedCount(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			SequenceNumber start = db.getLatestSequenceNumber();
 
 			WriteBatch batch = WriteBatch.create();
@@ -86,7 +86,7 @@ class WalIteratorTest {
 	@Test
 	void getUpdatesSince_emptyWhenNoWritesAfterSequence(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 			SequenceNumber after = db.getLatestSequenceNumber();
 
@@ -110,7 +110,7 @@ class WalIteratorTest {
 	@Test
 	void walIterator_isClosedSafely(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.open(dir)) {
+		try (var db = RocksDB.openReadWrite(dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 			SequenceNumber start = SequenceNumber.of(0);
 

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -184,7 +184,7 @@ Nothing in the library has a public constructor; objects come from named statics
 Two reasons. A constructor must call `super(...)` before anything else, which is impossible when the
 pointer has to be obtained from a native call that can fail and needs error handling — a static
 factory can do the work, check the error holder, and only then construct. And a named factory says
-which *kind* of thing you are getting: `RocksDB.open` versus `openReadOnly` versus `openTtl`
+which *kind* of thing you are getting: `RocksDB.openReadWrite` versus `openReadOnly` versus `openTtl`
 would otherwise all be constructor overloads distinguished only by argument types.
 
 ## Native library loading

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -184,7 +184,7 @@ Nothing in the library has a public constructor; objects come from named statics
 Two reasons. A constructor must call `super(...)` before anything else, which is impossible when the
 pointer has to be obtained from a native call that can fail and needs error handling — a static
 factory can do the work, check the error holder, and only then construct. And a named factory says
-which *kind* of thing you are getting: `RocksDB.open` versus `openReadOnly` versus `openWithTtl`
+which *kind* of thing you are getting: `RocksDB.open` versus `openReadOnly` versus `openTtl`
 would otherwise all be constructor overloads distinguished only by argument types.
 
 ## Native library loading

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -93,7 +93,7 @@ try (var options = Options.newOptions();
 Create a column family on an open database:
 
 ```java
-try (var db = RocksDB.open(dbPath);
+try (var db = RocksDB.openReadWrite(dbPath);
      var accounts = db.createColumnFamily(ColumnFamilyDescriptor.of("accounts"))) {
 	db.put(accounts, "alice".getBytes(), "100".getBytes());
 	byte[] balance = db.get(accounts, "alice".getBytes());
@@ -106,7 +106,7 @@ or the open fails. Handles come back in the same order as the descriptors:
 ```java
 List<ColumnFamilyHandle> handles = new ArrayList<>();
 try (var options = Options.newOptions();
-     var db = RocksDB.open(options, dbPath,
+     var db = RocksDB.openReadWrite(options, dbPath,
 		     List.of(ColumnFamilyDescriptor.of("default"),
 				     ColumnFamilyDescriptor.of("accounts")),
 		     handles)) {
@@ -133,7 +133,7 @@ Every DB type has the same column-family overloads — see
 A snapshot pins a sequence number; reads through it ignore everything written afterwards.
 
 ```java
-try (var db = RocksDB.open(dbPath)) {
+try (var db = RocksDB.openReadWrite(dbPath)) {
 	db.put("k".getBytes(), "before".getBytes());
 
 	try (var snapshot = db.getSnapshot();
@@ -277,7 +277,7 @@ A checkpoint is a point-in-time directory of hard links — near-instant and che
 filesystem.
 
 ```java
-try (var db = RocksDB.open(dbPath);
+try (var db = RocksDB.openReadWrite(dbPath);
      var checkpoint = Checkpoint.newCheckpoint(db)) {
 	checkpoint.exportTo(checkpointDir);   // directory must not already exist
 }
@@ -297,7 +297,7 @@ Backups are incremental across calls: unchanged SST files are shared, not recopi
 
 ```java
 try (var options = Options.newOptions().setCreateIfMissing(true);
-     var db = RocksDB.open(options, dbPath);
+     var db = RocksDB.openReadWrite(options, dbPath);
      var engine = BackupEngine.open(options, backupDir)) {
 
 	db.put("k".getBytes(), "v".getBytes());
@@ -342,7 +342,7 @@ try (var options = Options.newOptions().setCreateIfMissing(true);
 	writer.finish();
 }
 
-try (var db = RocksDB.open(dbPath)) {
+try (var db = RocksDB.openReadWrite(dbPath)) {
 	db.ingestExternalFile(sstPath);
 	// or db.ingestExternalFile(List.of(sst1, sst2));
 }
@@ -357,7 +357,7 @@ Useful for change-data-capture, replication, and auditing: read every batch writ
 sequence number.
 
 ```java
-try (var db = RocksDB.open(dbPath)) {
+try (var db = RocksDB.openReadWrite(dbPath)) {
 	SequenceNumber from = db.getLatestSequenceNumber();
 
 	db.put("a".getBytes(), "1".getBytes());
@@ -425,7 +425,7 @@ try (var cache = LRUCache.newLRUCache(MemorySize.ofMB(512));
      var options = Options.newOptions()
 		     .setCreateIfMissing(true)
 		     .setTableFormatConfig(tableConfig);
-     var db = RocksDB.open(options, dbPath)) {
+     var db = RocksDB.openReadWrite(options, dbPath)) {
 	// ...
 }
 ```
@@ -446,7 +446,7 @@ try (var rateLimiter = RateLimiter.create(MemorySize.ofMB(10));   // 10 MB/s
      var options = Options.newOptions()
 		     .setCreateIfMissing(true)
 		     .setRateLimiter(rateLimiter);
-     var db = RocksDB.open(options, dbPath)) {
+     var db = RocksDB.openReadWrite(options, dbPath)) {
 	// ...
 }
 ```
@@ -464,7 +464,7 @@ try (var env = Env.defaultEnv();
      var options = Options.newOptions()
 		     .setCreateIfMissing(true)
 		     .setSstFileManager(sstFileManager);
-     var db = RocksDB.open(options, dbPath)) {
+     var db = RocksDB.openReadWrite(options, dbPath)) {
 
 	if (sstFileManager.isMaxAllowedSpaceReached()) {
 		// writes are now failing with RocksDBException
@@ -490,7 +490,7 @@ try (var options = Options.newOptions()
 		.setCreateIfMissing(true)
 		.enableStatistics()
 		.setStatisticsLevel(StatsLevel.ALL);
-     var db = RocksDB.open(options, dbPath);
+     var db = RocksDB.openReadWrite(options, dbPath);
      var histogram = StatisticsHistogramData.newStatisticsHistogramData()) {
 
 	db.get("k".getBytes());
@@ -530,7 +530,7 @@ try (var logger = Logger.newCallbackLogger(LogLevel.INFO,
 		     .setCreateIfMissing(true)
 		     .setInfoLog(logger)
 		     .setInfoLogLevel(LogLevel.INFO);
-     var db = RocksDB.open(options, dbPath)) {
+     var db = RocksDB.openReadWrite(options, dbPath)) {
 	// ...
 }
 ```

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -106,7 +106,7 @@ or the open fails. Handles come back in the same order as the descriptors:
 ```java
 List<ColumnFamilyHandle> handles = new ArrayList<>();
 try (var options = Options.newOptions();
-     var db = RocksDB.openWithColumnFamilies(options, dbPath,
+     var db = RocksDB.open(options, dbPath,
 		     List.of(ColumnFamilyDescriptor.of("default"),
 				     ColumnFamilyDescriptor.of("accounts")),
 		     handles)) {
@@ -263,7 +263,7 @@ try (var options = Options.newOptions().setCreateIfMissing(true);
 `TtlDB` stamps each value with a write timestamp and drops expired entries during compaction.
 
 ```java
-try (var db = RocksDB.openWithTtl(dbPath, Duration.ofHours(24))) {
+try (var db = RocksDB.openTtl(dbPath, Duration.ofHours(24))) {
 	db.put("session:1".getBytes(), "...".getBytes());
 }
 ```
@@ -405,7 +405,7 @@ try (var options = Options.newOptions()
 		.setBlobFileSize(MemorySize.ofMB(256))
 		.setBlobCompressionType(CompressionType.ZSTD)
 		.setEnableBlobGc(true);
-     var db = RocksDB.openWithBlobFiles(options, dbPath)) {
+     var db = RocksDB.openBlob(options, dbPath)) {
 	db.put("k".getBytes(), largeValue);
 }
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -70,7 +70,7 @@ Column families are not a separate method name — every factory that supports t
 
 | Factory                                                                       | Column families? | Returns                   |
 |:------------------------------------------------------------------------------|:-----------------|:--------------------------|
-| `open(Path)` / `(Options, Path)`                                               | yes               | `ReadWriteDB` (creates if missing) |
+| `openReadWrite(Path)` / `(Options, Path)`                                      | yes               | `ReadWriteDB` (creates if missing) |
 | `openReadOnly(Path)` / `(Options, Path)` / `(Options, Path, boolean errorIfWalFileExists)` | yes  | `ReadOnlyDB`  |
 | `openTtl(Path, Duration)` / `(Options, Path, Duration)`                        | yes               | `TtlDB`                   |
 | `openBlob(Path)` / `(Options, Path)`                                           | no                | `BlobDB`                  |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -65,22 +65,19 @@ GitHub Advisory DB) use to identify the artifact.
 Every database is opened through a static factory on `RocksDB`. There is no public constructor
 anywhere in the library.
 
-| Factory                                                                       | Returns                   |
-|:------------------------------------------------------------------------------|:--------------------------|
-| `open(Path)`                                                                   | `ReadWriteDB` (creates if missing) |
-| `open(Options, Path)`                                                          | `ReadWriteDB`             |
-| `openReadOnly(Path)` / `(Options, Path)` / `(Options, Path, boolean errorIfWalFileExists)` | `ReadOnlyDB`  |
-| `openWithTtl(Path, Duration)` / `(Options, Path, Duration)`                    | `TtlDB`                   |
-| `openWithBlobFiles(Path)` / `(Options, Path)`                                  | `BlobDB`                  |
-| `openSecondary(Options, Path primary, Path secondary)`                         | `SecondaryDB`             |
-| `openTransaction(Options, TransactionDBOptions, Path)`                         | `TransactionDB`           |
-| `openOptimistic(Options, Path)`                                                | `OptimisticTransactionDB` |
-| `openWithColumnFamilies(Options, Path, List<ColumnFamilyDescriptor>, List<ColumnFamilyHandle> out)` | `ReadWriteDB` |
-| `openReadOnlyWithColumnFamilies(...)`                                          | `ReadOnlyDB`              |
-| `openWithColumnFamiliesAndTtl(...)`                                            | `TtlDB`                   |
-| `openTransactionWithColumnFamilies(...)`                                       | `TransactionDB`           |
-| `openOptimisticWithColumnFamilies(...)`                                        | `OptimisticTransactionDB` |
-| `listColumnFamilies(Options, Path)`                                            | `List<byte[]>`            |
+Column families are not a separate method name — every factory that supports them takes
+`List<ColumnFamilyDescriptor>` / `List<ColumnFamilyHandle> out` as an overload of the plain form.
+
+| Factory                                                                       | Column families? | Returns                   |
+|:------------------------------------------------------------------------------|:-----------------|:--------------------------|
+| `open(Path)` / `(Options, Path)`                                               | yes               | `ReadWriteDB` (creates if missing) |
+| `openReadOnly(Path)` / `(Options, Path)` / `(Options, Path, boolean errorIfWalFileExists)` | yes  | `ReadOnlyDB`  |
+| `openTtl(Path, Duration)` / `(Options, Path, Duration)`                        | yes               | `TtlDB`                   |
+| `openBlob(Path)` / `(Options, Path)`                                           | no                | `BlobDB`                  |
+| `openSecondary(Options, Path primary, Path secondary)`                         | no                | `SecondaryDB`             |
+| `openTransaction(Options, TransactionDBOptions, Path)`                         | yes               | `TransactionDB`           |
+| `openOptimistic(Options, Path)`                                                | yes               | `OptimisticTransactionDB` |
+| `listColumnFamilies(Options, Path)`                                            | —                 | `List<byte[]>`            |
 
 `RocksDB` also exposes the FFM plumbing shared by every wrapper: `errHolder(Arena)`,
 `checkError(MemorySegment)`, `toNative(Arena, byte[])`, `free(MemorySegment)`.
@@ -140,7 +137,7 @@ Other read/write methods on the read-write types:
 | `setRateLimiter`                            | `RateLimiter`           |
 | `setSstFileManager`                         | `SstFileManager`        |
 
-Blob options (used with `RocksDB.openWithBlobFiles`, each with a matching getter):
+Blob options (used with `RocksDB.openBlob`, each with a matching getter):
 
 | Method                         | Type                    |
 |:-------------------------------|:------------------------|
@@ -362,7 +359,7 @@ Parity tracking against `rocksdbjni`. ✅ implemented · 🚧 partial · ❌ not
 | Compaction control         |   ✅    | `compactRange` (+`CompactOptions`), `suggestCompactRange`, file-deletion toggles            |
 | SST file ingest            |   ✅    | `SstFileWriter`, `ingestExternalFile`, `IngestExternalFileOptions`                          |
 | Backup engine              |   ✅    | Incremental backup/restore, purge, verify                                                   |
-| TTL DB                     |   ✅    | `openWithTtl(path, Duration)`; lazy expiry via compaction                                   |
+| TTL DB                     |   ✅    | `openTtl(path, Duration)`; lazy expiry via compaction                                   |
 | WAL iterator               |   ✅    | `getUpdatesSince`, `getLatestSequenceNumber` — CDC, replication, auditing                   |
 | Rate limiter               |   ✅    | Writes-only, reads-only, all-IO; auto-tuned variant                                         |
 | Env                        |   ✅    | `defaultEnv()`, `memEnv()`, background thread pools                                         |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -89,7 +89,7 @@ public class App {
 	public static void main(String[] args) {
 		Path dbPath = Path.of("target/demo-db");
 
-		try (var db = RocksDB.open(dbPath)) {
+		try (var db = RocksDB.openReadWrite(dbPath)) {
 			db.put("user:1".getBytes(), "alice".getBytes());
 
 			byte[] value = db.get("user:1".getBytes());
@@ -104,7 +104,7 @@ public class App {
 
 Three things are happening here.
 
-`RocksDB.open(Path)` creates the database if the directory does not exist. It returns a
+`RocksDB.openReadWrite(Path)` creates the database if the directory does not exist. It returns a
 `ReadWriteDB`, which is `AutoCloseable` — the try-with-resources block is what releases the native
 handle. **Every** type in this library that owns native memory works that way; see
 [explanation.md#lifecycle-and-ownership](explanation.md#lifecycle-and-ownership).
@@ -140,14 +140,14 @@ null
 
 ## 5. Control how the database is opened
 
-`RocksDB.open(Path)` is a shorthand for "create if missing". Anything beyond that goes through
+`RocksDB.openReadWrite(Path)` is a shorthand for "create if missing". Anything beyond that goes through
 `Options`, which is itself a native object and must be closed:
 
 ```java
 try (var options = Options.newOptions()
 		.setCreateIfMissing(true)
 		.setCompression(CompressionType.ZSTD);
-     var db = RocksDB.open(options, dbPath)) {
+     var db = RocksDB.openReadWrite(options, dbPath)) {
 	db.put("user:1".getBytes(), "alice".getBytes());
 }
 ```
@@ -165,7 +165,7 @@ try (var cache = LRUCache.newLRUCache(MemorySize.ofMB(64));
      var options = Options.newOptions()
 		     .setCreateIfMissing(true)
 		     .setTableFormatConfig(tableConfig);
-     var db = RocksDB.open(options, dbPath)) {
+     var db = RocksDB.openReadWrite(options, dbPath)) {
 	// ...
 }
 ```
@@ -181,7 +181,7 @@ way is covered in [explanation.md#lifecycle-and-ownership](explanation.md#lifecy
 A `WriteBatch` collects operations and applies them in a single atomic write:
 
 ```java
-try (var db = RocksDB.open(dbPath);
+try (var db = RocksDB.openReadWrite(dbPath);
      var batch = WriteBatch.create()) {
 	batch.put("user:1".getBytes(), "alice".getBytes());
 	batch.put("user:2".getBytes(), "bob".getBytes());

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineIntegrationTest.java
@@ -19,7 +19,7 @@ class BackupEngineIntegrationTest {
 
 		// Given — open DB, write data, create backup
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var engine = BackupEngine.open(opts, backupDir)) {
 
 			db.put("k1".getBytes(), "v1".getBytes());
@@ -45,7 +45,7 @@ class BackupEngineIntegrationTest {
 
 		// Then — restored DB contains original data
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.open(opts, restoreDir)) {
+		     var db = RocksDB.openReadWrite(opts, restoreDir)) {
 
 			assertThat(db.get("k1".getBytes())).isEqualTo("v1".getBytes());
 			assertThat(db.get("k2".getBytes())).isEqualTo("v2".getBytes());
@@ -61,7 +61,7 @@ class BackupEngineIntegrationTest {
 
 		// Given — two backups at different states
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var engine = BackupEngine.open(opts, backupDir)) {
 
 			db.put("k".getBytes(), "v1".getBytes());
@@ -81,8 +81,8 @@ class BackupEngineIntegrationTest {
 
 		// Then — each restored directory reflects the state at backup time
 		try (var opts = Options.newOptions();
-		     var db1 = RocksDB.open(opts, restoreV1);
-		     var db2 = RocksDB.open(opts, restoreV2)) {
+		     var db1 = RocksDB.openReadWrite(opts, restoreV1);
+		     var db2 = RocksDB.openReadWrite(opts, restoreV2)) {
 
 			assertThat(db1.get("k".getBytes())).isEqualTo("v1".getBytes());
 			assertThat(db2.get("k".getBytes())).isEqualTo("v2".getBytes());
@@ -96,7 +96,7 @@ class BackupEngineIntegrationTest {
 
 		// Given — three backups
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var engine = BackupEngine.open(opts, backupDir)) {
 
 			engine.createNewBackup(db);
@@ -122,7 +122,7 @@ class BackupEngineIntegrationTest {
 
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var engine = BackupEngine.open(opts, backupDir)) {
 
 			db.put("k".getBytes(), "v".getBytes());
@@ -141,7 +141,7 @@ class BackupEngineIntegrationTest {
 		var backupDir = dir.resolve("backup");
 
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var engine = BackupEngine.open(opts, backupDir)) {
 
 			engine.createNewBackup(db);
@@ -191,7 +191,7 @@ class BackupEngineIntegrationTest {
 
 		// Given — write data
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir)) {
+		     var db = RocksDB.openReadWrite(opts, dbDir)) {
 			db.put("key".getBytes(), "value".getBytes());
 
 			// When — backup via explicit BackupEngineOptions + Env
@@ -213,7 +213,7 @@ class BackupEngineIntegrationTest {
 
 		// Then
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.open(opts, restoreDir)) {
+		     var db = RocksDB.openReadWrite(opts, restoreDir)) {
 			assertThat(db.get("key".getBytes())).isEqualTo("value".getBytes());
 		}
 	}

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/BlobDBIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/BlobDBIntegrationTest.java
@@ -19,7 +19,7 @@ class BlobDBIntegrationTest {
 				.setCreateIfMissing(true)
 				.setEnableBlobFiles(true)
 				.setMinBlobSize(MemorySize.ofBytes(0));
-		     var db = RocksDB.openWithBlobFiles(opts, dir)) {
+		     var db = RocksDB.openBlob(opts, dir)) {
 
 			// When
 			db.put("k".getBytes(), VALUE_64KB);
@@ -30,9 +30,9 @@ class BlobDBIntegrationTest {
 	}
 
 	@Test
-	void openWithBlobFiles_convenienceFactory(@TempDir Path dir) {
+	void openBlob_convenienceFactory(@TempDir Path dir) {
 		// Given — convenience overload sets createIfMissing=true and enableBlobFiles=true
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 
 			// When
 			db.put("hello".getBytes(), VALUE_64KB);
@@ -45,7 +45,7 @@ class BlobDBIntegrationTest {
 	@Test
 	void delete_removesKey(@TempDir Path dir) {
 		// Given
-		try (var db = RocksDB.openWithBlobFiles(dir)) {
+		try (var db = RocksDB.openBlob(dir)) {
 			db.put("k".getBytes(), VALUE_64KB);
 
 			// When
@@ -90,7 +90,7 @@ class BlobDBIntegrationTest {
 			assertThat(blobGcForceThreshold).isEqualTo(0.8);
 			assertThat(blobFileStartingLevel).isEqualTo(0);
 
-			try (var db = RocksDB.openWithBlobFiles(opts, dir)) {
+			try (var db = RocksDB.openBlob(opts, dir)) {
 				db.put("k".getBytes(), VALUE_64KB);
 				assertThat(db.get("k".getBytes())).isEqualTo(VALUE_64KB);
 			}
@@ -107,7 +107,7 @@ class BlobDBIntegrationTest {
 				.setCreateIfMissing(true)
 				.setEnableBlobFiles(true)
 				.setMinBlobSize(MemorySize.ofKB(64));
-		     var db = RocksDB.openWithBlobFiles(opts, dbDir)) {
+		     var db = RocksDB.openBlob(opts, dbDir)) {
 			db.put("before".getBytes(), "snap".getBytes());
 
 			// When — take a checkpoint
@@ -132,7 +132,7 @@ class BlobDBIntegrationTest {
 				.setCreateIfMissing(true)
 				.setEnableBlobFiles(true)
 				.setMinBlobSize(MemorySize.ofBytes(0));
-		     var db = RocksDB.openWithBlobFiles(opts, dir)) {
+		     var db = RocksDB.openBlob(opts, dir)) {
 
 			db.put("k".getBytes(), VALUE_64KB);
 			db.flush(FlushOptions.newFlushOptions());

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyIntegrationTest.java
@@ -22,7 +22,7 @@ class ColumnFamilyIntegrationTest {
 	void data_survivesCloseAndReopen(@TempDir Path dir) {
 		// Given — write to a custom CF, then close the DB
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("accounts"))) {
 			db.put(cf, "alice".getBytes(), "100".getBytes());
 			db.put(cf, "bob".getBytes(), "200".getBytes());
@@ -31,7 +31,7 @@ class ColumnFamilyIntegrationTest {
 		// When — reopen with both column families
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.open(opts, dir,
+		     var db = RocksDB.openReadWrite(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("accounts")),
 				     handles)) {
@@ -50,7 +50,7 @@ class ColumnFamilyIntegrationTest {
 	void multipleColumnFamilies_persistIndependently(@TempDir Path dir) {
 		// Given — create two CFs and write distinct data to each
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var usersCf = db.createColumnFamily(ColumnFamilyDescriptor.of("users"));
 		     var ordersCf = db.createColumnFamily(ColumnFamilyDescriptor.of("orders"))) {
 			db.put(usersCf, "u1".getBytes(), "alice".getBytes());
@@ -61,7 +61,7 @@ class ColumnFamilyIntegrationTest {
 		// When — reopen all three CFs
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.open(opts, dir,
+		     var db = RocksDB.openReadWrite(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("users"),
 						     ColumnFamilyDescriptor.of("orders")),
@@ -90,7 +90,7 @@ class ColumnFamilyIntegrationTest {
 	void listColumnFamilies_reflectsCreatedAndDroppedFamilies(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			var cf1 = db.createColumnFamily(ColumnFamilyDescriptor.of("keep"));
 			var cf2 = db.createColumnFamily(ColumnFamilyDescriptor.of("drop-me"));
 			db.dropColumnFamily(cf2);
@@ -118,7 +118,7 @@ class ColumnFamilyIntegrationTest {
 	void writeBatch_appliesAcrossColumnFamiliesAtomically(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var inventoryCf = db.createColumnFamily(ColumnFamilyDescriptor.of("inventory"));
 		     var auditCf = db.createColumnFamily(ColumnFamilyDescriptor.of("audit"));
 		     var batch = WriteBatch.create()) {
@@ -138,7 +138,7 @@ class ColumnFamilyIntegrationTest {
 	void writeBatch_deleteRange_acrossCfsSurvivesReopen(@TempDir Path dir) {
 		// Given — populate a CF and delete a range via WriteBatch
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var logsCf = db.createColumnFamily(ColumnFamilyDescriptor.of("logs"))) {
 			for (int i = 1; i <= 5; i++) {
 				db.put(logsCf, ("log-" + i).getBytes(), ("entry-" + i).getBytes());
@@ -152,7 +152,7 @@ class ColumnFamilyIntegrationTest {
 		// When — reopen
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.open(opts, dir,
+		     var db = RocksDB.openReadWrite(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("logs")),
 				     handles)) {
@@ -177,7 +177,7 @@ class ColumnFamilyIntegrationTest {
 	void iterator_scansPersistedKeysInOrder(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("sorted"))) {
 			db.put(cf, "c".getBytes(), "3".getBytes());
 			db.put(cf, "a".getBytes(), "1".getBytes());
@@ -189,7 +189,7 @@ class ColumnFamilyIntegrationTest {
 		List<String> values = new ArrayList<>();
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.open(opts, dir,
+		     var db = RocksDB.openReadWrite(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("sorted")),
 				     handles)) {
@@ -216,7 +216,7 @@ class ColumnFamilyIntegrationTest {
 	void snapshot_seesConsistentViewWithinCf(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("events"))) {
 			db.put(cf, "e1".getBytes(), "v1".getBytes());
 
@@ -240,7 +240,7 @@ class ColumnFamilyIntegrationTest {
 	void flush_movesDataToSst_reflectedInProperties(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("metrics"));
 		     var flushOpts = FlushOptions.newFlushOptions().setWait(true)) {
 
@@ -267,7 +267,7 @@ class ColumnFamilyIntegrationTest {
 		// Given
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var cf1 = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
 		     var cf2 = db.createColumnFamily(ColumnFamilyDescriptor.of("cf2"))) {
 

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyIntegrationTest.java
@@ -31,7 +31,7 @@ class ColumnFamilyIntegrationTest {
 		// When — reopen with both column families
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.openWithColumnFamilies(opts, dir,
+		     var db = RocksDB.open(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("accounts")),
 				     handles)) {
@@ -61,7 +61,7 @@ class ColumnFamilyIntegrationTest {
 		// When — reopen all three CFs
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.openWithColumnFamilies(opts, dir,
+		     var db = RocksDB.open(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("users"),
 						     ColumnFamilyDescriptor.of("orders")),
@@ -152,7 +152,7 @@ class ColumnFamilyIntegrationTest {
 		// When — reopen
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.openWithColumnFamilies(opts, dir,
+		     var db = RocksDB.open(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("logs")),
 				     handles)) {
@@ -189,7 +189,7 @@ class ColumnFamilyIntegrationTest {
 		List<String> values = new ArrayList<>();
 		List<ColumnFamilyHandle> handles = new ArrayList<>();
 		try (var opts = Options.newOptions();
-		     var db = RocksDB.openWithColumnFamilies(opts, dir,
+		     var db = RocksDB.open(opts, dir,
 				     List.of(ColumnFamilyDescriptor.of("default"),
 						     ColumnFamilyDescriptor.of("sorted")),
 				     handles)) {

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/EntityCheckpointIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/EntityCheckpointIntegrationTest.java
@@ -48,7 +48,7 @@ class EntityCheckpointIntegrationTest {
 		var dbDir = sharedDir.resolve("db");
 		cpDir = sharedDir.resolve("checkpoint");
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var batch = WriteBatch.create()) {
 			for (int i = 0; i < ENTITY_COUNT; i++) {
 				var e = new Entity(i, "entity-" + i, Status.values()[i % Status.values().length]);
@@ -157,7 +157,7 @@ class EntityCheckpointIntegrationTest {
 		var dbDir = dir.resolve("db");
 		var isolatedCpDir = dir.resolve("checkpoint");
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dbDir);
+		     var db = RocksDB.openReadWrite(opts, dbDir);
 		     var batch = WriteBatch.create()) {
 			for (int i = 0; i < ENTITY_COUNT; i++) {
 				var e = new Entity(i, "entity-" + i, Status.values()[i % Status.values().length]);

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/PerfContextIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/PerfContextIntegrationTest.java
@@ -24,7 +24,7 @@ class PerfContextIntegrationTest {
 	@Test
 	void getAccumulatesBlockCacheMetrics(@TempDir Path dir) {
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// Given — data flushed to SST so block cache is consulted on read
 			db.put("k".getBytes(), "v".getBytes());
@@ -45,7 +45,7 @@ class PerfContextIntegrationTest {
 	@Test
 	void writeAccumulatesWalAndMemtableMetrics(@TempDir Path dir) {
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var ctx = PerfContext.newPerfContext()) {
 
 			// When
@@ -61,7 +61,7 @@ class PerfContextIntegrationTest {
 	@Test
 	void resetClearsCounters(@TempDir Path dir) {
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var ctx = PerfContext.currentPerfContext()) {
 
 			// Given — accumulate some metrics
@@ -83,7 +83,7 @@ class PerfContextIntegrationTest {
 	@Test
 	void reportProducesNonEmptyString(@TempDir Path dir) {
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var ctx = PerfContext.newPerfContext()) {
 
 			// Given — some metrics accumulated
@@ -107,7 +107,7 @@ class PerfContextIntegrationTest {
 		PerfContext.setPerfLevel(PerfLevel.DISABLE);
 
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var ctx = PerfContext.newPerfContext()) {
 
 			// When
@@ -134,7 +134,7 @@ class PerfContextIntegrationTest {
 	@Test
 	void iteratorAccumulatesMetrics(@TempDir Path dir) {
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// Given — two keys flushed to SST
 			db.put("a".getBytes(), "1".getBytes());

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterIntegrationTest.java
@@ -16,7 +16,7 @@ class RateLimiterIntegrationTest {
 		     var opts = Options.newOptions()
 				     .setCreateIfMissing(true)
 				     .setRateLimiter(limiter);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("key".getBytes(), "value".getBytes());
@@ -33,7 +33,7 @@ class RateLimiterIntegrationTest {
 		     var opts = Options.newOptions()
 				     .setCreateIfMissing(true)
 				     .setRateLimiter(limiter);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("k".getBytes(), "v".getBytes());
@@ -52,7 +52,7 @@ class RateLimiterIntegrationTest {
 		     var opts = Options.newOptions()
 				     .setCreateIfMissing(true)
 				     .setRateLimiter(limiter);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("key".getBytes(), "value".getBytes());
@@ -72,7 +72,7 @@ class RateLimiterIntegrationTest {
 			limiter.close();
 
 			// When — Options (and the underlying shared_ptr) still valid
-			try (var db = RocksDB.open(opts, dir)) {
+			try (var db = RocksDB.openReadWrite(opts, dir)) {
 				db.put("key".getBytes(), "value".getBytes());
 				var result = db.get("key".getBytes());
 

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBIntegrationTest.java
@@ -15,7 +15,7 @@ class ReadOnlyDBIntegrationTest {
 	void readsDataWrittenByPrimary(@TempDir Path dir) {
 		// Given — write data with a read-write db, then close it
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
 		}
 
@@ -32,7 +32,7 @@ class ReadOnlyDBIntegrationTest {
 	void iterator_scansAllKeys(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("b".getBytes(), "2".getBytes());
 			db.put("c".getBytes(), "3".getBytes());

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ReadWriteDBIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ReadWriteDBIntegrationTest.java
@@ -15,7 +15,7 @@ class ReadWriteDBIntegrationTest {
 	void putGetDelete(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("k1".getBytes(), "v1".getBytes());
@@ -38,7 +38,7 @@ class ReadWriteDBIntegrationTest {
 	void writeBatch_appliesAtomically(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir);
+		     var db = RocksDB.openReadWrite(opts, dir);
 		     var batch = WriteBatch.create()) {
 
 			// When
@@ -57,7 +57,7 @@ class ReadWriteDBIntegrationTest {
 	void iterator_scansKeysInOrder(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			db.put("a".getBytes(), "1".getBytes());
 			db.put("c".getBytes(), "3".getBytes());

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBIntegrationTest.java
@@ -14,7 +14,7 @@ class SecondaryDBIntegrationTest {
 			@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given — write and flush so the secondary can read from SSTs
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, primaryDir);
+		     var db = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			db.put("k1".getBytes(), "v1".getBytes());
 			db.flush(fo);
@@ -35,7 +35,7 @@ class SecondaryDBIntegrationTest {
 			@TempDir Path primaryDir, @TempDir Path secondaryDir) {
 		// Given — seed the primary so the secondary can open
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.open(opts, primaryDir);
+		     var db = RocksDB.openReadWrite(opts, primaryDir);
 		     var fo = FlushOptions.newFlushOptions()) {
 			db.put("k1".getBytes(), "v1".getBytes());
 			db.flush(fo);
@@ -47,7 +47,7 @@ class SecondaryDBIntegrationTest {
 
 			// When — primary adds more data and flushes
 			try (var popts = Options.newOptions();
-			     var primary = RocksDB.open(popts, primaryDir);
+			     var primary = RocksDB.openReadWrite(popts, primaryDir);
 			     var fo = FlushOptions.newFlushOptions()) {
 				primary.put("k2".getBytes(), "v2".getBytes());
 				primary.flush(fo);

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/SstFileManagerIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/SstFileManagerIntegrationTest.java
@@ -17,7 +17,7 @@ class SstFileManagerIntegrationTest {
 		     var opts = Options.newOptions()
 				     .setCreateIfMissing(true)
 				     .setSstFileManager(sfm);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("key".getBytes(), "value".getBytes());
@@ -38,7 +38,7 @@ class SstFileManagerIntegrationTest {
 		     var opts = Options.newOptions()
 				     .setCreateIfMissing(true)
 				     .setSstFileManager(sfm);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("k".getBytes(), "v".getBytes());
@@ -59,7 +59,7 @@ class SstFileManagerIntegrationTest {
 		     var opts = Options.newOptions()
 				     .setCreateIfMissing(true)
 				     .setSstFileManager(sfm);
-		     var db = RocksDB.open(opts, dir)) {
+		     var db = RocksDB.openReadWrite(opts, dir)) {
 
 			// When
 			db.put("key".getBytes(), "value".getBytes());
@@ -97,7 +97,7 @@ class SstFileManagerIntegrationTest {
 			sfm.close();
 
 			// When — Options (and the underlying shared_ptr) still valid
-			try (var db = RocksDB.open(opts, dir)) {
+			try (var db = RocksDB.openReadWrite(opts, dir)) {
 				db.put("key".getBytes(), "value".getBytes());
 				var result = db.get("key".getBytes());
 

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/TtlDBIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/TtlDBIntegrationTest.java
@@ -14,7 +14,7 @@ class TtlDBIntegrationTest {
 	void putGet_withinTtl(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ofSeconds(60))) {
+		     var db = RocksDB.openTtl(opts, dir, Duration.ofSeconds(60))) {
 
 			// When
 			db.put("k".getBytes(), "v".getBytes());
@@ -31,7 +31,7 @@ class TtlDBIntegrationTest {
 
 		// When
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, ttl)) {
+		     var db = RocksDB.openTtl(opts, dir, ttl)) {
 
 			// Then
 			assertThat(db.getTtl()).isEqualTo(ttl);
@@ -42,7 +42,7 @@ class TtlDBIntegrationTest {
 	void zeroTtl_disablesExpiry(@TempDir Path dir) {
 		// Given — Duration.ZERO disables expiry entirely
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
-		     var db = RocksDB.openWithTtl(opts, dir, Duration.ZERO)) {
+		     var db = RocksDB.openTtl(opts, dir, Duration.ZERO)) {
 
 			// When
 			db.put("k".getBytes(), "v".getBytes());


### PR DESCRIPTION
## Summary
- Column-family-ness was baked into method names (`openWithColumnFamilies`, `openReadOnlyWithColumnFamilies`, `openWithColumnFamiliesAndTtl`, `openTransactionWithColumnFamilies`, `openOptimisticWithColumnFamilies`) instead of being an overload of the base factory. Folded each into an overload of its base name:
  - `openWithColumnFamilies(...)` → `open(..., descriptors, handles)`
  - `openReadOnlyWithColumnFamilies(...)` → `openReadOnly(..., descriptors, handles[, boolean])`
  - `openWithTtl(...)` → `openTtl(...)`
  - `openWithColumnFamiliesAndTtl(...)` → `openTtl(..., descriptors, ttls, handles)`
  - `openWithBlobFiles(...)` → `openBlob(...)`
  - `openTransactionWithColumnFamilies(...)` → `openTransaction(..., descriptors, handles)`
  - `openOptimisticWithColumnFamilies(...)` → `openOptimistic(..., descriptors, handles)`
- `open` (the one factory without a descriptive suffix) renamed to `openReadWrite` for symmetry with `openReadOnly`/`openTtl`/`openBlob`/`openSecondary`/`openTransaction`/`openOptimistic`.
- No behavior change — pure rename plus continuation-line realignment for the shortened/lengthened signatures.
- Updated every call site (core, integration-tests, benchmarks — excluding `JniBenchmark.java`, which calls the upstream `org.rocksdb.RocksDB`, unrelated), `CLAUDE.md`'s source map, and `docs/{tutorial,how-to,reference,explanation}.md`.

## Test plan
- [x] `./mvnw compile -pl core -am` — clean (includes checkstyle)
- [x] `./mvnw javadoc:javadoc -pl core` — zero output (cross-references like `[RocksDB#openReadWrite]` resolve)
- [x] `./mvnw test-compile -pl integration-tests -am` / `-pl benchmarks -am` — clean
- [x] `./mvnw test -pl core -am` — 568/568 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)