### PR TITLE
Close ReadOptions C API coverage gap

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ColumnFamilyHandle.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ColumnFamilyHandle.java
@@ -66,7 +66,10 @@ public final class ColumnFamilyHandle extends NativeObject {
 			MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment namePtr = (MemorySegment) MH_GET_NAME.invokeExact(ptr(), lenSeg);
 			long nameLen = lenSeg.get(ValueLayout.JAVA_LONG, 0);
-			byte[] bytes = namePtr.reinterpret(nameLen).toArray(ValueLayout.JAVA_BYTE);
+			// namePtr is malloc'd by CopyString() on the C side (db/c.cc) -- unlike the other
+			// toByteArray() call sites in this codebase, this one owns the pointer and must free it.
+			byte[] bytes = RocksDB.toByteArray(namePtr, nameLen);
+			RocksDB.free(namePtr);
 			return new String(bytes, StandardCharsets.UTF_8);
 		} catch (Throwable t) {
 			throw RocksDBException.wrap("getName failed", t);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableHandle.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableHandle.java
@@ -61,7 +61,7 @@ final class PinnableHandle extends NativeObject {
 	/// @return the value's bytes, copied into a new array
 	byte[] toByteArray(MemorySegment vallenOut) {
 		MemorySegment data = value(vallenOut);
-		return data.reinterpret(vallenOut.get(ValueLayout.JAVA_LONG, 0)).toArray(ValueLayout.JAVA_BYTE);
+		return RocksDB.toByteArray(data, vallenOut.get(ValueLayout.JAVA_LONG, 0));
 	}
 
 	/// Maps this handle's value to a result via `fn`, with no intermediate copy. The view

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
@@ -62,7 +62,7 @@ final class PinnableSlice extends NativeObject {
 	/// @return the value's bytes, copied into a new array
 	byte[] toByteArray(MemorySegment vallenOut) {
 		MemorySegment data = value(vallenOut);
-		return data.reinterpret(vallenOut.get(ValueLayout.JAVA_LONG, 0)).toArray(ValueLayout.JAVA_BYTE);
+		return RocksDB.toByteArray(data, vallenOut.get(ValueLayout.JAVA_LONG, 0));
 	}
 
 	/// Copies this slice's value into `dest`, or reports insufficient capacity without

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOptions.java
@@ -1,9 +1,13 @@
 package io.github.dfa1.rocksdbffm;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 /// FFM wrapper for `rocksdb_readoptions_t`.
 public final class ReadOptions extends NativeObject {
@@ -14,6 +18,44 @@ public final class ReadOptions extends NativeObject {
 	private static final MethodHandle MH_DESTROY;
 	/// `void rocksdb_readoptions_set_snapshot(rocksdb_readoptions_t*, const rocksdb_snapshot_t*);`
 	private static final MethodHandle MH_SET_SNAPSHOT;
+	/// `void rocksdb_readoptions_set_verify_checksums(rocksdb_readoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_VERIFY_CHECKSUMS;
+	/// `unsigned char rocksdb_readoptions_get_verify_checksums(rocksdb_readoptions_t* opt);`
+	private static final MethodHandle MH_GET_VERIFY_CHECKSUMS;
+	/// `void rocksdb_readoptions_set_fill_cache(rocksdb_readoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_FILL_CACHE;
+	/// `unsigned char rocksdb_readoptions_get_fill_cache(rocksdb_readoptions_t* opt);`
+	private static final MethodHandle MH_GET_FILL_CACHE;
+	/// `void rocksdb_readoptions_set_pin_data(rocksdb_readoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_PIN_DATA;
+	/// `unsigned char rocksdb_readoptions_get_pin_data(rocksdb_readoptions_t* opt);`
+	private static final MethodHandle MH_GET_PIN_DATA;
+	/// `void rocksdb_readoptions_set_tailing(rocksdb_readoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_TAILING;
+	/// `unsigned char rocksdb_readoptions_get_tailing(rocksdb_readoptions_t* opt);`
+	private static final MethodHandle MH_GET_TAILING;
+	/// `void rocksdb_readoptions_set_total_order_seek(rocksdb_readoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_TOTAL_ORDER_SEEK;
+	/// `unsigned char rocksdb_readoptions_get_total_order_seek(rocksdb_readoptions_t* opt);`
+	private static final MethodHandle MH_GET_TOTAL_ORDER_SEEK;
+	/// `void rocksdb_readoptions_set_prefix_same_as_start(rocksdb_readoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_PREFIX_SAME_AS_START;
+	/// `unsigned char rocksdb_readoptions_get_prefix_same_as_start(rocksdb_readoptions_t* opt);`
+	private static final MethodHandle MH_GET_PREFIX_SAME_AS_START;
+	/// `void rocksdb_readoptions_set_readahead_size(rocksdb_readoptions_t* opt, size_t v);`
+	private static final MethodHandle MH_SET_READAHEAD_SIZE;
+	/// `size_t rocksdb_readoptions_get_readahead_size(rocksdb_readoptions_t* opt);`
+	private static final MethodHandle MH_GET_READAHEAD_SIZE;
+	/// `void rocksdb_readoptions_set_iterate_lower_bound(rocksdb_readoptions_t*, const char* key, size_t keylen);`
+	private static final MethodHandle MH_SET_ITERATE_LOWER_BOUND;
+	/// `void rocksdb_readoptions_set_iterate_upper_bound(rocksdb_readoptions_t*, const char* key, size_t keylen);`
+	private static final MethodHandle MH_SET_ITERATE_UPPER_BOUND;
+	/// `void rocksdb_readoptions_set_request_id(rocksdb_readoptions_t*, const char* request_id, size_t request_id_len);`
+	private static final MethodHandle MH_SET_REQUEST_ID;
+	/// `void rocksdb_readoptions_clear_request_id(rocksdb_readoptions_t*);`
+	private static final MethodHandle MH_CLEAR_REQUEST_ID;
+	/// `const char* rocksdb_readoptions_get_request_id(rocksdb_readoptions_t*, size_t* request_id_len);`
+	private static final MethodHandle MH_GET_REQUEST_ID;
 
 	static {
 		MH_CREATE = NativeLibrary.lookup("rocksdb_readoptions_create",
@@ -24,10 +66,74 @@ public final class ReadOptions extends NativeObject {
 
 		MH_SET_SNAPSHOT = NativeLibrary.lookup("rocksdb_readoptions_set_snapshot",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+		MH_SET_VERIFY_CHECKSUMS = NativeLibrary.lookup("rocksdb_readoptions_set_verify_checksums",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_VERIFY_CHECKSUMS = NativeLibrary.lookup("rocksdb_readoptions_get_verify_checksums",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_FILL_CACHE = NativeLibrary.lookup("rocksdb_readoptions_set_fill_cache",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_FILL_CACHE = NativeLibrary.lookup("rocksdb_readoptions_get_fill_cache",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_PIN_DATA = NativeLibrary.lookup("rocksdb_readoptions_set_pin_data",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_PIN_DATA = NativeLibrary.lookup("rocksdb_readoptions_get_pin_data",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_TAILING = NativeLibrary.lookup("rocksdb_readoptions_set_tailing",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_TAILING = NativeLibrary.lookup("rocksdb_readoptions_get_tailing",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_TOTAL_ORDER_SEEK = NativeLibrary.lookup("rocksdb_readoptions_set_total_order_seek",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_TOTAL_ORDER_SEEK = NativeLibrary.lookup("rocksdb_readoptions_get_total_order_seek",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_PREFIX_SAME_AS_START = NativeLibrary.lookup("rocksdb_readoptions_set_prefix_same_as_start",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_PREFIX_SAME_AS_START = NativeLibrary.lookup("rocksdb_readoptions_get_prefix_same_as_start",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_READAHEAD_SIZE = NativeLibrary.lookup("rocksdb_readoptions_set_readahead_size",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_READAHEAD_SIZE = NativeLibrary.lookup("rocksdb_readoptions_get_readahead_size",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_ITERATE_LOWER_BOUND = NativeLibrary.lookup("rocksdb_readoptions_set_iterate_lower_bound",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_SET_ITERATE_UPPER_BOUND = NativeLibrary.lookup("rocksdb_readoptions_set_iterate_upper_bound",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_SET_REQUEST_ID = NativeLibrary.lookup("rocksdb_readoptions_set_request_id",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_CLEAR_REQUEST_ID = NativeLibrary.lookup("rocksdb_readoptions_clear_request_id",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+		MH_GET_REQUEST_ID = NativeLibrary.lookup("rocksdb_readoptions_get_request_id",
+				FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 	}
+
+	// Backs iterate_lower_bound/iterate_upper_bound/request_id for the byte[] tier: the C API
+	// stores a raw Slice view over whatever pointer is passed to set_iterate_*_bound rather than
+	// copying it, so a copy made from a bound must outlive this ReadOptions, not just the setter
+	// call. Closed alongside the native pointer in tryClose.
+	private final Arena boundsArena;
 
 	private ReadOptions(MemorySegment ptr) {
 		super(ptr);
+		this.boundsArena = Arena.ofConfined();
 	}
 
 	/// Creates [ReadOptions] with RocksDB defaults.
@@ -57,8 +163,349 @@ public final class ReadOptions extends NativeObject {
 		}
 	}
 
+	/// If `true`, checksums are verified for all data read from disk. Slower but catches
+	/// corruption; block-cache hits are never re-verified regardless of this setting. Default: `true`.
+	///
+	/// @param verifyChecksums `true` to verify checksums on disk reads
+	/// @return `this` for chaining
+	public ReadOptions setVerifyChecksums(boolean verifyChecksums) {
+		try {
+			MH_SET_VERIFY_CHECKSUMS.invokeExact(ptr(), RocksDB.toByte(verifyChecksums));
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setVerifyChecksums failed", t);
+		}
+	}
+
+	/// Returns whether checksums are verified for data read from disk.
+	///
+	/// @return `true` if checksum verification is enabled
+	public boolean isVerifyChecksums() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_VERIFY_CHECKSUMS.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("isVerifyChecksums failed", t);
+		}
+	}
+
+	/// If `true`, blocks read from disk are inserted into the block cache. Set `false` for scans
+	/// that should not evict hotter data from the cache. Default: `true`.
+	///
+	/// @param fillCache `true` to populate the block cache with blocks read for this operation
+	/// @return `this` for chaining
+	public ReadOptions setFillCache(boolean fillCache) {
+		try {
+			MH_SET_FILL_CACHE.invokeExact(ptr(), RocksDB.toByte(fillCache));
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setFillCache failed", t);
+		}
+	}
+
+	/// Returns whether blocks read for this operation are inserted into the block cache.
+	///
+	/// @return `true` if the block cache is populated on read
+	public boolean isFillCache() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_FILL_CACHE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("isFillCache failed", t);
+		}
+	}
+
+	/// If `true`, an iterator's returned keys/values stay valid for the iterator's lifetime
+	/// instead of only until the next `Next()`/`Prev()` call, at the cost of pinning the
+	/// underlying blocks in memory. Default: `false`.
+	///
+	/// @param pinData `true` to pin blocks backing iterator results for the iterator's lifetime
+	/// @return `this` for chaining
+	public ReadOptions setPinData(boolean pinData) {
+		try {
+			MH_SET_PIN_DATA.invokeExact(ptr(), RocksDB.toByte(pinData));
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setPinData failed", t);
+		}
+	}
+
+	/// Returns whether iterator results pin their backing blocks in memory.
+	///
+	/// @return `true` if iterator results stay valid for the iterator's lifetime
+	public boolean isPinData() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_PIN_DATA.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("isPinData failed", t);
+		}
+	}
+
+	/// If `true`, creates a tailing iterator that reflects writes committed after it was created,
+	/// without needing to be recreated. Not compatible with snapshots. Default: `false`.
+	///
+	/// @param tailing `true` to create a tailing iterator
+	/// @return `this` for chaining
+	public ReadOptions setTailing(boolean tailing) {
+		try {
+			MH_SET_TAILING.invokeExact(ptr(), RocksDB.toByte(tailing));
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setTailing failed", t);
+		}
+	}
+
+	/// Returns whether this creates a tailing iterator.
+	///
+	/// @return `true` if a tailing iterator is created
+	public boolean isTailing() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_TAILING.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("isTailing failed", t);
+		}
+	}
+
+	/// If `true`, forces a total-order seek even when the column family uses a prefix extractor,
+	/// bypassing the prefix bloom filter. Needed to seek to a key that does not share the
+	/// iteration prefix. Default: `false`.
+	///
+	/// @param totalOrderSeek `true` to bypass prefix-based seek optimizations
+	/// @return `this` for chaining
+	public ReadOptions setTotalOrderSeek(boolean totalOrderSeek) {
+		try {
+			MH_SET_TOTAL_ORDER_SEEK.invokeExact(ptr(), RocksDB.toByte(totalOrderSeek));
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setTotalOrderSeek failed", t);
+		}
+	}
+
+	/// Returns whether total-order seek is forced, bypassing prefix-based optimizations.
+	///
+	/// @return `true` if total-order seek is forced
+	public boolean isTotalOrderSeek() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_TOTAL_ORDER_SEEK.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("isTotalOrderSeek failed", t);
+		}
+	}
+
+	/// If `true`, an iterator only returns entries that share the same prefix (per the column
+	/// family's prefix extractor) as the seek key, stopping instead of continuing past the prefix
+	/// boundary. Default: `false`.
+	///
+	/// @param prefixSameAsStart `true` to stop iteration at the seek key's prefix boundary
+	/// @return `this` for chaining
+	public ReadOptions setPrefixSameAsStart(boolean prefixSameAsStart) {
+		try {
+			MH_SET_PREFIX_SAME_AS_START.invokeExact(ptr(), RocksDB.toByte(prefixSameAsStart));
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setPrefixSameAsStart failed", t);
+		}
+	}
+
+	/// Returns whether iteration is confined to the seek key's prefix.
+	///
+	/// @return `true` if iteration stops at the seek key's prefix boundary
+	public boolean isPrefixSameAsStart() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_PREFIX_SAME_AS_START.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("isPrefixSameAsStart failed", t);
+		}
+	}
+
+	/// Read-ahead bytes requested per disk read during a scan. A non-zero value overrides the
+	/// per-file setting and applies even when [BlockBasedTableOptions] read-ahead tuning would
+	/// otherwise not kick in. [MemorySize#ZERO] leaves read-ahead unset. Default: [MemorySize#ZERO].
+	///
+	/// @param readaheadSize read-ahead size, or [MemorySize#ZERO] to leave it unset
+	/// @return `this` for chaining
+	public ReadOptions setReadaheadSize(MemorySize readaheadSize) {
+		try {
+			MH_SET_READAHEAD_SIZE.invokeExact(ptr(), readaheadSize.toBytes());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setReadaheadSize failed", t);
+		}
+	}
+
+	/// Returns the configured read-ahead size.
+	///
+	/// @return read-ahead size; [MemorySize#ZERO] means unset
+	public MemorySize getReadaheadSize() {
+		try {
+			return MemorySize.ofBytes((long) MH_GET_READAHEAD_SIZE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getReadaheadSize failed", t);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Iterate bounds
+	// -----------------------------------------------------------------------
+	//
+	// The C API stores a Slice view over whatever pointer is passed in, not a copy, so the bytes
+	// backing a bound must stay valid for as long as this ReadOptions is used for reads or
+	// iteration -- not just for the duration of the setter call. The byte[] tier copies into
+	// this instance's own boundsArena to satisfy that automatically. The ByteBuffer/MemorySegment
+	// tiers are zero-copy instead: the caller owns that lifetime guarantee.
+
+	/// Restricts iteration to keys `>= lowerBound`. Slow path: copies `lowerBound` into a
+	/// segment owned by this [ReadOptions] instance, valid until it is closed. Calling this
+	/// repeatedly on the same instance (e.g. advancing a scan window across a pagination loop)
+	/// does not reclaim earlier copies -- each one stays allocated until the whole [ReadOptions]
+	/// is closed, so memory grows with the number of calls. Pass `null` to clear a previously
+	/// set lower bound.
+	///
+	/// @param lowerBound inclusive lower bound, or `null` to clear
+	/// @return `this` for chaining
+	public ReadOptions setIterateLowerBound(byte[] lowerBound) {
+		try {
+			if (lowerBound == null) {
+				MH_SET_ITERATE_LOWER_BOUND.invokeExact(ptr(), MemorySegment.NULL, 0L);
+			} else {
+				MemorySegment seg = RocksDB.toNative(boundsArena, lowerBound);
+				MH_SET_ITERATE_LOWER_BOUND.invokeExact(ptr(), seg, (long) lowerBound.length);
+			}
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setIterateLowerBound failed", t);
+		}
+	}
+
+	/// Zero-copy for a direct [ByteBuffer]: `lowerBound` must remain valid for as long as this
+	/// [ReadOptions] is used for reads or iteration, not just for this call -- the C API retains
+	/// a view over it rather than copying it.
+	///
+	/// @param lowerBound direct [ByteBuffer] containing the inclusive lower bound
+	/// @return `this` for chaining
+	public ReadOptions setIterateLowerBound(ByteBuffer lowerBound) {
+		try {
+			MH_SET_ITERATE_LOWER_BOUND.invokeExact(ptr(),
+					MemorySegment.ofBuffer(lowerBound), (long) lowerBound.remaining());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setIterateLowerBound failed", t);
+		}
+	}
+
+	/// Zero-copy for a native segment: `lowerBound` must remain valid for as long as this
+	/// [ReadOptions] is used for reads or iteration, not just for this call -- the C API retains
+	/// a view over it rather than copying it.
+	///
+	/// @param lowerBound native segment containing the inclusive lower bound
+	/// @return `this` for chaining
+	public ReadOptions setIterateLowerBound(MemorySegment lowerBound) {
+		try {
+			MH_SET_ITERATE_LOWER_BOUND.invokeExact(ptr(), lowerBound, lowerBound.byteSize());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setIterateLowerBound failed", t);
+		}
+	}
+
+	/// Restricts iteration to keys `< upperBound`. Slow path: copies `upperBound` into a
+	/// segment owned by this [ReadOptions] instance, valid until it is closed. Calling this
+	/// repeatedly on the same instance (e.g. advancing a scan window across a pagination loop)
+	/// does not reclaim earlier copies -- each one stays allocated until the whole [ReadOptions]
+	/// is closed, so memory grows with the number of calls. Pass `null` to clear a previously
+	/// set upper bound.
+	///
+	/// @param upperBound exclusive upper bound, or `null` to clear
+	/// @return `this` for chaining
+	public ReadOptions setIterateUpperBound(byte[] upperBound) {
+		try {
+			if (upperBound == null) {
+				MH_SET_ITERATE_UPPER_BOUND.invokeExact(ptr(), MemorySegment.NULL, 0L);
+			} else {
+				MemorySegment seg = RocksDB.toNative(boundsArena, upperBound);
+				MH_SET_ITERATE_UPPER_BOUND.invokeExact(ptr(), seg, (long) upperBound.length);
+			}
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setIterateUpperBound failed", t);
+		}
+	}
+
+	/// Zero-copy for a direct [ByteBuffer]: `upperBound` must remain valid for as long as this
+	/// [ReadOptions] is used for reads or iteration, not just for this call -- the C API retains
+	/// a view over it rather than copying it.
+	///
+	/// @param upperBound direct [ByteBuffer] containing the exclusive upper bound
+	/// @return `this` for chaining
+	public ReadOptions setIterateUpperBound(ByteBuffer upperBound) {
+		try {
+			MH_SET_ITERATE_UPPER_BOUND.invokeExact(ptr(),
+					MemorySegment.ofBuffer(upperBound), (long) upperBound.remaining());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setIterateUpperBound failed", t);
+		}
+	}
+
+	/// Zero-copy for a native segment: `upperBound` must remain valid for as long as this
+	/// [ReadOptions] is used for reads or iteration, not just for this call -- the C API retains
+	/// a view over it rather than copying it.
+	///
+	/// @param upperBound native segment containing the exclusive upper bound
+	/// @return `this` for chaining
+	public ReadOptions setIterateUpperBound(MemorySegment upperBound) {
+		try {
+			MH_SET_ITERATE_UPPER_BOUND.invokeExact(ptr(), upperBound, upperBound.byteSize());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setIterateUpperBound failed", t);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Request ID
+	// -----------------------------------------------------------------------
+
+	/// Sets an opaque identifier attached to this read for tracing/telemetry. Unlike the iterate
+	/// bounds above, the C API copies `requestId` into its own buffer immediately, so no
+	/// reference to the passed-in bytes is retained. Pass `null` to clear.
+	///
+	/// @param requestId the identifier to attach, or `null` to clear
+	/// @return `this` for chaining
+	public ReadOptions setRequestId(String requestId) {
+		try (Arena arena = Arena.ofConfined()) {
+			if (requestId == null) {
+				MH_CLEAR_REQUEST_ID.invokeExact(ptr());
+			} else {
+				byte[] bytes = requestId.getBytes(StandardCharsets.UTF_8);
+				MemorySegment seg = RocksDB.toNative(arena, bytes);
+				MH_SET_REQUEST_ID.invokeExact(ptr(), seg, (long) bytes.length);
+			}
+			return this;
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("setRequestId failed", t);
+		}
+	}
+
+	/// Returns the configured request identifier.
+	///
+	/// @return the request identifier, or [Optional#empty()] if unset
+	public Optional<String> getRequestId() {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment lenSeg = arena.allocate(ValueLayout.JAVA_LONG);
+			MemorySegment result = (MemorySegment) MH_GET_REQUEST_ID.invokeExact(ptr(), lenSeg);
+			if (MemorySegment.NULL.equals(result)) {
+				return Optional.empty();
+			}
+			long len = lenSeg.get(ValueLayout.JAVA_LONG, 0);
+			byte[] bytes = RocksDB.toByteArray(result, len);
+			return Optional.of(new String(bytes, StandardCharsets.UTF_8));
+		} catch (Throwable t) {
+			throw RocksDBException.wrap("getRequestId failed", t);
+		}
+	}
+
 	@Override
 	protected void tryClose(MemorySegment ptr) throws Throwable {
 		MH_DESTROY.invokeExact(ptr);
+		boundsArena.close();
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1766,6 +1766,18 @@ public final class RocksDB {
 		}
 	}
 
+	/// Copies `len` bytes out of a length-prefixed, non-owned native pointer (e.g. a `const
+	/// char*` + separate `size_t*` out-param) into a new Java array. Unlike [#toJavaString],
+	/// this does not free `ptr` -- use it for borrowed views the C API still owns, such as a
+	/// pointer into an internal `std::string` that stays alive only as long as its parent object.
+	///
+	/// @param ptr non-NULL native pointer to a borrowed buffer
+	/// @param len number of bytes to copy
+	/// @return a new array containing a copy of the bytes
+	public static byte[] toByteArray(MemorySegment ptr, long len) {
+		return ptr.reinterpret(len).toArray(ValueLayout.JAVA_BYTE);
+	}
+
 	/// Converts a malloc'd, NUL-terminated `char*` returned by the RocksDB C API into a
 	/// Java [String], then frees it.
 	///

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
@@ -384,7 +384,7 @@ public final class RocksIterator extends NativeObject {
 	/// @return current key as a newly allocated byte array
 	public byte[] key() {
 		MemorySegment raw = readKey();
-		return raw.reinterpret(lenSegment.get(ValueLayout.JAVA_LONG, 0)).toArray(ValueLayout.JAVA_BYTE);
+		return RocksDB.toByteArray(raw, lenSegment.get(ValueLayout.JAVA_LONG, 0));
 	}
 
 	/// Returns a copy of the current value as a byte array.
@@ -394,7 +394,7 @@ public final class RocksIterator extends NativeObject {
 	/// @return current value as a newly allocated byte array
 	public byte[] value() {
 		MemorySegment raw = readValue();
-		return raw.reinterpret(lenSegment.get(ValueLayout.JAVA_LONG, 0)).toArray(ValueLayout.JAVA_BYTE);
+		return RocksDB.toByteArray(raw, lenSegment.get(ValueLayout.JAVA_LONG, 0));
 	}
 
 	/// Invokes `MH_KEY`. Returns the raw, unsized key pointer — every caller reinterprets

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOptionsTest.java
@@ -1,0 +1,278 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReadOptionsTest {
+
+	@Test
+	void setVerifyChecksums_roundTrips() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			sut.setVerifyChecksums(false);
+
+			// Then
+			assertThat(sut.isVerifyChecksums()).isFalse();
+		}
+	}
+
+	@Test
+	void setFillCache_roundTrips() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			sut.setFillCache(false);
+
+			// Then
+			assertThat(sut.isFillCache()).isFalse();
+		}
+	}
+
+	@Test
+	void setPinData_roundTrips() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			sut.setPinData(true);
+
+			// Then
+			assertThat(sut.isPinData()).isTrue();
+		}
+	}
+
+	@Test
+	void setTailing_roundTrips() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			sut.setTailing(true);
+
+			// Then
+			assertThat(sut.isTailing()).isTrue();
+		}
+	}
+
+	@Test
+	void setTotalOrderSeek_roundTrips() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			sut.setTotalOrderSeek(true);
+
+			// Then
+			assertThat(sut.isTotalOrderSeek()).isTrue();
+		}
+	}
+
+	@Test
+	void setPrefixSameAsStart_roundTrips() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			sut.setPrefixSameAsStart(true);
+
+			// Then
+			assertThat(sut.isPrefixSameAsStart()).isTrue();
+		}
+	}
+
+	@Test
+	void setReadaheadSize_roundTrips() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			sut.setReadaheadSize(MemorySize.ofKB(64));
+
+			// Then
+			assertThat(sut.getReadaheadSize()).isEqualTo(MemorySize.ofKB(64));
+		}
+	}
+
+	@Test
+	void setRequestId_roundTrips() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			sut.setRequestId("trace-123");
+
+			// Then
+			assertThat(sut.getRequestId()).contains("trace-123");
+		}
+	}
+
+	@Test
+	void setRequestId_null_clears() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+			sut.setRequestId("trace-123");
+
+			// When
+			sut.setRequestId(null);
+
+			// Then
+			assertThat(sut.getRequestId()).isEmpty();
+		}
+	}
+
+	@Test
+	void getRequestId_unset_isEmpty() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			Optional<String> requestId = sut.getRequestId();
+
+			// Then
+			assertThat(requestId).isEmpty();
+		}
+	}
+
+	@Test
+	void defaults_matchRocksDbDefaults() {
+		// Given
+		try (var sut = ReadOptions.newReadOptions()) {
+
+			// When
+			// no action -- verifying defaults immediately after construction
+
+			// Then
+			assertThat(sut.isVerifyChecksums()).isTrue();
+			assertThat(sut.isFillCache()).isTrue();
+			assertThat(sut.isPinData()).isFalse();
+			assertThat(sut.isTailing()).isFalse();
+			assertThat(sut.isTotalOrderSeek()).isFalse();
+			assertThat(sut.isPrefixSameAsStart()).isFalse();
+			assertThat(sut.getReadaheadSize()).isEqualTo(MemorySize.ZERO);
+			assertThat(sut.getRequestId()).isEmpty();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Iterate bounds -- no getter exists in the C API, so these are verified
+	// through actual iteration behavior against a real DB.
+	// -----------------------------------------------------------------------
+
+	@Test
+	void setIterateLowerBound_bytes_restrictsIteration(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+			db.put("c".getBytes(), "3".getBytes());
+
+			try (var readOptions = ReadOptions.newReadOptions()) {
+				readOptions.setIterateLowerBound("b".getBytes());
+
+				// When
+				List<String> keys = new ArrayList<>();
+				try (RocksIterator it = db.newIterator(readOptions)) {
+					for (it.seekToFirst(); it.isValid(); it.next()) {
+						keys.add(new String(it.key()));
+					}
+					it.checkError();
+				}
+
+				// Then
+				assertThat(keys).containsExactly("b", "c");
+			}
+		}
+	}
+
+	@Test
+	void setIterateUpperBound_bytes_restrictsIteration(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+			db.put("c".getBytes(), "3".getBytes());
+
+			try (var readOptions = ReadOptions.newReadOptions()) {
+				readOptions.setIterateUpperBound("b".getBytes());
+
+				// When
+				List<String> keys = new ArrayList<>();
+				try (RocksIterator it = db.newIterator(readOptions)) {
+					for (it.seekToFirst(); it.isValid(); it.next()) {
+						keys.add(new String(it.key()));
+					}
+					it.checkError();
+				}
+
+				// Then
+				assertThat(keys).containsExactly("a");
+			}
+		}
+	}
+
+	@Test
+	void setIterateLowerBound_memorySegment_restrictsIteration(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var arena = Arena.ofConfined()) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+			db.put("c".getBytes(), "3".getBytes());
+
+			try (var readOptions = ReadOptions.newReadOptions()) {
+				MemorySegment bound = arena.allocateFrom("b", java.nio.charset.StandardCharsets.US_ASCII);
+				readOptions.setIterateLowerBound(bound.asSlice(0, 1));
+
+				// When
+				List<String> keys = new ArrayList<>();
+				try (RocksIterator it = db.newIterator(readOptions)) {
+					for (it.seekToFirst(); it.isValid(); it.next()) {
+						keys.add(new String(it.key()));
+					}
+					it.checkError();
+				}
+
+				// Then
+				assertThat(keys).containsExactly("b", "c");
+			}
+		}
+	}
+
+	@Test
+	void setIterateLowerBound_null_clearsBound(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+
+			try (var readOptions = ReadOptions.newReadOptions()) {
+				readOptions.setIterateLowerBound("b".getBytes());
+				readOptions.setIterateLowerBound((byte[]) null);
+
+				// When
+				List<String> keys = new ArrayList<>();
+				try (RocksIterator it = db.newIterator(readOptions)) {
+					for (it.seekToFirst(); it.isValid(); it.next()) {
+						keys.add(new String(it.key()));
+					}
+					it.checkError();
+				}
+
+				// Then
+				assertThat(keys).containsExactly("a", "b");
+			}
+		}
+	}
+}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -157,7 +157,7 @@ Per-call options:
 
 | Class                            | Factory                                 | Setters                                                     |
 |:---------------------------------|:----------------------------------------|:------------------------------------------------------------|
