### PR TITLE
refactor: move byte[] get to rocksdb_get_pinned_v2

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -58,8 +58,6 @@ public final class RocksDB {
 
 	/// `void rocksdb_close(rocksdb_t* db);`
 	private static final MethodHandle MH_CLOSE;
-	/// `rocksdb_pinnableslice_t* rocksdb_get_pinned(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char** errptr);`
-	private static final MethodHandle MH_GET_PINNED;
 	/// `unsigned char rocksdb_get_into_buffer(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char* buffer, size_t buffer_size, size_t* vallen, unsigned char* found, char** errptr);`
 	private static final MethodHandle MH_GET_INTO_BUFFER;
 	/// `rocksdb_pinnable_handle_t* rocksdb_get_pinned_v2(rocksdb_t* db, const rocksdb_readoptions_t* options, const char* key, size_t keylen, char** errptr);`
@@ -133,8 +131,6 @@ public final class RocksDB {
 	private static final MethodHandle MH_DROP_CF;
 	/// `void rocksdb_put_cf(rocksdb_t* db, const rocksdb_writeoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, const char* val, size_t vallen, char** errptr);`
 	private static final MethodHandle MH_PUT_CF;
-	/// `rocksdb_pinnableslice_t* rocksdb_get_pinned_cf(rocksdb_t* db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char** errptr);`
-	private static final MethodHandle MH_GET_PINNED_CF;
 	/// `unsigned char rocksdb_get_into_buffer_cf(rocksdb_t* db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char* buffer, size_t buffer_size, size_t* vallen, unsigned char* found, char** errptr);`
 	private static final MethodHandle MH_GET_INTO_BUFFER_CF;
 	/// `void rocksdb_delete_cf(rocksdb_t* db, const rocksdb_writeoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char** errptr);`
@@ -197,12 +193,6 @@ public final class RocksDB {
 
 		MH_CLOSE = NativeLibrary.lookup("rocksdb_close",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
-
-		MH_GET_PINNED = NativeLibrary.lookup("rocksdb_get_pinned",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
-						ValueLayout.ADDRESS));
 
 		MH_GET_INTO_BUFFER = NativeLibrary.lookup("rocksdb_get_into_buffer",
 				FunctionDescriptor.of(ValueLayout.JAVA_BYTE,
@@ -366,12 +356,6 @@ public final class RocksDB {
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
-						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
-						ValueLayout.ADDRESS));
-
-		MH_GET_PINNED_CF = NativeLibrary.lookup("rocksdb_get_pinned_cf",
-				FunctionDescriptor.of(ValueLayout.ADDRESS,
-						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
 
@@ -668,23 +652,32 @@ public final class RocksDB {
 	// Package-private shared helpers — rocksdb_t* operations, mapped once
 	// -----------------------------------------------------------------------
 
-	/// Single-copy byte[] get: pins the value via `rocksdb_get_pinned` and copies it out
+	/// Single-copy byte[] get: pins the value via `rocksdb_get_pinned_v2` and copies it out
 	/// once. Not zero-copy — the returned array is a copy by definition — but cheaper than
 	/// `rocksdb_get`, which per `c.h` returns "a malloc()ed array" the caller must free:
 	/// that path copies the value into a fresh native buffer first, so producing a byte[]
 	/// from it costs two copies plus a malloc/free round trip. Pinning skips the
 	/// intermediate buffer entirely; `destroy` just drops the pin.
 	///
+	/// Uses the `_v2` handle rather than the older `rocksdb_get_pinned`, per `c.h`'s note
+	/// on that family: "These functions avoid unnecessary memory allocations and copies.
+	/// Bindings should migrate to these for better performance." [Transaction] and
+	/// [TransactionDB] have no `_v2` equivalent in the C API and still go through
+	/// [PinnableSlice].
+	///
 	/// Returns `null` if not found.
 	static byte[] getBytes(MemorySegment db, MemorySegment readOpts, byte[] key) {
+		// Calls withPinnedCore rather than withPinned: this method already needs an arena to
+		// marshal `key`, and withPinned opens its own, so delegating there would pay for two
+		// Arena.ofConfined() per get instead of one.
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment k = toNative(arena, key);
-			MemorySegment pin = (MemorySegment) MH_GET_PINNED.invokeExact(db, readOpts, k, (long) key.length, err);
-			checkError(err);
-			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				return slice == null ? null : slice.toByteArray(arena);
-			}
+			MemorySegment handle = (MemorySegment) MH_GET_PINNED_V2.invokeExact(
+					db, readOpts, k, (long) key.length, err);
+			return withPinnedCore(arena, err, handle, MH_PINNABLE_HANDLE_GET_VALUE,
+					MH_PINNABLE_HANDLE_DESTROY, value -> value.toArray(ValueLayout.JAVA_BYTE))
+					.orElse(null);
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}
@@ -1573,18 +1566,20 @@ public final class RocksDB {
 		}
 	}
 
-	/// Single-copy byte[] get from `cf` via `rocksdb_get_pinned_cf`. See [#getBytes] for why
-	/// this pins rather than calling `rocksdb_get`. Returns `null` if not found.
+	/// Single-copy byte[] get from `cf` via `rocksdb_get_pinned_cf_v2`. See [#getBytes] for
+	/// why this pins rather than calling `rocksdb_get`, and why it uses the `_v2` handle.
+	/// Returns `null` if not found.
 	static byte[] getCfBytes(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
 	                         byte[] key) {
+		// Single arena, same reasoning as getBytes above.
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
-					db, readOpts, cf.ptr(), toNative(arena, key), (long) key.length, err);
-			checkError(err);
-			try (PinnableSlice slice = PinnableSlice.wrapOrNull(pin)) {
-				return slice == null ? null : slice.toByteArray(arena);
-			}
+			MemorySegment k = toNative(arena, key);
+			MemorySegment handle = (MemorySegment) MH_GET_PINNED_CF_V2.invokeExact(
+					db, readOpts, cf.ptr(), k, (long) key.length, err);
+			return withPinnedCore(arena, err, handle, MH_PINNABLE_HANDLE_GET_VALUE,
+					MH_PINNABLE_HANDLE_DESTROY, value -> value.toArray(ValueLayout.JAVA_BYTE))
+					.orElse(null);
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("get failed", t);
 		}


### PR DESCRIPTION
## Why

`c.h:4682` heads the `_v2` Get family with:

> High-performance zero-copy Get variants. These functions avoid unnecessary memory allocations and copies. The returned buffer is valid until the handle is destroyed. **Bindings should migrate to these for better performance.**

The `Mapper`-based `get` migrated when `_v2` was first mapped. The `byte[]` tier never did — it was still calling the older `rocksdb_get_pinned` and going through `PinnableSlice`.

## What

`RocksDB.getBytes`/`getCfBytes` now use `rocksdb_get_pinned_v2`/`rocksdb_get_pinned_cf_v2` and share `withPinnedCore` with the zero-copy path, so pinned-value lifetime logic lives in one place instead of two.

They call `withPinnedCore` directly rather than `withPinned`/`withPinnedCf`, because both already open an arena to marshal the key and those wrappers open their own — delegating would pay for two `Arena.ofConfined()` per get instead of one. (I wrote it the delegating way first; it's the kind of regression that doesn't show up in a correctness test.)

**No new symbol mappings** — all four handles were already mapped. The now-dead `rocksdb_get_pinned`/`_cf` mappings and their `NativeLibrary.lookup` calls are removed, so `RocksDB` no longer touches the older pinnableslice API at all.

`PinnableSlice` is unchanged and still required: `Transaction` and `TransactionDB` have no `_v2` equivalent in the C API (only `rocksdb_transaction_get_pinned`, `_cf`, `_for_update`, `_for_update_cf`, and `rocksdb_transactiondb_get_pinned`, `_cf`).

## Measured

`FfmValueSizeBenchmark.readsValueViaByteArray`, before vs after, full sweep:

| valueSize | alloc before | alloc after | Δ | thrpt before | thrpt after |
|---|---|---|---|---|---|
| 8 B | 224.021 | **120.020** | −104 | 2,288,427 ±18k | 2,361,684 ±108k |
| 16 B | 232.026 | **128.026** | −104 | 1,856,918 ±73k | 1,886,239 ±43k |
| 1 KB | 1,240.020 | **1,136.020** | −104 | 2,441,558 ±57k | 2,485,256 ±173k |
| 4 KB | 4,312.025 | **4,208.024** | −104 | 1,949,933 ±23k | 2,014,342 ±99k |
| 64 KB | 65,752.093 | **65,648.091** | −104 | 526,145 ±1.4k | 529,043 ±16k |
| 1 MB | 1,048,793.223 | **1,048,689.223** | −104 | 39,712 ±189 | 40,027 ±2.4k |

Allocation drops by exactly **104 B/op at every size** (error ±0.15): the `PinnableSlice` wrapper object plus the length segment its `toByteArray` allocated per call.

Throughput is higher in all six rows (+0.6% to +3.3%), but every delta is inside the error bars and these are `@Fork(1)` cross-run numbers rather than a within-run A/B. Treat it as a direction, not a result — the allocation reduction is the claim this PR stands on.

## Testing

- 663 tests pass
- `javadoc:javadoc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)