### PR TITLE
PinnableSlice wrapper + FFM/JNI scale benchmarks

### DIFF
--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmScaleBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmScaleBenchmark.java
@@ -1,0 +1,156 @@
+package io.github.dfa1.rocksdbffm.benchmark;
+
+import io.github.dfa1.rocksdbffm.FlushOptions;
+import io.github.dfa1.rocksdbffm.ReadWriteDB;
+import io.github.dfa1.rocksdbffm.RocksDB;
+import io.github.dfa1.rocksdbffm.RocksIterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/// Get and iteration throughput against a database sized by `@Param keyCount`, with a
+/// fixed per-key value size also swept via `@Param` — 8 bytes (typical counter/flag-sized
+/// value) and 1024 bytes (typical small-document-sized value). Compares the copy tier
+/// (byte[]) against the zero-copy tier ([ReadWriteDB#get(MemorySegment, Mapper)] /
+/// [RocksIterator#value(Mapper)]) on both operations.
+///
+/// See [JniScaleBenchmark] for the JNI baseline (copy tier only — the JNI API has no
+/// zero-copy read path) and [ScaleBenchmarkRunner] for the side-by-side table.
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3, jvmArgsPrepend = {"--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow"})
+public class FfmScaleBenchmark {
+
+	private static final int KEY_SIZE = 16;
+
+	// JMH requires @Param fields to be public.
+	@Param({"10000", "100000"})
+	public int keyCount;
+
+	@Param({"8", "1024"})
+	public int valueSize;
+
+	private ReadWriteDB db;
+	private Path dbPath;
+	private Arena arena;
+	private RocksIterator iterator;
+
+	// Fixed lookup key for the get() benchmarks: the middle key of the generated set,
+	// consistent with the rest of this project's benchmarks using a single fixed read
+	// key rather than cycling through random keys per invocation, which would mix
+	// key-selection overhead into the measurement itself.
+	private byte[] lookupKeyBytes;
+	private MemorySegment lookupKeySegment;
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		dbPath = Files.createTempDirectory("bench-ffm-scale-");
+		db = RocksDB.openReadWrite(dbPath);
+		arena = Arena.ofConfined();
+
+		byte[][] keys = TestData.randomBytes(keyCount, KEY_SIZE);
+		byte[][] values = TestData.randomBytes(keyCount, valueSize);
+		for (int i = 0; i < keyCount; i++) {
+			db.put(keys[i], values[i]);
+		}
+
+		// Settle the LSM tree before measuring. Without this the memtable is still partly
+		// filled and background compactions are still running when the first measurement
+		// iteration starts, so whether the lookup key is served from the memtable, L0, or
+		// a deeper level varies per fork -- observed as tight within-fork numbers that
+		// differ by 60% between forks of the same trial. flush() drains the memtable and
+		// compactRange() (a blocking call) leaves every fork with the same LSM shape.
+		try (FlushOptions flushOptions = FlushOptions.newFlushOptions().setWait(true)) {
+			db.flush(flushOptions);
+		}
+		db.compactRange();
+
+		lookupKeyBytes = keys[keyCount / 2];
+		lookupKeySegment = arena.allocateFrom(ValueLayout.JAVA_BYTE, lookupKeyBytes);
+
+		iterator = db.newIterator();
+		iterator.seekToFirst();
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() throws IOException {
+		iterator.close();
+		db.close();
+		arena.close();
+		TestData.deleteDir(dbPath);
+	}
+
+	// ---- get ----------------------------------------------------------------
+
+	@Benchmark
+	public byte[] getByteArray() {
+		return db.get(lookupKeyBytes);
+	}
+
+	@Benchmark
+	public long getZeroCopy() {
+		return db.get(lookupKeySegment, MemorySegment::byteSize).orElseThrow();
+	}
+
+	// ---- iteration ------------------------------------------------------------
+	// Each invocation advances by one entry, wrapping to the start when exhausted:
+	// steady-state per-entry cost, the standard JMH pattern for measuring iterator
+	// throughput over a dataset larger than a single measurement window.
+
+	@Benchmark
+	public byte[] iterateByteArray() {
+		if (!iterator.isValid()) {
+			iterator.seekToFirst();
+		}
+		byte[] result = iterator.value();
+		iterator.next();
+		return result;
+	}
+
+	@Benchmark
+	public long iterateZeroCopy() {
+		if (!iterator.isValid()) {
+			iterator.seekToFirst();
+		}
+		long result = iterator.value(MemorySegment::byteSize);
+		iterator.next();
+		return result;
+	}
+
+	/// Runs this class with [GCProfiler] attached. `-Djmh.include=<regex>` narrows which
+	/// benchmarks run (e.g. `FfmScaleBenchmark.getZeroCopy` for just the zero-copy pair)
+	/// and `-Djmh.forks=<n>` overrides the `@Fork` count above.
+	static void main() throws Exception {
+		OptionsBuilder builder = new OptionsBuilder();
+		builder.addProfiler(GCProfiler.class);
+		builder.include(System.getProperty("jmh.include", FfmScaleBenchmark.class.getSimpleName()));
+		String forks = System.getProperty("jmh.forks");
+		if (forks != null) {
+			builder.forks(Integer.parseInt(forks));
+		}
+		new org.openjdk.jmh.runner.Runner(builder.build()).run();
+	}
+}

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/JniScaleBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/JniScaleBenchmark.java
@@ -1,0 +1,113 @@
+package io.github.dfa1.rocksdbffm.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.rocksdb.FlushOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksIterator;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/// JNI baseline for [FfmScaleBenchmark]: same `keyCount`/`valueSize` sweep, byte[]-copy
+/// tier only — `org.rocksdb`'s `get`/`RocksIterator` API has no zero-copy read path to
+/// compare against.
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3, jvmArgsPrepend = {"--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow"})
+public class JniScaleBenchmark {
+
+	static {
+		RocksDB.loadLibrary();
+	}
+
+	private static final int KEY_SIZE = 16;
+
+	// JMH requires @Param fields to be public.
+	@Param({"10000", "100000"})
+	public int keyCount;
+
+	@Param({"8", "1024"})
+	public int valueSize;
+
+	private RocksDB db;
+	private Options options;
+	private Path dbPath;
+	private RocksIterator iterator;
+
+	// Same fixed-key rationale as FfmScaleBenchmark.
+	private byte[] lookupKey;
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		dbPath = Files.createTempDirectory("bench-jni-scale-");
+		options = new Options().setCreateIfMissing(true);
+		db = RocksDB.open(options, dbPath.toString());
+
+		byte[][] keys = TestData.randomBytes(keyCount, KEY_SIZE);
+		byte[][] values = TestData.randomBytes(keyCount, valueSize);
+		for (int i = 0; i < keyCount; i++) {
+			db.put(keys[i], values[i]);
+		}
+
+		// Same LSM settling as FfmScaleBenchmark.setup() -- see the rationale there. Both
+		// sides must do this or the comparison comes down to which one happened to get a
+		// luckier compaction state rather than to per-call overhead.
+		try (FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+			db.flush(flushOptions);
+		}
+		db.compactRange();
+
+		lookupKey = keys[keyCount / 2];
+
+		iterator = db.newIterator();
+		iterator.seekToFirst();
+	}
+
+	@TearDown(Level.Trial)
+	public void teardown() throws Exception {
+		iterator.close();
+		db.close();
+		options.close();
+		TestData.deleteDir(dbPath);
+	}
+
+	@Benchmark
+	public byte[] getByteArray() throws Exception {
+		return db.get(lookupKey);
+	}
+
+	@Benchmark
+	public byte[] iterateByteArray() {
+		if (!iterator.isValid()) {
+			iterator.seekToFirst();
+		}
+		byte[] result = iterator.value();
+		iterator.next();
+		return result;
+	}
+
+	static void main() throws Exception {
+		org.openjdk.jmh.runner.options.Options opt = new org.openjdk.jmh.runner.options.OptionsBuilder()
+				.include(JniScaleBenchmark.class.getSimpleName())
+				.build();
+
+		new org.openjdk.jmh.runner.Runner(opt).run();
+	}
+}

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/ScaleBenchmarkRunner.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/ScaleBenchmarkRunner.java
@@ -1,0 +1,175 @@
+package io.github.dfa1.rocksdbffm.benchmark;
+
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+/// Runs [FfmScaleBenchmark] and [JniScaleBenchmark] back-to-back and prints a
+/// side-by-side comparison, grouped by `(keyCount, valueSize)`, for both get and
+/// iteration.
+/// ```
+/// ./scripts/benchmark.sh ScaleBenchmarkRunner
+/// ```
+///
+/// Set `-Djmh.forks=<n>` to override the `@Fork` count declared on the benchmark classes,
+/// e.g. to trade confidence for a shorter run.
+///
+/// Each operation gets two tables: throughput (ops/s) and allocation (bytes/op, from
+/// [GCProfiler]'s `gc.alloc.rate.norm`). Allocation is the metric the zero-copy tiers
+/// exist to move, and unlike throughput it is near-noiseless — a byte[] tier allocates
+/// its result array on every call, a zero-copy tier should be flat at 0.
+public class ScaleBenchmarkRunner {
+
+	private record ComboKey(int keyCount, int valueSize) implements Comparable<ComboKey> {
+		@Override
+		public int compareTo(ComboKey o) {
+			int c = Integer.compare(keyCount, o.keyCount);
+			return c != 0 ? c : Integer.compare(valueSize, o.valueSize);
+		}
+	}
+
+	/// Throughput and allocation for one `(keyCount, valueSize)` row, indexed by the
+	/// column constants below.
+	private record Row(double[] ops, double[] alloc) {
+		/// Cells start negative, meaning "not measured" -- the benchmark class owning this
+		/// column has no such method (JNI has no zero-copy tier, iteration has no orThrow
+		/// variant). They print as N/A instead of as a 0 indistinguishable from a real
+		/// zero-allocation reading.
+		static Row empty() {
+			double[] ops = new double[COLUMNS];
+			double[] alloc = new double[COLUMNS];
+			Arrays.fill(ops, -1);
+			Arrays.fill(alloc, -1);
+			return new Row(ops, alloc);
+		}
+	}
+
+	private static final int FFM_BYTE_ARRAY = 0;
+	private static final int FFM_ZERO_COPY = 1;
+	private static final int JNI_BYTE_ARRAY = 2;
+	private static final int COLUMNS = 3;
+
+	/// JMH secondary result carrying allocation normalized per operation.
+	private static final String ALLOC_NORM = "gc.alloc.rate.norm";
+
+	static void main() throws Exception {
+		Map<ComboKey, Row> getResults = new TreeMap<>();
+		Map<ComboKey, Row> iterateResults = new TreeMap<>();
+
+		System.out.printf("%n=== FFM ===%n%n");
+		collect(FfmScaleBenchmark.class, getResults, iterateResults,
+				Map.of("getByteArray", FFM_BYTE_ARRAY,
+						"getZeroCopy", FFM_ZERO_COPY),
+				Map.of("iterateByteArray", FFM_BYTE_ARRAY,
+						"iterateZeroCopy", FFM_ZERO_COPY));
+
+		System.out.printf("%n=== JNI ===%n%n");
+		collect(JniScaleBenchmark.class, getResults, iterateResults,
+				Map.of("getByteArray", JNI_BYTE_ARRAY),
+				Map.of("iterateByteArray", JNI_BYTE_ARRAY));
+
+		printTable("get(key)", getResults);
+		printTable("iterator.next() + value()", iterateResults);
+	}
+
+	private static void collect(Class<?> benchClass, Map<ComboKey, Row> getResults,
+	                            Map<ComboKey, Row> iterateResults, Map<String, Integer> getColumns,
+	                            Map<String, Integer> iterateColumns) throws Exception {
+		OptionsBuilder builder = new OptionsBuilder();
+		builder.include(benchClass.getSimpleName());
+		builder.addProfiler(GCProfiler.class);
+		String forks = System.getProperty("jmh.forks");
+		if (forks != null) {
+			builder.forks(Integer.parseInt(forks));
+		}
+		Options opt = builder.build();
+		Collection<RunResult> results = new Runner(opt).run();
+		for (RunResult r : results) {
+			String name = r.getPrimaryResult().getLabel();
+			int keyCount = Integer.parseInt(r.getParams().getParam("keyCount"));
+			int valueSize = Integer.parseInt(r.getParams().getParam("valueSize"));
+			ComboKey key = new ComboKey(keyCount, valueSize);
+
+			Integer getColumn = getColumns.get(name);
+			if (getColumn != null) {
+				record(getResults.computeIfAbsent(key, k -> Row.empty()), getColumn, r);
+			}
+			Integer iterateColumn = iterateColumns.get(name);
+			if (iterateColumn != null) {
+				record(iterateResults.computeIfAbsent(key, k -> Row.empty()), iterateColumn, r);
+			}
+		}
+	}
+
+	private static void record(Row row, int column, RunResult r) {
+		row.ops()[column] = r.getPrimaryResult().getStatistics().getMean();
+		Result<?> alloc = r.getSecondaryResults().get(ALLOC_NORM);
+		// Negative marks "profiler produced no value", which prints as N/A rather than
+		// as a misleading 0 B/op -- 0 is a real, meaningful reading for the zero-copy tiers.
+		row.alloc()[column] = alloc != null ? alloc.getScore() : -1;
+	}
+
+	private static void printTable(String title, Map<ComboKey, Row> results) {
+		System.out.printf("%n=== %s: throughput (ops/s) ===%n%n", title);
+		System.out.println("=".repeat(104));
+		System.out.printf("%-10s %-10s %16s %16s %16s %10s %10s%n",
+				"Keys", "ValueSize", "FFM byte[]", "FFM zero-copy", "JNI byte[]",
+				"ZC gain*", "FFM gain**");
+		System.out.println("-".repeat(104));
+		for (Map.Entry<ComboKey, Row> e : results.entrySet()) {
+			ComboKey key = e.getKey();
+			double[] v = e.getValue().ops();
+			String zcGain = gain(v[FFM_ZERO_COPY], v[FFM_BYTE_ARRAY]);
+			String ffmGain = gain(v[FFM_BYTE_ARRAY], v[JNI_BYTE_ARRAY]);
+			System.out.printf("%-10d %-10d %16s %16s %16s %s %s%n",
+					key.keyCount(), key.valueSize(), ops(v[FFM_BYTE_ARRAY]), ops(v[FFM_ZERO_COPY]),
+					ops(v[JNI_BYTE_ARRAY]), zcGain, ffmGain);
+		}
+		System.out.println("-".repeat(104));
+		System.out.println("* FFM zero-copy vs FFM byte[]   ** FFM byte[] vs JNI byte[]");
+		System.out.println("=".repeat(104));
+
+		System.out.printf("%n=== %s: allocation (bytes/op) ===%n%n", title);
+		System.out.println("=".repeat(77));
+		System.out.printf("%-10s %-10s %16s %16s %16s%n",
+				"Keys", "ValueSize", "FFM byte[]", "FFM zero-copy", "JNI byte[]");
+		System.out.println("-".repeat(77));
+		for (Map.Entry<ComboKey, Row> e : results.entrySet()) {
+			ComboKey key = e.getKey();
+			double[] v = e.getValue().alloc();
+			System.out.printf("%-10d %-10d %16s %16s %16s%n",
+					key.keyCount(), key.valueSize(), bytes(v[FFM_BYTE_ARRAY]), bytes(v[FFM_ZERO_COPY]),
+					bytes(v[JNI_BYTE_ARRAY]));
+		}
+		System.out.println("=".repeat(77));
+	}
+
+	// Locale.ROOT: the default locale renders the grouping separator per-machine (a Swiss
+	// JVM prints 2'131'318), which makes committed benchmark numbers differ by who ran them.
+	private static String gain(double value, double baseline) {
+		return baseline > 0 && value >= 0
+				? String.format(Locale.ROOT, "%+9.1f%%", (value - baseline) / baseline * 100)
+				: "      N/A";
+	}
+
+	private static String ops(double value) {
+		return value < 0 ? "N/A" : String.format(Locale.ROOT, "%,.0f", value);
+	}
+
+	private static String bytes(double value) {
+		return value < 0 ? "N/A" : String.format(Locale.ROOT, "%,.1f", value);
+	}
+
+	private ScaleBenchmarkRunner() {
+		// no instances
+	}
+}

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/TestData.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/TestData.java
@@ -43,7 +43,7 @@ final class TestData {
 		return randomBytes(count, BATCH_VALUE_SIZE);
 	}
 
