### PR TITLE
Skip native cross-compile for non-host classifiers locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
           key: rocksdb-${{ hashFiles('rocksdb/CMakeLists.txt', 'rocksdb/Makefile', 'scripts/build-rocksdb.sh', 'scripts/build-rocksdb-windows.sh') }}-${{ matrix.os }}-${{ runner.arch }}
 
       - name: Build and test
-        run: mvn --batch-mode verify
+        run: mvn --batch-mode verify -Pall-natives

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,4 +66,4 @@ jobs:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: ./mvnw deploy -Prelease -DskipTests --batch-mode
+        run: ./mvnw deploy -Prelease,all-natives -DskipTests --batch-mode

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          mvn --batch-mode verify -P coverage \
+          mvn --batch-mode verify -P coverage,all-natives \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.projectKey=dfa1_rocksdbffm \
             -Dsonar.organization=dfa11 \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,10 @@ This project is heavily AI-driven. As an agent, your goal is to:
 - **Native Compiler:** `zig cc` / `zig c++` — used as a drop-in C/C++ compiler via
   `CC="zig cc" CXX="zig c++" PORTABLE=1 make shared_lib`. Zig bundles clang + libc++ for every target, enabling
   cross-compilation without a separate sysroot.
-- **Build System:** Maven Wrapper (`./mvnw`). Run `./mvnw generate-resources -Pnative-build` once to build the native lib; `./mvnw test`
-  thereafter. Use `./mvnw` (not `mvn`) to ensure the correct Maven version is used.
+- **Build System:** Maven Wrapper (`./mvnw`). `./mvnw generate-resources` (or `test`, `compile`, ...) auto-detects the
+  host OS/arch and cross-compiles RocksDB for just that one `native/*` classifier via zig cc — a plain local build no
+  longer compiles all 5 targets. Add `-Pall-natives` to build every classifier regardless of host (what CI and
+  releases use). Use `./mvnw` (not `mvn`) to ensure the correct Maven version is used.
   **NEVER run `mvn install` or `./mvnw install`** — it pollutes `~/.m2` with local artifacts. Use `compile`, `test`, or `package` instead.
 - **Testing:** JUnit 5, AssertJ.
 - **Benchmarking:** JMH (Java Microbenchmark Harness).
@@ -45,8 +47,8 @@ To ensure type safety and consistent units across the API:
 - **Read-only headers:** NEVER modify system include files (e.g. `/opt/homebrew/...`, `/usr/include/...`). They are
   read-only references; all mappings live in Java source.
 - **Library loading:** `NativeLibrary.java` loads the native library from the classpath resource