-| `ReadOptions`                    | `newReadOptions()`                      | `setSnapshot(Snapshot)`                                     |
+| `ReadOptions`                    | `newReadOptions()`                      | `setSnapshot(Snapshot)`, `setVerifyChecksums`, `setFillCache`, `setPinData`, `setTailing`, `setTotalOrderSeek`, `setPrefixSameAsStart`, `setReadaheadSize(MemorySize)`, `setIterateLowerBound`/`setIterateUpperBound` (byte[]/ByteBuffer/MemorySegment), `setRequestId(String)` |
 | `WriteOptions`                   | `newWriteOptions()`                     | `setSync`, `setDisableWal`, `setIgnoreMissingColumnFamilies`, `setNoSlowdown`, `setLowPri`, `setMemtableInsertHintPerBatch`, `setRateLimiterPriority(IOPriority)`, `setIoActivity(IOActivity)` |
 | `FlushOptions`                   | `newFlushOptions()`                     | `setWait(boolean)` / `isWait()`                             |
 | `CompactOptions`                 | `newCompactOptions()`                   | `setExclusiveManualCompaction`, `setBottommostLevelCompaction`, `setChangeLevel`, `setTargetLevel` |


### PR DESCRIPTION
## Summary
- `ReadOptions` previously wrapped only `create`/`destroy`/`set_snapshot`; adds the high-value subset of the ~30 unmapped `rocksdb_readoptions_*` setters: `verifyChecksums`, `fillCache`, `pinData`, `tailing`, `totalOrderSeek`, `prefixSameAsStart`, `readaheadSize` (`MemorySize`), `iterateLowerBound`/`iterateUpperBound` (full byte[]/ByteBuffer/MemorySegment 3-tier, with an owned `Arena` on `ReadOptions` to keep byte[]-tier bounds alive since the C API stores a raw `Slice` view rather than copying), and `requestId` (String)
- Fixes a memory leak found while auditing for a shared helper: `ColumnFamilyHandle.getName()` never freed the malloc'd pointer `rocksdb_column_family_handle_get_name` returns
- Adds `RocksDB.toByteArray(MemorySegment, long)` and dedups the identical `reinterpret+toArray` one-liner across `PinnableSlice`, `PinnableHandle`, `RocksIterator.key()`/`value()`, and the new `ReadOptions.getRequestId()`
- Updates `docs/reference.md`'s per-call-options table

## Test plan
- [x] `./mvnw test` (full reactor) passes
- [x] `./mvnw javadoc:javadoc -pl core` produces zero output
- [x] New `ReadOptionsTest`: round-trips, RocksDB defaults, and iterate-bound behavior verified against a real DB/iterator (no getter exists in the C API for the bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)