-	private static byte[][] randomBytes(int count, int size) {
+	static byte[][] randomBytes(int count, int size) {
 		byte[][] result = new byte[count][];
 		for (int i = 0; i < count; i++) {
 			byte[] bytes = new byte[size];

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
@@ -1,0 +1,67 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/// FFM wrapper for `rocksdb_pinnableslice_t` — the pinned-value handle returned by the
+/// byte[]-tier `rocksdb_*get_pinned[_cf]` family (`rocksdb_get_pinned[_cf]`,
+/// `rocksdb_transaction_get_pinned[_cf]`, `rocksdb_transactiondb_get_pinned[_cf]`).
+///
+/// Not the same native type as `rocksdb_pinnable_handle_t` (see `RocksDB.withPinned`),
+/// which is the newer, zero-copy `_v2` handle. `Transaction` and `TransactionDB` have no
+/// `_v2` equivalent in `rocksdb/include/rocksdb/c.h`, so they still go through this
+/// older API.
+///
+/// Package-private: purely internal plumbing for the `get_pinned`-based `get(...)`
+/// overloads on [RocksDB], [Transaction], and [TransactionDB] — never returned to callers.
+/// This is the single mapping of `rocksdb_pinnableslice_value`/`_destroy`; those three
+/// classes used to each map the same two symbols independently.
+final class PinnableSlice extends NativeObject {
+
+	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
+	private static final MethodHandle MH_VALUE;
+	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
+	private static final MethodHandle MH_DESTROY;
+
+	static {
+		MH_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
+				FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+		MH_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+	}
+
+	private PinnableSlice(MemorySegment ptr) {
+		super(ptr);
+	}
+
+	/// Wraps `ptr`, or returns `null` if `ptr` is `MemorySegment.NULL` — the
+	/// `get_pinned`/`get_pinned_cf` downcalls return NULL for NotFound or error (the two
+	/// are distinguished only by `errptr`, which callers must check separately).
+	///
+	/// @param ptr the raw `rocksdb_pinnableslice_t*`, or `MemorySegment.NULL`
+	/// @return a wrapper owning `ptr`, or `null` if `ptr` is `MemorySegment.NULL`
+	static PinnableSlice wrapOrNull(MemorySegment ptr) {
+		return MemorySegment.NULL.equals(ptr) ? null : new PinnableSlice(ptr);
+	}
+
+	/// Returns the raw value pointer and writes its length into `vallenOut`, a
+	/// caller-allocated `size_t*` slot.
+	///
+	/// @param vallenOut native slot to receive the value's length
+	/// @return pointer to the value's bytes
+	MemorySegment value(MemorySegment vallenOut) {
+		try {
+			return (MemorySegment) MH_VALUE.invokeExact(ptr(), vallenOut);
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("pinnableslice value failed", t);
+		}
+	}
+
+	@Override
+	protected void tryClose(MemorySegment ptr) throws Throwable {
+		MH_DESTROY.invokeExact(ptr);
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
@@ -1,9 +1,12 @@
 package io.github.dfa1.rocksdbffm;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /// FFM wrapper for `rocksdb_pinnableslice_t` — the pinned-value handle returned by the
 /// byte[]-tier `rocksdb_*get_pinned[_cf]` family (`rocksdb_get_pinned[_cf]`,
@@ -15,9 +18,12 @@ import java.lang.invoke.MethodHandle;
 /// older API.
 ///
 /// Package-private: purely internal plumbing for the `get_pinned`-based `get(...)`
-/// overloads on [RocksDB], [Transaction], and [TransactionDB] — never returned to callers.
-/// This is the single mapping of `rocksdb_pinnableslice_value`/`_destroy`; those three
-/// classes used to each map the same two symbols independently.
+/// overloads on [RocksDB], [Transaction], and [TransactionDB] — never returned to
+/// callers. This is the single mapping of `rocksdb_pinnableslice_value`/`_destroy`;
+/// those three classes used to each map the same two symbols independently. Beyond that
+/// mapping, this class also owns every way a pinned value gets consumed — copy to
+/// `byte[]`, copy into a caller's buffer, or a zero-copy [Mapper] callback — so callers
+/// never touch the raw pointer.
 final class PinnableSlice extends NativeObject {
 
 	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
@@ -47,12 +53,80 @@ final class PinnableSlice extends NativeObject {
 		return MemorySegment.NULL.equals(ptr) ? null : new PinnableSlice(ptr);
 	}
 
+	/// Copies this slice's value into a freshly allocated array.
+	///
+	/// @param arena arena to allocate the native length scratch slot in
+	/// @return the value's bytes, copied into a new array
+	byte[] toByteArray(Arena arena) {
+		MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+		MemorySegment data = value(lenSeg);
+		long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+		return data.reinterpret(len).toArray(ValueLayout.JAVA_BYTE);
+	}
+
+	/// Copies this slice's value into `dest`, or reports insufficient capacity without
+	/// copying anything.
+	///
+	/// @param arena       arena to allocate the native length scratch slot in
+	/// @param dest        destination segment to copy into
+	/// @param destCapacity `dest`'s usable capacity in bytes
+	/// @return [CopyResult.Copied] on success, [CopyResult.NotEnoughCapacity] if `dest` is too small
+	CopyResult copyInto(Arena arena, MemorySegment dest, long destCapacity) {
+		MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+		MemorySegment data = value(lenSeg);
+		long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+		if (len > destCapacity) {
+			return new CopyResult.NotEnoughCapacity(len);
+		}
+		dest.copyFrom(data.reinterpret(len));
+		return new CopyResult.Copied();
+	}
+
+	/// [ByteBuffer] counterpart of [#copyInto(Arena, MemorySegment, long)]; also advances
+	/// `dest`'s position by the copied length on success.
+	///
+	/// @param arena arena to allocate the native length scratch slot in
+	/// @param dest  direct [ByteBuffer] to copy into
+	/// @return [CopyResult.Copied] on success, [CopyResult.NotEnoughCapacity] if `dest` is too small
+	CopyResult copyInto(Arena arena, ByteBuffer dest) {
+		MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+		MemorySegment data = value(lenSeg);
+		long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+		if (len > dest.remaining()) {
+			return new CopyResult.NotEnoughCapacity(len);
+		}
+		MemorySegment.ofBuffer(dest).copyFrom(data.reinterpret(len));
+		dest.position(dest.position() + (int) len);
+		return new CopyResult.Copied();
+	}
+
+	/// Maps this slice's value to a result via `fn`, with no intermediate copy. The view
+	/// passed to `fn` is bound to `arena` and read-only; it must not be retained beyond
+	/// the call, per [Mapper]'s contract.
+	///
+	/// @param arena arena to allocate the native length scratch slot in and bind the view to
+	/// @param fn    callback invoked with a zero-copy view of this slice's value
+	/// @param <R>   the type produced by `fn`
+	/// @throws NullPointerException if `fn` returns `null`
+	/// @return the non-null result of `fn`
+	<R> R map(Arena arena, Mapper<R> fn) {
+		MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+		MemorySegment data = value(lenSeg);
+		long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+		// The `null` cleanup is deliberate: this view borrows from the slice, it does
+		// not own the memory, so closing `arena` must not attempt to free it.
+		MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
+		R result = fn.map(view);
+		Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
+		return result;
+	}
+
 	/// Returns the raw value pointer and writes its length into `vallenOut`, a
 	/// caller-allocated `size_t*` slot.
 	///
 	/// @param vallenOut native slot to receive the value's length
 	/// @return pointer to the value's bytes
-	MemorySegment value(MemorySegment vallenOut) {
+	private MemorySegment value(MemorySegment vallenOut) {
 		try {
 			return (MemorySegment) MH_VALUE.invokeExact(ptr(), vallenOut);
 		} catch (Throwable t) {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -676,13 +676,7 @@ public final class RocksDB {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, k, (long) key.length, err);
 			checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
@@ -780,9 +774,10 @@ public final class RocksDB {
 	/// `destroyHandle` stay as raw [MethodHandle] parameters rather than going through a
 	/// wrapper type: `MH_PINNABLE_HANDLE_GET_VALUE`/`MH_PINNABLE_HANDLE_DESTROY` are
 	/// already mapped exactly once, right here, so there is no duplication to hide behind
-	/// a wrapper. Contrast with [#withPinnableSlice] below, for the older
-	/// `rocksdb_pinnableslice_t` API, where [PinnableSlice] exists specifically because
-	/// that mapping used to be duplicated across three classes.
+	/// a wrapper. Contrast with the older `rocksdb_pinnableslice_t` API, where
+	/// [PinnableSlice] owns both the mapping and every way a pinned value gets consumed
+	/// (copy to `byte[]`, copy into a buffer, or this same [Mapper] callback pattern),
+	/// since that mapping used to be duplicated across three classes.
 	///
 	/// The caller has already opened `arena` in its own try-with-resources (closed once
 	/// this method returns) and obtained `scratch` (its `errptr` slot) and `handle` (or
@@ -832,36 +827,6 @@ public final class RocksDB {
 				// exception already in flight from fn.map above. Same convention as
 				// NativeObject#close().
 			}
-		}
-	}
-
-	/// Shared core for the `rocksdb_pinnableslice_t`-based scoped `get(key, Mapper)`,
-	/// used by [TransactionDB] and [Transaction] — the only two wrappers whose C API has
-	/// no `_v2`/`pinnable_handle_t` equivalent (see `rocksdb/include/rocksdb/c.h`). The
-	/// caller has already opened `arena` in its own try-with-resources (closed once this
-	/// method returns) and obtained `err` (its `errptr` slot) and `pin` (or
-	/// `MemorySegment.NULL` for NotFound/error) via its own class-specific
-	/// `get_pinned`/`get_pinned_cf` downcall.
-	///
-	/// [PinnableSlice] owns the destroy step here (via its inherited
-	/// `NativeObject#close()`, which swallows a destroy failure the same way
-	/// [#withPinnedCore] does), so this method needs no `finally` of its own — the
-	/// try-with-resources on `slice` runs before this method returns, BEFORE the
-	/// caller's own try-with-resources closes `arena`, for the same reason
-	/// [#withPinnedCore] destroys its handle before `arena` closes.
-	static <R> Optional<R> withPinnableSlice(Arena arena, MemorySegment err, MemorySegment pin, Mapper<R> fn) {
-		checkError(err);
-		try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-			if (slice == null) {
-				return Optional.empty();
-			}
-			MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment data = slice.value(lenSeg);
-			long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
-			MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
-			R result = fn.map(view);
-			Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
-			return Optional.of(result);
 		}
 	}
 
@@ -1610,13 +1575,7 @@ public final class RocksDB {
 					db, readOpts, cf.ptr(), toNative(arena, key), (long) key.length, err);
 			checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -62,10 +62,6 @@ public final class RocksDB {
 	private static final MethodHandle MH_GET_PINNED;
 	/// `unsigned char rocksdb_get_into_buffer(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char* buffer, size_t buffer_size, size_t* vallen, unsigned char* found, char** errptr);`
 	private static final MethodHandle MH_GET_INTO_BUFFER;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 	/// `rocksdb_pinnable_handle_t* rocksdb_get_pinned_v2(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char** errptr);`
 	private static final MethodHandle MH_GET_PINNED_V2;
 	/// `rocksdb_pinnable_handle_t* rocksdb_get_pinned_cf_v2(rocksdb_t* db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char** errptr);`
@@ -216,12 +212,6 @@ public final class RocksDB {
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS));
 
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
 		// get_pinned_*_v2 can block on disk I/O (a Get), so it must NOT be marked
 		// critical: a critical downcall stalls GC for its entire duration.
@@ -685,15 +675,15 @@ public final class RocksDB {
 			MemorySegment k = toNative(arena, key);
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, k, (long) key.length, err);
 			checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -785,19 +775,19 @@ public final class RocksDB {
 		}
 	}
 
-	/// Shared core for every scoped zero-copy `get(key, Mapper)` in this codebase,
-	/// regardless of which native handle kind backs it: `rocksdb_pinnable_handle_t`
-	/// (`get_pinned_v2`/`_cf_v2`, used everywhere a plain `rocksdb_t*` exists — see
-	/// [#withPinned]/[#withPinnedCf] above) or `rocksdb_pinnableslice_t` (the older API,
-	/// still needed by [TransactionDB] and [Transaction] — the only two wrappers with no
-	/// `_v2` equivalent in `rocksdb/include/rocksdb/c.h`). Both handle kinds expose the
-	/// same shape — `getValue(handle, size_t* vallen) -> const char*` then
-	/// `destroy(handle) -> void` — so one method covers both; `valueHandle`/
-	/// `destroyHandle` are the caller's own bindings for whichever pair applies. The
-	/// caller has already opened `arena` in its own try-with-resources (closed once this
-	/// method returns) and obtained `scratch` (its `errptr` slot) and `handle` (or
+	/// Shared core for the `rocksdb_pinnable_handle_t`-based scoped `get(key, Mapper)` —
+	/// used only by [#withPinned]/[#withPinnedCf] above, which is why `valueHandle`/
+	/// `destroyHandle` stay as raw [MethodHandle] parameters rather than going through a
+	/// wrapper type: `MH_PINNABLE_HANDLE_GET_VALUE`/`MH_PINNABLE_HANDLE_DESTROY` are
+	/// already mapped exactly once, right here, so there is no duplication to hide behind
+	/// a wrapper. Contrast with [#withPinnableSlice] below, for the older
+	/// `rocksdb_pinnableslice_t` API, where [PinnableSlice] exists specifically because
+	/// that mapping used to be duplicated across three classes.
+	///
+	/// The caller has already opened `arena` in its own try-with-resources (closed once
+	/// this method returns) and obtained `scratch` (its `errptr` slot) and `handle` (or
 	/// `MemorySegment.NULL` for NotFound/error) via its own class-specific
-	/// `get_pinned`/`get_pinned_cf` downcall.
+	/// `get_pinned_v2`/`get_pinned_cf_v2` downcall.
 	///
 	/// `scratch` is the same native slot the caller already used as `errptr`: once
 	/// [#checkError] passes below, that slot is dead, so `valueHandle`'s
@@ -842,6 +832,36 @@ public final class RocksDB {
 				// exception already in flight from fn.map above. Same convention as
 				// NativeObject#close().
 			}
+		}
+	}
+
+	/// Shared core for the `rocksdb_pinnableslice_t`-based scoped `get(key, Mapper)`,
+	/// used by [TransactionDB] and [Transaction] — the only two wrappers whose C API has
+	/// no `_v2`/`pinnable_handle_t` equivalent (see `rocksdb/include/rocksdb/c.h`). The
+	/// caller has already opened `arena` in its own try-with-resources (closed once this
+	/// method returns) and obtained `err` (its `errptr` slot) and `pin` (or
+	/// `MemorySegment.NULL` for NotFound/error) via its own class-specific
+	/// `get_pinned`/`get_pinned_cf` downcall.
+	///
+	/// [PinnableSlice] owns the destroy step here (via its inherited
+	/// `NativeObject#close()`, which swallows a destroy failure the same way
+	/// [#withPinnedCore] does), so this method needs no `finally` of its own — the
+	/// try-with-resources on `slice` runs before this method returns, BEFORE the
+	/// caller's own try-with-resources closes `arena`, for the same reason
+	/// [#withPinnedCore] destroys its handle before `arena` closes.
+	static <R> Optional<R> withPinnableSlice(Arena arena, MemorySegment err, MemorySegment pin, Mapper<R> fn) {
+		checkError(err);
+		try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+			if (slice == null) {
+				return Optional.empty();
+			}
+			MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment data = slice.value(lenSeg);
+			long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+			MemorySegment view = data.reinterpret(len, arena, null).asReadOnly();
+			R result = fn.map(view);
+			Objects.requireNonNull(result, "Mapper.map(MemorySegment) must not return null");
+			return Optional.of(result);
 		}
 	}
 
@@ -1589,15 +1609,15 @@ public final class RocksDB {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
 					db, readOpts, cf.ptr(), toNative(arena, key), (long) key.length, err);
 			checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -248,13 +248,7 @@ public final class Transaction extends NativeObject {
 			RocksDB.checkError(err);
 
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -276,18 +270,7 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.remaining()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-				value.position(value.position() + (int) valLen);
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -309,17 +292,7 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.byteSize()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				value.copyFrom(valPtr.reinterpret(valLen));
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value, value.byteSize());
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -349,7 +322,10 @@ public final class Transaction extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnableSlice(arena, err, pin, fn);
+			RocksDB.checkError(err);
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				return slice == null ? Optional.empty() : Optional.of(slice.map(arena, fn));
+			}
 		}
 	}
 