-  `/native/<os>-<arch>/librocksdb.<ext>` (bundled by the `native-build` Maven profile). There is no brew/system
-  fallback. NEVER add hardcoded system paths back.
+  `/native/<os>-<arch>/librocksdb.<ext>` (bundled by each `native/*` module's `exec-maven-plugin` execution). There is
+  no brew/system fallback. NEVER add hardcoded system paths back.
 - **Paths:** Never use raw `String` for file system paths. Always use `java.nio.file.Path` for any API surface that
   accepts paths (open, backup, checkpoint).
 - **Memory Sizes:** Never use raw `long` for byte counts (e.g., cache size, write buffer size). Always use the project's

--- a/native/linux-aarch64/pom.xml
+++ b/native/linux-aarch64/pom.xml
@@ -26,6 +26,9 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
+							<!-- See skip.native.* in the root pom.xml: skipped unless this host
+								 matches the classifier, or -Pall-natives is active. -->
+							<skip>${skip.native.linux-aarch64}</skip>
 							<!-- exec-maven-plugin cannot launch a .sh directly on native Windows
 								 (CreateProcess error=193); invoke it through bash (Git Bash on
 								 windows-latest runners) instead. -->

--- a/native/linux-x86_64/pom.xml
+++ b/native/linux-x86_64/pom.xml
@@ -26,6 +26,9 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
+							<!-- See skip.native.* in the root pom.xml: skipped unless this host
+								 matches the classifier, or -Pall-natives is active. -->
+							<skip>${skip.native.linux-x86_64}</skip>
 							<!-- exec-maven-plugin cannot launch a .sh directly on native Windows
 								 (CreateProcess error=193); invoke it through bash (Git Bash on
 								 windows-latest runners) instead. -->

--- a/native/osx-aarch64/pom.xml
+++ b/native/osx-aarch64/pom.xml
@@ -33,6 +33,9 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
+							<!-- See skip.native.* in the root pom.xml: skipped unless this host
+								 matches the classifier, or -Pall-natives is active. -->
+							<skip>${skip.native.osx-aarch64}</skip>
 							<!-- exec-maven-plugin cannot launch a .sh directly on native Windows
 								 (CreateProcess error=193); invoke it through bash (Git Bash on
 								 windows-latest runners) instead. -->

--- a/native/windows-aarch64/pom.xml
+++ b/native/windows-aarch64/pom.xml
@@ -26,6 +26,9 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
+							<!-- See skip.native.* in the root pom.xml: skipped unless this host
+								 matches the classifier, or -Pall-natives is active. -->
+							<skip>${skip.native.windows-aarch64}</skip>
 							<!-- exec-maven-plugin cannot launch a .sh directly on native Windows
 								 (CreateProcess error=193); invoke it through bash (Git Bash on
 								 windows-latest runners) instead. -->

--- a/native/windows-x86_64/pom.xml
+++ b/native/windows-x86_64/pom.xml
@@ -26,6 +26,9 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
+							<!-- See skip.native.* in the root pom.xml: skipped unless this host
+								 matches the classifier, or -Pall-natives is active. -->
+							<skip>${skip.native.windows-x86_64}</skip>
 							<!-- exec-maven-plugin cannot launch a .sh directly on native Windows
 								 (CreateProcess error=193); invoke it through bash (Git Bash on
 								 windows-latest runners) instead. -->

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,17 @@
 		     default, a plain build (no coverage profile) would pass the literal token "@{argLine}" to
 		     the JVM instead of resolving it to nothing. -->
 		<argLine />
+		<!-- Each native/* module cross-compiles RocksDB via zig cc, which works from
+		     any host for any target — so a plain local build was compiling RocksDB
+		     5 times (once per classifier) even though local dev only ever needs the
+		     host's own. Default every classifier to skipped; the host-* profiles
+		     below un-skip the one matching the machine actually running the build,
+		     and the all-natives profile (used by CI/release) un-skips every one. -->
+		<skip.native.osx-aarch64>true</skip.native.osx-aarch64>
+		<skip.native.linux-x86_64>true</skip.native.linux-x86_64>
+		<skip.native.linux-aarch64>true</skip.native.linux-aarch64>
+		<skip.native.windows-x86_64>true</skip.native.windows-x86_64>
+		<skip.native.windows-aarch64>true</skip.native.windows-aarch64>
 	</properties>
 
 	<dependencyManagement>
@@ -342,6 +353,85 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<!-- Local-dev convenience: auto-activate the one classifier matching the
+		     host running the build, so a plain `mvn compile`/`mvn test` only
+		     cross-compiles RocksDB once instead of for all 5 targets. See the
+		     skip.native.* property defaults above. `name`/`arch` match against
+		     the os.name/os.arch system properties; `family=unix` also matches
+		     Mac OS X in Maven's own os-activation logic, so Linux uses an
+		     explicit name check instead to stay unambiguous. -->
+		<profile>
+			<id>host-osx-aarch64</id>
+			<activation>
+				<os>
+					<family>mac</family>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<properties>
+				<skip.native.osx-aarch64>false</skip.native.osx-aarch64>
+			</properties>
+		</profile>
+		<profile>
+			<id>host-linux-x86_64</id>
+			<activation>
+				<os>
+					<name>linux</name>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<skip.native.linux-x86_64>false</skip.native.linux-x86_64>
+			</properties>
+		</profile>
+		<profile>
+			<id>host-linux-aarch64</id>
+			<activation>
+				<os>
+					<name>linux</name>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<properties>
+				<skip.native.linux-aarch64>false</skip.native.linux-aarch64>
+			</properties>
+		</profile>
+		<profile>
+			<id>host-windows-x86_64</id>
+			<activation>
+				<os>
+					<family>windows</family>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<skip.native.windows-x86_64>false</skip.native.windows-x86_64>
+			</properties>
+		</profile>
+		<profile>
+			<id>host-windows-aarch64</id>
+			<activation>
+				<os>
+					<family>windows</family>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<properties>
+				<skip.native.windows-aarch64>false</skip.native.windows-aarch64>
+			</properties>
+		</profile>
+		<!-- CI/release: build every classifier regardless of host, e.g.
+		     `mvn verify -Pall-natives`. -->
+		<profile>
+			<id>all-natives</id>
+			<properties>
+				<skip.native.osx-aarch64>false</skip.native.osx-aarch64>
+				<skip.native.linux-x86_64>false</skip.native.linux-x86_64>
+				<skip.native.linux-aarch64>false</skip.native.linux-aarch64>
+				<skip.native.windows-x86_64>false</skip.native.windows-x86_64>
+				<skip.native.windows-aarch64>false</skip.native.windows-aarch64>
+			</properties>
 		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
## Summary
- A plain `mvn compile`/`mvn test` was cross-compiling RocksDB via zig cc for all 5 native classifiers, even though local dev only ever needs the host's own — zig's hermetic cross-compilation means any host can build any target, so this was pure waste.
- Adds `skip.native.<classifier>` properties (default `true`), un-skipped by an OS-family-activated profile matching the running host, plus an `-Pall-natives` profile that un-skips every classifier — added to `ci.yml`, `sonar.yml`, and `publish.yml` since those need the full matrix regardless of runner OS.
- Fixes CLAUDE.md's stale `-Pnative-build` profile reference, which didn't actually exist anywhere in the POMs.

## Test plan
- [x] `mvn help:active-profiles` confirms `host-osx-aarch64` auto-activates on this machine
- [x] Default `mvn generate-resources` only runs the `build-rocksdb-native` exec step for `osx-aarch64`; the other 4 classifiers log `skipping execute as per configuration`
- [x] `mvn -Pall-natives help:evaluate -Dexpression=skip.native.linux-x86_64` returns `false`, confirming the override still works
- [x] Full `mvn test` dropped from ~4-5 min to 45s locally, all modules still build/pass
- [ ] CI (ci.yml/sonar.yml/publish.yml with `-Pall-natives`) — will confirm once this PR's checks run

🤖 Generated with [Claude Code](https://claude.com/claude-code)