@@ -569,13 +545,7 @@ public final class Transaction extends NativeObject {
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -599,18 +569,7 @@ public final class Transaction extends NativeObject {
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.remaining()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-				value.position(value.position() + (int) valLen);
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -633,17 +592,7 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.byteSize()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				value.copyFrom(valPtr.reinterpret(valLen));
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value, value.byteSize());
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
@@ -672,7 +621,10 @@ public final class Transaction extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnableSlice(arena, err, pin, fn);
+			RocksDB.checkError(err);
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				return slice == null ? Optional.empty() : Optional.of(slice.map(arena, fn));
+			}
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -51,10 +51,6 @@ public final class Transaction extends NativeObject {
 	private static final MethodHandle MH_GET_PINNED;
 	/// `char* rocksdb_transaction_get_for_update(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, const char* key, size_t klen, size_t* vlen, unsigned char exclusive, char** errptr);`
 	private static final MethodHandle MH_GET_FOR_UPDATE;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 
 	static {
 		MH_COMMIT = NativeLibrary.lookup("rocksdb_transaction_commit",
@@ -97,13 +93,6 @@ public final class Transaction extends NativeObject {
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE,
 						ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
 
 		MH_PUT_CF = NativeLibrary.lookup("rocksdb_transaction_put_cf",
@@ -258,16 +247,15 @@ public final class Transaction extends NativeObject {
 
 			RocksDB.checkError(err);
 
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -287,20 +275,20 @@ public final class Transaction extends NativeObject {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
 					ptr(), readOptions.ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.remaining()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+				value.position(value.position() + (int) valLen);
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.remaining()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-			value.position(value.position() + (int) valLen);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -320,19 +308,19 @@ public final class Transaction extends NativeObject {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(
 					ptr(), readOptions.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.byteSize()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				value.copyFrom(valPtr.reinterpret(valLen));
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.byteSize()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			value.copyFrom(valPtr.reinterpret(valLen));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -361,7 +349,7 @@ public final class Transaction extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+			return RocksDB.withPinnableSlice(arena, err, pin, fn);
 		}
 	}
 
@@ -580,15 +568,15 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr(),
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -610,20 +598,20 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.remaining()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+				value.position(value.position() + (int) valLen);
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.remaining()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-			value.position(value.position() + (int) valLen);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -644,19 +632,19 @@ public final class Transaction extends NativeObject {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
 					ptr(), readOptions.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.byteSize()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				value.copyFrom(valPtr.reinterpret(valLen));
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.byteSize()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			value.copyFrom(valPtr.reinterpret(valLen));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("Native call failed", t);
 		}
@@ -684,7 +672,7 @@ public final class Transaction extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+			return RocksDB.withPinnableSlice(arena, err, pin, fn);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -443,7 +443,10 @@ public final class TransactionDB extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnableSlice(arena, err, pin, fn);
+			RocksDB.checkError(err);
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				return slice == null ? Optional.empty() : Optional.of(slice.map(arena, fn));
+			}
 		}
 	}
 
@@ -652,13 +655,7 @@ public final class TransactionDB extends NativeObject {
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return null;
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
+				return slice == null ? null : slice.toByteArray(arena);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
@@ -681,18 +678,7 @@ public final class TransactionDB extends NativeObject {
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.remaining()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-				value.position(value.position() + (int) valLen);
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value);
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
@@ -714,17 +700,7 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				if (slice == null) {
-					return new CopyResult.NotFound();
-				}
-				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-				MemorySegment valPtr = slice.value(valLenSeg);
-				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-				if (valLen > value.byteSize()) {
-					return new CopyResult.NotEnoughCapacity(valLen);
-				}
-				value.copyFrom(valPtr.reinterpret(valLen));
-				return new CopyResult.Copied();
+				return slice == null ? new CopyResult.NotFound() : slice.copyInto(arena, value, value.byteSize());
 			}
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
@@ -749,7 +725,10 @@ public final class TransactionDB extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnableSlice(arena, err, pin, fn);
+			RocksDB.checkError(err);
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				return slice == null ? Optional.empty() : Optional.of(slice.map(arena, fn));
+			}
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -68,10 +68,6 @@ public final class TransactionDB extends NativeObject {
 	private static final MethodHandle MH_CREATE_ITERATOR_CF;
 	/// `void rocksdb_transactiondb_flush_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_flushoptions_t* options, rocksdb_column_family_handle_t* column_family, char** errptr);`
 	private static final MethodHandle MH_FLUSH_CF;
-	/// `const char* rocksdb_pinnableslice_value(const rocksdb_pinnableslice_t* t, size_t* vlen);`
-	private static final MethodHandle MH_PINNABLESLICE_VALUE;
-	/// `void rocksdb_pinnableslice_destroy(rocksdb_pinnableslice_t* v);`
-	private static final MethodHandle MH_PINNABLESLICE_DESTROY;
 
 
 	static {
@@ -134,14 +130,6 @@ public final class TransactionDB extends NativeObject {
 		MH_FLUSH_CF = NativeLibrary.lookup("rocksdb_transactiondb_flush_cf",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_VALUE = NativeLibrary.lookup("rocksdb_pinnableslice_value",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-
-		MH_PINNABLESLICE_DESTROY = NativeLibrary.lookup("rocksdb_pinnableslice_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
-
 
 		MH_CREATE_SNAPSHOT = NativeLibrary.lookup("rocksdb_transactiondb_create_snapshot",
 				FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
@@ -455,7 +443,7 @@ public final class TransactionDB extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+			return RocksDB.withPinnableSlice(arena, err, pin, fn);
 		}
 	}
 
@@ -663,15 +651,15 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr(),
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return null;
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return null;
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				return valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] result = valPtr.reinterpret(valLen).toArray(ValueLayout.JAVA_BYTE);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return result;
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -692,20 +680,20 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOpts.ptr(), cf.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.remaining()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
+				value.position(value.position() + (int) valLen);
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.remaining()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			MemorySegment.ofBuffer(value).copyFrom(valPtr.reinterpret(valLen));
-			value.position(value.position() + (int) valLen);
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -725,19 +713,19 @@ public final class TransactionDB extends NativeObject {
 			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
 					ptr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
-			if (MemorySegment.NULL.equals(pin)) {
-				return new CopyResult.NotFound();
+			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
+				if (slice == null) {
+					return new CopyResult.NotFound();
+				}
+				MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+				MemorySegment valPtr = slice.value(valLenSeg);
+				long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
+				if (valLen > value.byteSize()) {
+					return new CopyResult.NotEnoughCapacity(valLen);
+				}
+				value.copyFrom(valPtr.reinterpret(valLen));
+				return new CopyResult.Copied();
 			}
-			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
-			MemorySegment valPtr = (MemorySegment) MH_PINNABLESLICE_VALUE.invokeExact(pin, valLenSeg);
-			long valLen = valLenSeg.get(ValueLayout.JAVA_LONG, 0);
-			if (valLen > value.byteSize()) {
-				MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-				return new CopyResult.NotEnoughCapacity(valLen);
-			}
-			value.copyFrom(valPtr.reinterpret(valLen));
-			MH_PINNABLESLICE_DESTROY.invokeExact(pin);
-			return new CopyResult.Copied();
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -761,7 +749,7 @@ public final class TransactionDB extends NativeObject {
 			} catch (Throwable t) {
 				throw RocksDBException.wrap("get_pinned failed", t);
 			}
-			return RocksDB.withPinnedCore(arena, err, pin, MH_PINNABLESLICE_VALUE, MH_PINNABLESLICE_DESTROY, fn);
+			return RocksDB.withPinnableSlice(arena, err, pin, fn);
 		}
 	}
 

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -4,12 +4,17 @@
 # Usage:
 #   ./scripts/benchmark.sh                     # the FFM-vs-JNI comparison table
 #   ./scripts/benchmark.sh PinnedReadBenchmark # a single benchmark class
+#
+# Anything after the class name is passed straight to the JVM, e.g.
+#   ./scripts/benchmark.sh ScaleBenchmarkRunner -Djmh.forks=2
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 MAIN_CLASS="io.github.dfa1.rocksdbffm.benchmark.${1:-BenchmarkRunner}"
+shift || true
+JVM_ARGS=("$@")
 
 # One reactor invocation builds every upstream module and resolves the test-scope
 # classpath from it. Inside a single session Maven resolves sibling modules to their
@@ -30,5 +35,6 @@ CP="benchmarks/target/test-classes:benchmarks/target/classes:$DEPS"
 echo ">>> Running ${MAIN_CLASS}..."
 java --enable-native-access=ALL-UNNAMED \
     --sun-misc-unsafe-memory-access=allow \
+    ${JVM_ARGS[@]+"${JVM_ARGS[@]}"} \
     -cp "$CP" \
     "$MAIN_CLASS"


### PR DESCRIPTION
Two related pieces of work: a `PinnableSlice` wrapper that de-duplicates the pinned-value plumbing, and a scale benchmark suite trustworthy enough to tell whether any of it matters.

## PinnableSlice

`rocksdb_pinnableslice_value`/`_destroy` were mapped independently in `RocksDB`, `Transaction`, and `TransactionDB`, with the copy/consume logic repeated at every call site. `PinnableSlice` now owns that mapping exactly once, plus every way a pinned value gets consumed — copy to `byte[]`, copy into a caller's buffer, or a zero-copy `Mapper` callback. It extends `NativeObject`, so cleanup runs on the exception path and a double `close()` is a no-op rather than a JVM crash.

`withPinnedCore` keeps raw `MethodHandle` parameters deliberately: it backs only the newer `rocksdb_pinnable_handle_t` (`_v2`) API, whose handles are mapped exactly once already, so there is no duplication for a wrapper to hide. `Transaction`/`TransactionDB` have no `_v2` equivalent in `c.h` and go through `PinnableSlice`.

## Scale benchmarks

`FfmScaleBenchmark`/`JniScaleBenchmark` sweep `keyCount` × `valueSize` and compare the copy tier against zero-copy on both `get` and iteration; `ScaleBenchmarkRunner` prints them side by side.

These were initially unusable — `getZeroCopy` at 100k/8B gave 1,657,185 ops/s ± 416,044 stdev (25%), bimodal across forks. The cause was LSM shape, not the data: keys were already deterministic (`Random(42)`, fresh JVM per fork), but setup measured immediately after writing, so the lookup key came from the memtable in one fork and an SST in the next. Both suites now `flush(wait)` + `compactRange()` first, taking the same combo to 2,153,196 ops/s ± 29,957 (1.4%).

## Allocation

The runner attaches `GCProfiler` and prints `gc.alloc.rate.norm` beside throughput — exact and repeatable where throughput still carries a few percent of noise, and the metric the zero-copy tiers exist to move:

| path | 8 B values | 1 KB values |
|---|---|---|
| get, byte[] (FFM) | 168 B/op | 1,184 B/op |
| get, zero-copy | 224 B/op | 248 B/op |
| get, byte[] (JNI) | 24 B/op | 1,040 B/op |
| iterate, byte[] | 24 B/op | 1,040 B/op |
| iterate, zero-copy | **0 B/op** | **0 B/op** |

Zero-copy iteration is genuinely allocation-free. Zero-copy `get` is not: it allocates a constant ~224 B/op regardless of value size, which is why it loses to the copying path at 8-byte values and only wins from ~1 KB up.

That constant is the per-call `Arena.ofConfined()` in `withPinned` — it escapes into `errHolder()` and cannot scalar-replace. `RocksIterator` hoists its arena to a field and reaches 0. The same fix is not directly transferable: `RocksIterator` is single-threaded by RocksDB contract, while `ReadWriteDB.get` can be called concurrently, and a confined arena in a field would throw `WrongThreadException`. Left as follow-up.

## Testing

663 tests pass, `javadoc:javadoc` clean. Benchmarks run with 5 forks throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)