### PR TITLE
Separate genuine RocksDB errors from FFM binding bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,21 @@ try (Arena arena = Arena.ofConfined()) {
     MemorySegment err = RocksDB.errHolder(arena);
     MH_DO_SOMETHING.invokeExact(handle, ..., err);
     RocksDB.checkError(err);
+} catch (Throwable t) {
+    throw RocksDB.wrapInvokeFailure("doSomething failed", t);
 }
 ```
 
-`RocksDB.errHolder`, `RocksDB.checkError`, and `RocksDB.toNative` are the shared FFM plumbing used by every wrapper
-class.
+`RocksDB.errHolder`, `RocksDB.checkError`, `RocksDB.toNative`, and `RocksDB.wrapInvokeFailure` are the shared FFM
+plumbing used by every wrapper class.
+
+**`RocksDBException` is only ever constructed by `RocksDB.checkError`**, for a genuine `errptr`-reported RocksDB
+error. Never construct it — or call something you wrote yourself that would — from an `invokeExact` catch block;
+use `RocksDB.wrapInvokeFailure(message, t)` there instead, which rethrows any `RuntimeException` (including a
+`RocksDBException` `checkError` already threw earlier in the same `try`) unwrapped, an `IOException` as
+`UncheckedIOException`, and anything else — which should never happen for a correctly configured downcall handle —
+as `AssertionError`. See [ADR 0004](docs/adr/0004-error-handling.md) for why: a bug in this library's own FFM
+plumbing must never be indistinguishable from a genuine RocksDB error.
 
 ### 2. Zero-Copy Patterns
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngine.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngine.java
@@ -177,7 +177,7 @@ public final class BackupEngine extends NativeObject {
 			RocksDB.checkError(err);
 			return new BackupEngine(ptr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("BackupEngine.open failed", t);
+			throw RocksDB.wrapInvokeFailure("BackupEngine.open failed", t);
 		}
 	}
 
@@ -196,7 +196,7 @@ public final class BackupEngine extends NativeObject {
 			RocksDB.checkError(err);
 			return new BackupEngine(ptr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("BackupEngine.open failed", t);
+			throw RocksDB.wrapInvokeFailure("BackupEngine.open failed", t);
 		}
 	}
 
@@ -260,7 +260,7 @@ public final class BackupEngine extends NativeObject {
 			MH_CREATE_NEW_BACKUP_FLUSH.invokeExact(ptr(), dbPtr, RocksDB.toByte(flush), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("createNewBackup failed", t);
+			throw RocksDB.wrapInvokeFailure("createNewBackup failed", t);
 		}
 	}
 
@@ -277,7 +277,7 @@ public final class BackupEngine extends NativeObject {
 			MH_PURGE_OLD_BACKUPS.invokeExact(ptr(), numBackupsToKeep, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("purgeOldBackups failed", t);
+			throw RocksDB.wrapInvokeFailure("purgeOldBackups failed", t);
 		}
 	}
 
@@ -291,7 +291,7 @@ public final class BackupEngine extends NativeObject {
 			MH_VERIFY_BACKUP.invokeExact(ptr(), backupId.toNativeInt(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("verifyBackup failed", t);
+			throw RocksDB.wrapInvokeFailure("verifyBackup failed", t);
 		}
 	}
 
@@ -323,7 +323,7 @@ public final class BackupEngine extends NativeObject {
 			MH_RESTORE_FROM_LATEST.invokeExact(ptr(), dbDirSeg, walDirSeg, restoreOptions.ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("restoreDbFromLatestBackup failed", t);
+			throw RocksDB.wrapInvokeFailure("restoreDbFromLatestBackup failed", t);
 		}
 	}
 
@@ -351,7 +351,7 @@ public final class BackupEngine extends NativeObject {
 					restoreOptions.ptr(), backupId.toNativeInt(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("restoreDbFromBackup failed", t);
+			throw RocksDB.wrapInvokeFailure("restoreDbFromBackup failed", t);
 		}
 	}
 
@@ -370,7 +370,7 @@ public final class BackupEngine extends NativeObject {
 		try {
 			infoPtr = (MemorySegment) MH_GET_BACKUP_INFO.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBackupInfo failed", t);
+			throw RocksDB.wrapInvokeFailure("getBackupInfo failed", t);
 		}
 		try {
 			int count = (int) MH_INFO_COUNT.invokeExact(infoPtr);
@@ -384,7 +384,7 @@ public final class BackupEngine extends NativeObject {
 			}
 			return Collections.unmodifiableList(result);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBackupInfo failed", t);
+			throw RocksDB.wrapInvokeFailure("getBackupInfo failed", t);
 		} finally {
 			try {
 				MH_INFO_DESTROY.invokeExact(infoPtr);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngineOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngineOptions.java
@@ -181,7 +181,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MemorySegment dirSeg = arena.allocateFrom(backupDir.toString());
 			return new BackupEngineOptions((MemorySegment) MH_CREATE.invokeExact(dirSeg));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("BackupEngineOptions.create failed", t);
+			throw RocksDB.wrapInvokeFailure("BackupEngineOptions.create failed", t);
 		}
 	}
 
@@ -195,7 +195,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_BACKUP_DIR.invokeExact(ptr(), dirSeg);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBackupDir failed", t);
+			throw RocksDB.wrapInvokeFailure("setBackupDir failed", t);
 		}
 	}
 
@@ -211,7 +211,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_ENV.invokeExact(ptr(), env.ptr());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setEnv failed", t);
+			throw RocksDB.wrapInvokeFailure("setEnv failed", t);
 		}
 	}
 
@@ -225,7 +225,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_SHARE_TABLE_FILES.invokeExact(ptr(), RocksDB.toByte(val));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setShareTableFiles failed", t);
+			throw RocksDB.wrapInvokeFailure("setShareTableFiles failed", t);
 		}
 	}
 
@@ -236,7 +236,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_SHARE_TABLE_FILES.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isShareTableFiles failed", t);
+			throw RocksDB.wrapInvokeFailure("isShareTableFiles failed", t);
 		}
 	}
 
@@ -249,7 +249,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_SYNC.invokeExact(ptr(), RocksDB.toByte(val));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setSync failed", t);
+			throw RocksDB.wrapInvokeFailure("setSync failed", t);
 		}
 	}
 
@@ -260,7 +260,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_SYNC.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isSync failed", t);
+			throw RocksDB.wrapInvokeFailure("isSync failed", t);
 		}
 	}
 
@@ -274,7 +274,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_DESTROY_OLD_DATA.invokeExact(ptr(), RocksDB.toByte(val));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setDestroyOldData failed", t);
+			throw RocksDB.wrapInvokeFailure("setDestroyOldData failed", t);
 		}
 	}
 
@@ -285,7 +285,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_DESTROY_OLD_DATA.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isDestroyOldData failed", t);
+			throw RocksDB.wrapInvokeFailure("isDestroyOldData failed", t);
 		}
 	}
 
@@ -298,7 +298,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_BACKUP_LOG_FILES.invokeExact(ptr(), RocksDB.toByte(val));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBackupLogFiles failed", t);
+			throw RocksDB.wrapInvokeFailure("setBackupLogFiles failed", t);
 		}
 	}
 
@@ -309,7 +309,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_BACKUP_LOG_FILES.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isBackupLogFiles failed", t);
+			throw RocksDB.wrapInvokeFailure("isBackupLogFiles failed", t);
 		}
 	}
 
@@ -323,7 +323,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_BACKUP_RATE_LIMIT.invokeExact(ptr(), limit.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBackupRateLimit failed", t);
+			throw RocksDB.wrapInvokeFailure("setBackupRateLimit failed", t);
 		}
 	}
 
@@ -334,7 +334,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_BACKUP_RATE_LIMIT.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBackupRateLimit failed", t);
+			throw RocksDB.wrapInvokeFailure("getBackupRateLimit failed", t);
 		}
 	}
 
@@ -348,7 +348,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_RESTORE_RATE_LIMIT.invokeExact(ptr(), limit.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setRestoreRateLimit failed", t);
+			throw RocksDB.wrapInvokeFailure("setRestoreRateLimit failed", t);
 		}
 	}
 
@@ -359,7 +359,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_RESTORE_RATE_LIMIT.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getRestoreRateLimit failed", t);
+			throw RocksDB.wrapInvokeFailure("getRestoreRateLimit failed", t);
 		}
 	}
 
@@ -372,7 +372,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_MAX_BACKGROUND_OPERATIONS.invokeExact(ptr(), val);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMaxBackgroundOperations failed", t);
+			throw RocksDB.wrapInvokeFailure("setMaxBackgroundOperations failed", t);
 		}
 	}
 
@@ -383,7 +383,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return (int) MH_GET_MAX_BACKGROUND_OPERATIONS.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMaxBackgroundOperations failed", t);
+			throw RocksDB.wrapInvokeFailure("getMaxBackgroundOperations failed", t);
 		}
 	}
 
@@ -396,7 +396,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_CALLBACK_TRIGGER_INTERVAL_SIZE.invokeExact(ptr(), size.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setCallbackTriggerIntervalSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setCallbackTriggerIntervalSize failed", t);
 		}
 	}
 
@@ -407,7 +407,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_CALLBACK_TRIGGER_INTERVAL_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getCallbackTriggerIntervalSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getCallbackTriggerIntervalSize failed", t);
 		}
 	}
 
@@ -421,7 +421,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_MAX_VALID_BACKUPS_TO_OPEN.invokeExact(ptr(), val);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMaxValidBackupsToOpen failed", t);
+			throw RocksDB.wrapInvokeFailure("setMaxValidBackupsToOpen failed", t);
 		}
 	}
 
@@ -432,7 +432,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return (int) MH_GET_MAX_VALID_BACKUPS_TO_OPEN.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMaxValidBackupsToOpen failed", t);
+			throw RocksDB.wrapInvokeFailure("getMaxValidBackupsToOpen failed", t);
 		}
 	}
 
@@ -446,7 +446,7 @@ public final class BackupEngineOptions extends NativeObject {
 			MH_SET_SHARE_FILES_WITH_CHECKSUM_NAMING.invokeExact(ptr(), val);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setShareFilesWithChecksumNaming failed", t);
+			throw RocksDB.wrapInvokeFailure("setShareFilesWithChecksumNaming failed", t);
 		}
 	}
 
@@ -457,7 +457,7 @@ public final class BackupEngineOptions extends NativeObject {
 		try {
 			return (int) MH_GET_SHARE_FILES_WITH_CHECKSUM_NAMING.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getShareFilesWithChecksumNaming failed", t);
+			throw RocksDB.wrapInvokeFailure("getShareFilesWithChecksumNaming failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlockBasedTableOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlockBasedTableOptions.java
@@ -175,7 +175,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			return new BlockBasedTableOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable e) {
-			throw RocksDBException.wrap("new block based config", e);
+			throw RocksDB.wrapInvokeFailure("new block based config", e);
 		}
 	}
 
@@ -192,7 +192,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_BLOCK_SIZE.invokeExact(ptr(), blockSize.toBytes());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlockSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlockSize failed", t);
 		}
 		return this;
 	}
@@ -205,7 +205,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_FILTER_POLICY.invokeExact(ptr(), policy.ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setFilterPolicy failed", t);
+			throw RocksDB.wrapInvokeFailure("setFilterPolicy failed", t);
 		}
 		// BlockBasedTableConfig will take care of the freeing the policy
 		policy.transferOwnership();
@@ -221,7 +221,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_NO_BLOCK_CACHE.invokeExact(ptr(), RocksDB.toByte(noBlockCache));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setNoBlockCache failed", t);
+			throw RocksDB.wrapInvokeFailure("setNoBlockCache failed", t);
 		}
 		return this;
 	}
@@ -235,7 +235,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_BLOCK_CACHE.invokeExact(ptr(), cache.ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlockCache failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlockCache failed", t);
 		}
 		return this;
 	}
@@ -249,7 +249,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_CACHE_INDEX_AND_FILTER_BLOCKS.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setCacheIndexAndFilterBlocks failed", t);
+			throw RocksDB.wrapInvokeFailure("setCacheIndexAndFilterBlocks failed", t);
 		}
 		return this;
 	}
@@ -263,7 +263,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_INDEX_TYPE.invokeExact(ptr(), indexType.value);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIndexType failed", t);
+			throw RocksDB.wrapInvokeFailure("setIndexType failed", t);
 		}
 		return this;
 	}
@@ -277,7 +277,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_FORMAT_VERSION.invokeExact(ptr(), formatVersion.value);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setFormatVersion failed", t);
+			throw RocksDB.wrapInvokeFailure("setFormatVersion failed", t);
 		}
 		return this;
 	}
@@ -289,7 +289,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			return FormatVersion.fromValue((int) MH_GET_FORMAT_VERSION.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getFormatVersion failed", t);
+			throw RocksDB.wrapInvokeFailure("getFormatVersion failed", t);
 		}
 	}
 
@@ -302,7 +302,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_WHOLE_KEY_FILTERING.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setWholeKeyFiltering failed", t);
+			throw RocksDB.wrapInvokeFailure("setWholeKeyFiltering failed", t);
 		}
 		return this;
 	}
@@ -316,7 +316,7 @@ public final class BlockBasedTableOptions extends NativeObject {
 		try {
 			MH_SET_PARTITION_FILTERS.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setPartitionFilters failed", t);
+			throw RocksDB.wrapInvokeFailure("setPartitionFilters failed", t);
 		}
 		return this;
 	}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Cache.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Cache.java
@@ -54,7 +54,7 @@ public abstract class Cache extends NativeObject {
 		try {
 			MH_SET_CAPACITY.invokeExact(ptr(), capacity.toBytes());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setCapacity failed", t);
+			throw RocksDB.wrapInvokeFailure("setCapacity failed", t);
 		}
 	}
 
@@ -65,7 +65,7 @@ public abstract class Cache extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_CAPACITY.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getCapacity failed", t);
+			throw RocksDB.wrapInvokeFailure("getCapacity failed", t);
 		}
 	}
 
@@ -76,7 +76,7 @@ public abstract class Cache extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_USAGE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getUsage failed", t);
+			throw RocksDB.wrapInvokeFailure("getUsage failed", t);
 		}
 	}
 
@@ -87,7 +87,7 @@ public abstract class Cache extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_PINNED_USAGE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getPinnedUsage failed", t);
+			throw RocksDB.wrapInvokeFailure("getPinnedUsage failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Checkpoint.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Checkpoint.java
@@ -104,7 +104,7 @@ public final class Checkpoint extends NativeObject {
 			RocksDB.checkError(err);
 			return new Checkpoint(ptr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("newCheckpoint failed", t);
+			throw RocksDB.wrapInvokeFailure("newCheckpoint failed", t);
 		}
 	}
 
@@ -126,7 +126,7 @@ public final class Checkpoint extends NativeObject {
 			MH_EXPORT.invokeExact(ptr(), dirSeg, logSizeForFlush.toBytes(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ColumnFamilyHandle.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ColumnFamilyHandle.java
@@ -54,7 +54,7 @@ public final class ColumnFamilyHandle extends NativeObject {
 		try {
 			return (int) MH_GET_ID.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getId failed", t);
+			throw RocksDB.wrapInvokeFailure("getId failed", t);
 		}
 	}
 
@@ -72,7 +72,7 @@ public final class ColumnFamilyHandle extends NativeObject {
 			RocksDB.free(namePtr);
 			return new String(bytes, StandardCharsets.UTF_8);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getName failed", t);
+			throw RocksDB.wrapInvokeFailure("getName failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/CompactOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/CompactOptions.java
@@ -87,7 +87,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			result = (MemorySegment) MH_CREATE.invokeExact();
 		} catch (Throwable e) {
-			throw RocksDBException.wrap(e.getMessage(), e);
+			throw RocksDB.wrapInvokeFailure(e.getMessage(), e);
 		}
 		return new CompactOptions(result);
 	}
@@ -101,7 +101,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			MH_SET_EXCLUSIVE.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setExclusiveManualCompaction failed", t);
+			throw RocksDB.wrapInvokeFailure("setExclusiveManualCompaction failed", t);
 		}
 		return this;
 	}
@@ -113,7 +113,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_EXCLUSIVE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isExclusiveManualCompaction failed", t);
+			throw RocksDB.wrapInvokeFailure("isExclusiveManualCompaction failed", t);
 		}
 	}
 
@@ -126,7 +126,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			MH_SET_BOTTOMMOST.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBottommostLevelCompaction failed", t);
+			throw RocksDB.wrapInvokeFailure("setBottommostLevelCompaction failed", t);
 		}
 		return this;
 	}
@@ -138,7 +138,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_BOTTOMMOST.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isBottommostLevelCompaction failed", t);
+			throw RocksDB.wrapInvokeFailure("isBottommostLevelCompaction failed", t);
 		}
 	}
 
@@ -152,7 +152,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			MH_SET_CHANGE_LEVEL.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setChangeLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("setChangeLevel failed", t);
 		}
 		return this;
 	}
@@ -164,7 +164,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_CHANGE_LEVEL.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isChangeLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("isChangeLevel failed", t);
 		}
 	}
 
@@ -177,7 +177,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			MH_SET_TARGET_LEVEL.invokeExact(ptr(), level);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setTargetLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("setTargetLevel failed", t);
 		}
 		return this;
 	}
@@ -189,7 +189,7 @@ public final class CompactOptions extends NativeObject {
 		try {
 			return (int) MH_GET_TARGET_LEVEL.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getTargetLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("getTargetLevel failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Env.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Env.java
@@ -72,7 +72,7 @@ public final class Env extends NativeObject {
 		try {
 			return new Env((MemorySegment) MH_CREATE_DEFAULT.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Env.defaultEnv failed", t);
+			throw RocksDB.wrapInvokeFailure("Env.defaultEnv failed", t);
 		}
 	}
 
@@ -83,7 +83,7 @@ public final class Env extends NativeObject {
 		try {
 			return new Env((MemorySegment) MH_CREATE_MEM.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Env.memEnv failed", t);
+			throw RocksDB.wrapInvokeFailure("Env.memEnv failed", t);
 		}
 	}
 
@@ -96,7 +96,7 @@ public final class Env extends NativeObject {
 			MH_SET_BACKGROUND_THREADS.invokeExact(ptr(), n);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBackgroundThreads failed", t);
+			throw RocksDB.wrapInvokeFailure("setBackgroundThreads failed", t);
 		}
 	}
 
@@ -107,7 +107,7 @@ public final class Env extends NativeObject {
 		try {
 			return (int) MH_GET_BACKGROUND_THREADS.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBackgroundThreads failed", t);
+			throw RocksDB.wrapInvokeFailure("getBackgroundThreads failed", t);
 		}
 	}
 
@@ -120,7 +120,7 @@ public final class Env extends NativeObject {
 			MH_SET_HIGH_PRIORITY_BACKGROUND_THREADS.invokeExact(ptr(), n);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setHighPriorityBackgroundThreads failed", t);
+			throw RocksDB.wrapInvokeFailure("setHighPriorityBackgroundThreads failed", t);
 		}
 	}
 
@@ -131,7 +131,7 @@ public final class Env extends NativeObject {
 		try {
 			return (int) MH_GET_HIGH_PRIORITY_BACKGROUND_THREADS.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getHighPriorityBackgroundThreads failed", t);
+			throw RocksDB.wrapInvokeFailure("getHighPriorityBackgroundThreads failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/FilterPolicy.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/FilterPolicy.java
@@ -53,7 +53,7 @@ public final class FilterPolicy extends NativeObject {
 		try {
 			return new FilterPolicy((MemorySegment) MH_CREATE_BLOOM.invokeExact(bitsPerKey));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("FilterPolicy.newBloom failed", t);
+			throw RocksDB.wrapInvokeFailure("FilterPolicy.newBloom failed", t);
 		}
 	}
 
@@ -67,7 +67,7 @@ public final class FilterPolicy extends NativeObject {
 		try {
 			return new FilterPolicy((MemorySegment) MH_CREATE_RIBBON.invokeExact(bloomEquivalentBitsPerKey));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("FilterPolicy.newRibbon failed", t);
+			throw RocksDB.wrapInvokeFailure("FilterPolicy.newRibbon failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/FlushOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/FlushOptions.java
@@ -51,7 +51,7 @@ public final class FlushOptions extends NativeObject {
 		try {
 			return new FlushOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flushoptions create failed", t);
+			throw RocksDB.wrapInvokeFailure("flushoptions create failed", t);
 		}
 	}
 
@@ -65,7 +65,7 @@ public final class FlushOptions extends NativeObject {
 			MH_SET_WAIT.invokeExact(ptr(), RocksDB.toByte(wait));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flushoptions setWait failed", t);
+			throw RocksDB.wrapInvokeFailure("flushoptions setWait failed", t);
 		}
 	}
 
@@ -76,7 +76,7 @@ public final class FlushOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_WAIT.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flushoptions getWait failed", t);
+			throw RocksDB.wrapInvokeFailure("flushoptions getWait failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/HyperClockCache.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/HyperClockCache.java
@@ -70,7 +70,7 @@ public final class HyperClockCache extends Cache {
 			return new HyperClockCache((MemorySegment) MH_CREATE.invokeExact(
 					capacity.toBytes(), estimatedEntryCharge.toBytes()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("HyperClockCache create failed", t);
+			throw RocksDB.wrapInvokeFailure("HyperClockCache create failed", t);
 		}
 	}
 
@@ -91,7 +91,7 @@ public final class HyperClockCache extends Cache {
 			MH_OPTS_SET_NUM_SHARD_BITS.invokeExact(opts, numShardBits);
 			return new HyperClockCache((MemorySegment) MH_CREATE_OPTS.invokeExact(opts));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("HyperClockCache create failed", t);
+			throw RocksDB.wrapInvokeFailure("HyperClockCache create failed", t);
 		} finally {
 			if (opts != null) {
 				try {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/IngestExternalFileOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/IngestExternalFileOptions.java
@@ -71,7 +71,7 @@ public final class IngestExternalFileOptions extends NativeObject {
 		try {
 			return new IngestExternalFileOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("ingestexternalfileoptions create failed", t);
+			throw RocksDB.wrapInvokeFailure("ingestexternalfileoptions create failed", t);
 		}
 	}
 
@@ -84,7 +84,7 @@ public final class IngestExternalFileOptions extends NativeObject {
 			MH_SET_MOVE_FILES.invokeExact(ptr(), RocksDB.toByte(moveFiles));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("ingestexternalfileoptions setMoveFiles failed", t);
+			throw RocksDB.wrapInvokeFailure("ingestexternalfileoptions setMoveFiles failed", t);
 		}
 	}
 
@@ -97,7 +97,7 @@ public final class IngestExternalFileOptions extends NativeObject {
 			MH_SET_SNAPSHOT_CONSISTENCY.invokeExact(ptr(), RocksDB.toByte(snapshotConsistency));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("ingestexternalfileoptions setSnapshotConsistency failed", t);
+			throw RocksDB.wrapInvokeFailure("ingestexternalfileoptions setSnapshotConsistency failed", t);
 		}
 	}
 
@@ -110,7 +110,7 @@ public final class IngestExternalFileOptions extends NativeObject {
 			MH_SET_ALLOW_GLOBAL_SEQNO.invokeExact(ptr(), RocksDB.toByte(allowGlobalSeqno));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("ingestexternalfileoptions setAllowGlobalSeqno failed", t);
+			throw RocksDB.wrapInvokeFailure("ingestexternalfileoptions setAllowGlobalSeqno failed", t);
 		}
 	}
 
@@ -123,7 +123,7 @@ public final class IngestExternalFileOptions extends NativeObject {
 			MH_SET_ALLOW_BLOCKING_FLUSH.invokeExact(ptr(), RocksDB.toByte(allowBlockingFlush));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("ingestexternalfileoptions setAllowBlockingFlush failed", t);
+			throw RocksDB.wrapInvokeFailure("ingestexternalfileoptions setAllowBlockingFlush failed", t);
 		}
 	}
 
@@ -137,7 +137,7 @@ public final class IngestExternalFileOptions extends NativeObject {
 			MH_SET_INGEST_BEHIND.invokeExact(ptr(), RocksDB.toByte(ingestBehind));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("ingestexternalfileoptions setIngestBehind failed", t);
+			throw RocksDB.wrapInvokeFailure("ingestexternalfileoptions setIngestBehind failed", t);
 		}
 	}
 
@@ -150,7 +150,7 @@ public final class IngestExternalFileOptions extends NativeObject {
 			MH_SET_FAIL_IF_NOT_BOTTOMMOST_LEVEL.invokeExact(ptr(), RocksDB.toByte(failIfNotBottommostLevel));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("ingestexternalfileoptions setFailIfNotBottommostLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("ingestexternalfileoptions setFailIfNotBottommostLevel failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/LRUCache.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/LRUCache.java
@@ -35,7 +35,7 @@ public final class LRUCache extends Cache {
 		try {
 			return new LRUCache((MemorySegment) MH_CREATE.invokeExact(capacity.toBytes()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("LRUCache create failed", t);
+			throw RocksDB.wrapInvokeFailure("LRUCache create failed", t);
 		}
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Logger.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Logger.java
@@ -109,7 +109,7 @@ public final class Logger extends NativeObject {
 			MemorySegment ptr = (MemorySegment) MH_CREATE_STDERR.invokeExact(level.value, prefixSeg);
 			return new Logger(ptr, STDERR_CALLBACK_ID);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Logger.newStderrLogger failed", t);
+			throw RocksDB.wrapInvokeFailure("Logger.newStderrLogger failed", t);
 		}
 	}
 
@@ -132,7 +132,7 @@ public final class Logger extends NativeObject {
 			return new Logger(ptr, id);
 		} catch (Throwable t) {
 			REGISTRY.remove(id);
-			throw RocksDBException.wrap("Logger.newCallbackLogger failed", t);
+			throw RocksDB.wrapInvokeFailure("Logger.newCallbackLogger failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
@@ -96,7 +96,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 					ptr(), writeOptions.ptr(), txnOptions.ptr(), MemorySegment.NULL);
 			return new Transaction(txnPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("beginTransaction failed", t);
+			throw RocksDB.wrapInvokeFailure("beginTransaction failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionOptions.java
@@ -41,7 +41,7 @@ public final class OptimisticTransactionOptions extends NativeObject {
 		try {
 			return new OptimisticTransactionOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("optimistic transaction options create failed", t);
+			throw RocksDB.wrapInvokeFailure("optimistic transaction options create failed", t);
 		}
 	}
 
@@ -56,7 +56,7 @@ public final class OptimisticTransactionOptions extends NativeObject {
 		try {
 			MH_SET_SET_SNAPSHOT.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setSetSnapshot failed", t);
+			throw RocksDB.wrapInvokeFailure("setSetSnapshot failed", t);
 		}
 		return this;
 	}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
@@ -236,7 +236,7 @@ public final class Options extends NativeObject {
 		try {
 			return new Options((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("options create failed", t);
+			throw RocksDB.wrapInvokeFailure("options create failed", t);
 		}
 	}
 
@@ -249,7 +249,7 @@ public final class Options extends NativeObject {
 		try {
 			MH_SET_CREATE_IF_MISSING.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setCreateIfMissing failed", t);
+			throw RocksDB.wrapInvokeFailure("setCreateIfMissing failed", t);
 		}
 		return this;
 	}
@@ -261,7 +261,7 @@ public final class Options extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_CREATE_IF_MISSING.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getCreateIfMissing failed", t);
+			throw RocksDB.wrapInvokeFailure("getCreateIfMissing failed", t);
 		}
 	}
 
@@ -272,7 +272,7 @@ public final class Options extends NativeObject {
 		try {
 			MH_ENABLE_STATISTICS.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("enableStatistics failed", t);
+			throw RocksDB.wrapInvokeFailure("enableStatistics failed", t);
 		}
 		return this;
 	}
@@ -285,7 +285,7 @@ public final class Options extends NativeObject {
 		try {
 			MH_SET_STATISTICS_LEVEL.invokeExact(ptr(), level.getValue());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setStatisticsLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("setStatisticsLevel failed", t);
 		}
 		return this;
 	}
@@ -298,7 +298,7 @@ public final class Options extends NativeObject {
 			int level = (int) MH_GET_STATISTICS_LEVEL.invokeExact(ptr());
 			return StatsLevel.fromValue(level);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getStatisticsLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("getStatisticsLevel failed", t);
 		}
 	}
 
@@ -313,7 +313,7 @@ public final class Options extends NativeObject {
 			}
 			return RocksDB.toJavaString(strPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getStatisticsString failed", t);
+			throw RocksDB.wrapInvokeFailure("getStatisticsString failed", t);
 		}
 	}
 
@@ -325,7 +325,7 @@ public final class Options extends NativeObject {
 		try {
 			return (long) MH_STATISTICS_GET_TICKER_COUNT.invokeExact(ptr(), ticker.getValue());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getTickerCount failed", t);
+			throw RocksDB.wrapInvokeFailure("getTickerCount failed", t);
 		}
 	}
 
@@ -337,7 +337,7 @@ public final class Options extends NativeObject {
 		try {
 			MH_STATISTICS_GET_HISTOGRAM_DATA.invokeExact(ptr(), histogram.getValue(), data.ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getHistogramData failed", t);
+			throw RocksDB.wrapInvokeFailure("getHistogramData failed", t);
 		}
 	}
 
@@ -351,7 +351,7 @@ public final class Options extends NativeObject {
 			MH_SET_COMPRESSION.invokeExact(ptr(), type.getValue());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setCompression failed", t);
+			throw RocksDB.wrapInvokeFailure("setCompression failed", t);
 		}
 	}
 
@@ -362,7 +362,7 @@ public final class Options extends NativeObject {
 		try {
 			return CompressionType.fromValue((int) MH_GET_COMPRESSION.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getCompression failed", t);
+			throw RocksDB.wrapInvokeFailure("getCompression failed", t);
 		}
 	}
 
@@ -375,7 +375,7 @@ public final class Options extends NativeObject {
 		try {
 			MH_SET_BLOCK_BASED_TABLE_FACTORY.invokeExact(ptr(), tableConfig.ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setTableFormatConfig failed", t);
+			throw RocksDB.wrapInvokeFailure("setTableFormatConfig failed", t);
 		}
 		return this;
 	}
@@ -395,7 +395,7 @@ public final class Options extends NativeObject {
 			MH_SET_ENABLE_BLOB_FILES.invokeExact(ptr(), RocksDB.toByte(value));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setEnableBlobFiles failed", t);
+			throw RocksDB.wrapInvokeFailure("setEnableBlobFiles failed", t);
 		}
 	}
 
@@ -406,7 +406,7 @@ public final class Options extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_ENABLE_BLOB_FILES.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getEnableBlobFiles failed", t);
+			throw RocksDB.wrapInvokeFailure("getEnableBlobFiles failed", t);
 		}
 	}
 
@@ -420,7 +420,7 @@ public final class Options extends NativeObject {
 			MH_SET_MIN_BLOB_SIZE.invokeExact(ptr(), size.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMinBlobSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setMinBlobSize failed", t);
 		}
 	}
 
@@ -431,7 +431,7 @@ public final class Options extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_MIN_BLOB_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMinBlobSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getMinBlobSize failed", t);
 		}
 	}
 
@@ -445,7 +445,7 @@ public final class Options extends NativeObject {
 			MH_SET_BLOB_FILE_SIZE.invokeExact(ptr(), size.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlobFileSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlobFileSize failed", t);
 		}
 	}
 
@@ -456,7 +456,7 @@ public final class Options extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_BLOB_FILE_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBlobFileSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getBlobFileSize failed", t);
 		}
 	}
 
@@ -470,7 +470,7 @@ public final class Options extends NativeObject {
 			MH_SET_BLOB_COMPRESSION_TYPE.invokeExact(ptr(), type.getValue());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlobCompressionType failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlobCompressionType failed", t);
 		}
 	}
 
@@ -481,7 +481,7 @@ public final class Options extends NativeObject {
 		try {
 			return CompressionType.fromValue((int) MH_GET_BLOB_COMPRESSION_TYPE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBlobCompressionType failed", t);
+			throw RocksDB.wrapInvokeFailure("getBlobCompressionType failed", t);
 		}
 	}
 
@@ -495,7 +495,7 @@ public final class Options extends NativeObject {
 			MH_SET_ENABLE_BLOB_GC.invokeExact(ptr(), RocksDB.toByte(value));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setEnableBlobGc failed", t);
+			throw RocksDB.wrapInvokeFailure("setEnableBlobGc failed", t);
 		}
 	}
 
@@ -506,7 +506,7 @@ public final class Options extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_ENABLE_BLOB_GC.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getEnableBlobGc failed", t);
+			throw RocksDB.wrapInvokeFailure("getEnableBlobGc failed", t);
 		}
 	}
 
@@ -521,7 +521,7 @@ public final class Options extends NativeObject {
 			MH_SET_BLOB_GC_AGE_CUTOFF.invokeExact(ptr(), value.toDouble());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlobGcAgeCutoff failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlobGcAgeCutoff failed", t);
 		}
 	}
 
@@ -532,7 +532,7 @@ public final class Options extends NativeObject {
 		try {
 			return Ratio.of((double) MH_GET_BLOB_GC_AGE_CUTOFF.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBlobGcAgeCutoff failed", t);
+			throw RocksDB.wrapInvokeFailure("getBlobGcAgeCutoff failed", t);
 		}
 	}
 
@@ -546,7 +546,7 @@ public final class Options extends NativeObject {
 			MH_SET_BLOB_GC_FORCE_THRESHOLD.invokeExact(ptr(), value.toDouble());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlobGcForceThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlobGcForceThreshold failed", t);
 		}
 	}
 
@@ -557,7 +557,7 @@ public final class Options extends NativeObject {
 		try {
 			return Ratio.of((double) MH_GET_BLOB_GC_FORCE_THRESHOLD.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBlobGcForceThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("getBlobGcForceThreshold failed", t);
 		}
 	}
 
@@ -571,7 +571,7 @@ public final class Options extends NativeObject {
 			MH_SET_BLOB_COMPACTION_READAHEAD_SIZE.invokeExact(ptr(), size.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlobCompactionReadaheadSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlobCompactionReadaheadSize failed", t);
 		}
 	}
 
@@ -582,7 +582,7 @@ public final class Options extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_BLOB_COMPACTION_READAHEAD_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBlobCompactionReadaheadSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getBlobCompactionReadaheadSize failed", t);
 		}
 	}
 
@@ -596,7 +596,7 @@ public final class Options extends NativeObject {
 			MH_SET_BLOB_FILE_STARTING_LEVEL.invokeExact(ptr(), level);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlobFileStartingLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlobFileStartingLevel failed", t);
 		}
 	}
 
@@ -607,7 +607,7 @@ public final class Options extends NativeObject {
 		try {
 			return (int) MH_GET_BLOB_FILE_STARTING_LEVEL.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getBlobFileStartingLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("getBlobFileStartingLevel failed", t);
 		}
 	}
 
@@ -621,7 +621,7 @@ public final class Options extends NativeObject {
 			MH_SET_BLOB_CACHE.invokeExact(ptr(), cache.ptr());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setBlobCache failed", t);
+			throw RocksDB.wrapInvokeFailure("setBlobCache failed", t);
 		}
 	}
 
@@ -635,7 +635,7 @@ public final class Options extends NativeObject {
 			MH_SET_PREPOPULATE_BLOB_CACHE.invokeExact(ptr(), mode.value);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setPrepopulateBlobCache failed", t);
+			throw RocksDB.wrapInvokeFailure("setPrepopulateBlobCache failed", t);
 		}
 	}
 
@@ -646,7 +646,7 @@ public final class Options extends NativeObject {
 		try {
 			return PrepopulateBlobCache.fromValue((int) MH_GET_PREPOPULATE_BLOB_CACHE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getPrepopulateBlobCache failed", t);
+			throw RocksDB.wrapInvokeFailure("getPrepopulateBlobCache failed", t);
 		}
 	}
 
@@ -664,7 +664,7 @@ public final class Options extends NativeObject {
 			MH_SET_INFO_LOG.invokeExact(ptr(), logger.ptr());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setInfoLog failed", t);
+			throw RocksDB.wrapInvokeFailure("setInfoLog failed", t);
 		}
 	}
 
@@ -677,7 +677,7 @@ public final class Options extends NativeObject {
 			MH_SET_INFO_LOG_LEVEL.invokeExact(ptr(), level.value);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setInfoLogLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("setInfoLogLevel failed", t);
 		}
 	}
 
@@ -688,7 +688,7 @@ public final class Options extends NativeObject {
 		try {
 			return LogLevel.fromValue((int) MH_GET_INFO_LOG_LEVEL.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getInfoLogLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("getInfoLogLevel failed", t);
 		}
 	}
 
@@ -704,7 +704,7 @@ public final class Options extends NativeObject {
 			MH_SET_ENV.invokeExact(ptr(), env.ptr());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setEnv failed", t);
+			throw RocksDB.wrapInvokeFailure("setEnv failed", t);
 		}
 	}
 
@@ -719,7 +719,7 @@ public final class Options extends NativeObject {
 			MH_SET_SST_FILE_MANAGER.invokeExact(ptr(), sfm.ptr());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setSstFileManager failed", t);
+			throw RocksDB.wrapInvokeFailure("setSstFileManager failed", t);
 		}
 	}
 
@@ -735,7 +735,7 @@ public final class Options extends NativeObject {
 			MH_SET_RATELIMITER.invokeExact(ptr(), rateLimiter.ptr());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setRateLimiter failed", t);
+			throw RocksDB.wrapInvokeFailure("setRateLimiter failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PerfContext.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PerfContext.java
@@ -93,7 +93,7 @@ public final class PerfContext extends NativeObject {
 		try {
 			MH_SET_PERF_LEVEL.invokeExact(level.value);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setPerfLevel failed", t);
+			throw RocksDB.wrapInvokeFailure("setPerfLevel failed", t);
 		}
 	}
 
@@ -122,7 +122,7 @@ public final class PerfContext extends NativeObject {
 		try {
 			return new PerfContext((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("PerfContext.currentPerfContext failed", t);
+			throw RocksDB.wrapInvokeFailure("PerfContext.currentPerfContext failed", t);
 		}
 	}
 
@@ -135,7 +135,7 @@ public final class PerfContext extends NativeObject {
 		try {
 			MH_RESET.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("reset failed", t);
+			throw RocksDB.wrapInvokeFailure("reset failed", t);
 		}
 	}
 
@@ -147,7 +147,7 @@ public final class PerfContext extends NativeObject {
 		try {
 			return (long) MH_METRIC.invokeExact(ptr(), metric.value);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("metric failed", t);
+			throw RocksDB.wrapInvokeFailure("metric failed", t);
 		}
 	}
 
@@ -161,7 +161,7 @@ public final class PerfContext extends NativeObject {
 			strPtr = (MemorySegment) MH_REPORT.invokeExact(ptr(),
 					RocksDB.toByte(excludeZeroCounters));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("report failed", t);
+			throw RocksDB.wrapInvokeFailure("report failed", t);
 		}
 		if (MemorySegment.NULL.equals(strPtr)) {
 			return "";

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableHandle.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableHandle.java
@@ -97,7 +97,7 @@ final class PinnableHandle extends NativeObject {
 		try {
 			return (MemorySegment) MH_GET_VALUE.invokeExact(ptr(), vallenOut);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("pinnable_handle_get_value failed", t);
+			throw RocksDB.wrapInvokeFailure("pinnable_handle_get_value failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/PinnableSlice.java
@@ -136,7 +136,7 @@ final class PinnableSlice extends NativeObject {
 		try {
 			return (MemorySegment) MH_VALUE.invokeExact(ptr(), vallenOut);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("pinnableslice value failed", t);
+			throw RocksDB.wrapInvokeFailure("pinnableslice value failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RateLimiter.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RateLimiter.java
@@ -98,7 +98,7 @@ public final class RateLimiter extends NativeObject {
 					rateBytesPerSec.toBytes(), refillPeriodUs, fairness);
 			return new RateLimiter(ptr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("RateLimiter create failed", t);
+			throw RocksDB.wrapInvokeFailure("RateLimiter create failed", t);
 		}
 	}
 
@@ -115,7 +115,7 @@ public final class RateLimiter extends NativeObject {
 					rateBytesPerSec.toBytes(), refillPeriodUs, fairness);
 			return new RateLimiter(ptr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("RateLimiter createAutoTuned failed", t);
+			throw RocksDB.wrapInvokeFailure("RateLimiter createAutoTuned failed", t);
 		}
 	}
 
@@ -144,7 +144,7 @@ public final class RateLimiter extends NativeObject {
 					mode.value, RocksDB.toByte(autoTuned));
 			return new RateLimiter(ptr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("RateLimiter createWithMode failed", t);
+			throw RocksDB.wrapInvokeFailure("RateLimiter createWithMode failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOptions.java
@@ -143,7 +143,7 @@ public final class ReadOptions extends NativeObject {
 		try {
 			return new ReadOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("readoptions create failed", t);
+			throw RocksDB.wrapInvokeFailure("readoptions create failed", t);
 		}
 	}
 
@@ -159,7 +159,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_SNAPSHOT.invokeExact(ptr(), snapPtr);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("readoptions setSnapshot failed", t);
+			throw RocksDB.wrapInvokeFailure("readoptions setSnapshot failed", t);
 		}
 	}
 
@@ -173,7 +173,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_VERIFY_CHECKSUMS.invokeExact(ptr(), RocksDB.toByte(verifyChecksums));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setVerifyChecksums failed", t);
+			throw RocksDB.wrapInvokeFailure("setVerifyChecksums failed", t);
 		}
 	}
 
@@ -184,7 +184,7 @@ public final class ReadOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_VERIFY_CHECKSUMS.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isVerifyChecksums failed", t);
+			throw RocksDB.wrapInvokeFailure("isVerifyChecksums failed", t);
 		}
 	}
 
@@ -198,7 +198,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_FILL_CACHE.invokeExact(ptr(), RocksDB.toByte(fillCache));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setFillCache failed", t);
+			throw RocksDB.wrapInvokeFailure("setFillCache failed", t);
 		}
 	}
 
@@ -209,7 +209,7 @@ public final class ReadOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_FILL_CACHE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isFillCache failed", t);
+			throw RocksDB.wrapInvokeFailure("isFillCache failed", t);
 		}
 	}
 
@@ -224,7 +224,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_PIN_DATA.invokeExact(ptr(), RocksDB.toByte(pinData));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setPinData failed", t);
+			throw RocksDB.wrapInvokeFailure("setPinData failed", t);
 		}
 	}
 
@@ -235,7 +235,7 @@ public final class ReadOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_PIN_DATA.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isPinData failed", t);
+			throw RocksDB.wrapInvokeFailure("isPinData failed", t);
 		}
 	}
 
@@ -249,7 +249,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_TAILING.invokeExact(ptr(), RocksDB.toByte(tailing));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setTailing failed", t);
+			throw RocksDB.wrapInvokeFailure("setTailing failed", t);
 		}
 	}
 
@@ -260,7 +260,7 @@ public final class ReadOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_TAILING.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isTailing failed", t);
+			throw RocksDB.wrapInvokeFailure("isTailing failed", t);
 		}
 	}
 
@@ -275,7 +275,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_TOTAL_ORDER_SEEK.invokeExact(ptr(), RocksDB.toByte(totalOrderSeek));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setTotalOrderSeek failed", t);
+			throw RocksDB.wrapInvokeFailure("setTotalOrderSeek failed", t);
 		}
 	}
 
@@ -286,7 +286,7 @@ public final class ReadOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_TOTAL_ORDER_SEEK.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isTotalOrderSeek failed", t);
+			throw RocksDB.wrapInvokeFailure("isTotalOrderSeek failed", t);
 		}
 	}
 
@@ -301,7 +301,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_PREFIX_SAME_AS_START.invokeExact(ptr(), RocksDB.toByte(prefixSameAsStart));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setPrefixSameAsStart failed", t);
+			throw RocksDB.wrapInvokeFailure("setPrefixSameAsStart failed", t);
 		}
 	}
 
@@ -312,7 +312,7 @@ public final class ReadOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_PREFIX_SAME_AS_START.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isPrefixSameAsStart failed", t);
+			throw RocksDB.wrapInvokeFailure("isPrefixSameAsStart failed", t);
 		}
 	}
 
@@ -327,7 +327,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_READAHEAD_SIZE.invokeExact(ptr(), readaheadSize.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setReadaheadSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setReadaheadSize failed", t);
 		}
 	}
 
@@ -338,7 +338,7 @@ public final class ReadOptions extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_READAHEAD_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getReadaheadSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getReadaheadSize failed", t);
 		}
 	}
 
@@ -371,7 +371,7 @@ public final class ReadOptions extends NativeObject {
 			}
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIterateLowerBound failed", t);
+			throw RocksDB.wrapInvokeFailure("setIterateLowerBound failed", t);
 		}
 	}
 
@@ -387,7 +387,7 @@ public final class ReadOptions extends NativeObject {
 					MemorySegment.ofBuffer(lowerBound), (long) lowerBound.remaining());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIterateLowerBound failed", t);
+			throw RocksDB.wrapInvokeFailure("setIterateLowerBound failed", t);
 		}
 	}
 
@@ -402,7 +402,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_ITERATE_LOWER_BOUND.invokeExact(ptr(), lowerBound, lowerBound.byteSize());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIterateLowerBound failed", t);
+			throw RocksDB.wrapInvokeFailure("setIterateLowerBound failed", t);
 		}
 	}
 
@@ -425,7 +425,7 @@ public final class ReadOptions extends NativeObject {
 			}
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIterateUpperBound failed", t);
+			throw RocksDB.wrapInvokeFailure("setIterateUpperBound failed", t);
 		}
 	}
 
@@ -441,7 +441,7 @@ public final class ReadOptions extends NativeObject {
 					MemorySegment.ofBuffer(upperBound), (long) upperBound.remaining());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIterateUpperBound failed", t);
+			throw RocksDB.wrapInvokeFailure("setIterateUpperBound failed", t);
 		}
 	}
 
@@ -456,7 +456,7 @@ public final class ReadOptions extends NativeObject {
 			MH_SET_ITERATE_UPPER_BOUND.invokeExact(ptr(), upperBound, upperBound.byteSize());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIterateUpperBound failed", t);
+			throw RocksDB.wrapInvokeFailure("setIterateUpperBound failed", t);
 		}
 	}
 
@@ -481,7 +481,7 @@ public final class ReadOptions extends NativeObject {
 			}
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setRequestId failed", t);
+			throw RocksDB.wrapInvokeFailure("setRequestId failed", t);
 		}
 	}
 
@@ -499,7 +499,7 @@ public final class ReadOptions extends NativeObject {
 			byte[] bytes = RocksDB.toByteArray(result, len);
 			return Optional.of(new String(bytes, StandardCharsets.UTF_8));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getRequestId failed", t);
+			throw RocksDB.wrapInvokeFailure("getRequestId failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RestoreOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RestoreOptions.java
@@ -46,7 +46,7 @@ public final class RestoreOptions extends NativeObject {
 		try {
 			return new RestoreOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("RestoreOptions.create failed", t);
+			throw RocksDB.wrapInvokeFailure("RestoreOptions.create failed", t);
 		}
 	}
 
@@ -60,7 +60,7 @@ public final class RestoreOptions extends NativeObject {
 			MH_SET_KEEP_LOG_FILES.invokeExact(ptr(), keepLogFiles ? 1 : 0);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setKeepLogFiles failed", t);
+			throw RocksDB.wrapInvokeFailure("setKeepLogFiles failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1,5 +1,7 @@
 package io.github.dfa1.rocksdbffm;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
@@ -437,7 +439,7 @@ public final class RocksDB {
 			checkError(err);
 			return new ReadWriteDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openReadWrite failed", t);
+			throw RocksDB.wrapInvokeFailure("openReadWrite failed", t);
 		}
 	}
 
@@ -469,7 +471,7 @@ public final class RocksDB {
 			checkError(err);
 			return new TtlDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions(), ttl);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openTtl failed", t);
+			throw RocksDB.wrapInvokeFailure("openTtl failed", t);
 		}
 	}
 
@@ -502,7 +504,7 @@ public final class RocksDB {
 			checkError(err);
 			return new BlobDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openBlob failed", t);
+			throw RocksDB.wrapInvokeFailure("openBlob failed", t);
 		}
 	}
 
@@ -536,7 +538,7 @@ public final class RocksDB {
 			checkError(err);
 			return new ReadOnlyDB(ptr, ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openReadOnly failed", t);
+			throw RocksDB.wrapInvokeFailure("openReadOnly failed", t);
 		}
 	}
 
@@ -581,7 +583,7 @@ public final class RocksDB {
 
 			return new SecondaryDB(ptr, ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openSecondary failed", t);
+			throw RocksDB.wrapInvokeFailure("openSecondary failed", t);
 		}
 	}
 
@@ -607,7 +609,7 @@ public final class RocksDB {
 			MemorySegment baseDb = (MemorySegment) MH_TRANSACTION_GET_BASE_DB.invokeExact(ptr);
 			return new TransactionDB(ptr, baseDb, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openTransaction failed", t);
+			throw RocksDB.wrapInvokeFailure("openTransaction failed", t);
 		}
 	}
 
@@ -628,7 +630,7 @@ public final class RocksDB {
 			MemorySegment baseDb = (MemorySegment) MH_GET_BASE_DB.invokeExact(ptr);
 			return new OptimisticTransactionDB(ptr, baseDb, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openOptimistic failed", t);
+			throw RocksDB.wrapInvokeFailure("openOptimistic failed", t);
 		}
 	}
 
@@ -666,7 +668,7 @@ public final class RocksDB {
 				return ph.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -690,7 +692,7 @@ public final class RocksDB {
 			value.position(value.position() + (int) valLen);
 			return CopyResult.Copied.INSTANCE;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -713,7 +715,7 @@ public final class RocksDB {
 			}
 			return CopyResult.Copied.INSTANCE;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -723,16 +725,10 @@ public final class RocksDB {
 
 	/// Scoped zero-copy get via `rocksdb_get_pinned_v2`. [PinnableHandle] owns the pinned
 	/// value's lifetime and every way it gets consumed.
-	static <R> Optional<R> withPinned(MemorySegment db, MemorySegment readOpts,
-	                                   MemorySegment key, Mapper<R> fn) {
+	static <R> Optional<R> withPinned(MemorySegment db, MemorySegment readOpts, MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment handle;
-			try {
-				handle = (MemorySegment) MH_GET_PINNED_V2.invokeExact(db, readOpts, key, key.byteSize(), err);
-			} catch (Throwable t) {
-				throw RocksDBException.wrap("get_pinned failed", t);
-			}
+			MemorySegment handle = (MemorySegment) MH_GET_PINNED_V2.invokeExact(db, readOpts, key, key.byteSize(), err);
 			checkError(err);
 			if (MemorySegment.NULL.equals(handle)) {
 				return Optional.empty();
@@ -740,6 +736,8 @@ public final class RocksDB {
 			try (PinnableHandle ph = PinnableHandle.wrap(handle)) {
 				return Optional.of(ph.map(arena, fn, err));
 			}
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("get_pinned failed", t);
 		}
 	}
 
@@ -749,13 +747,8 @@ public final class RocksDB {
 	                                     MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment handle;
-			try {
-				handle = (MemorySegment) MH_GET_PINNED_CF_V2.invokeExact(
-						db, readOpts, cf.ptr(), key, key.byteSize(), err);
-			} catch (Throwable t) {
-				throw RocksDBException.wrap("get_pinned failed", t);
-			}
+			MemorySegment handle = (MemorySegment) MH_GET_PINNED_CF_V2.invokeExact(
+					db, readOpts, cf.ptr(), key, key.byteSize(), err);
 			checkError(err);
 			if (MemorySegment.NULL.equals(handle)) {
 				return Optional.empty();
@@ -763,6 +756,8 @@ public final class RocksDB {
 			try (PinnableHandle ph = PinnableHandle.wrap(handle)) {
 				return Optional.of(ph.map(arena, fn, err));
 			}
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("get_pinned failed", t);
 		}
 	}
 
@@ -775,7 +770,7 @@ public final class RocksDB {
 			MH_PUT.invokeExact(db, writeOpts, k, (long) key.length, v, (long) value.length, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -788,7 +783,7 @@ public final class RocksDB {
 			MH_PUT.invokeExact(db, writeOpts, k, (long) key.length, v, (long) value.length, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -800,7 +795,7 @@ public final class RocksDB {
 			MH_PUT.invokeExact(db, writeOpts, key, keyLen, val, valLen, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -812,7 +807,7 @@ public final class RocksDB {
 			MH_PUT.invokeExact(db, writeOpts, key, keyLen, val, valLen, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -824,7 +819,7 @@ public final class RocksDB {
 			MH_DELETE.invokeExact(db, writeOpts, k, (long) key.length, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -835,7 +830,7 @@ public final class RocksDB {
 			MH_DELETE.invokeExact(db, writeOpts, key, keyLen, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -845,7 +840,7 @@ public final class RocksDB {
 			MH_FLUSH.invokeExact(db, flushOptions.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flush failed", t);
+			throw RocksDB.wrapInvokeFailure("flush failed", t);
 		}
 	}
 
@@ -853,7 +848,7 @@ public final class RocksDB {
 		try {
 			MH_CANCEL_ALL_BACKGROUND_WORK.invokeExact(db, toByte(wait));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("cancelAllBackgroundWork failed", t);
+			throw RocksDB.wrapInvokeFailure("cancelAllBackgroundWork failed", t);
 		}
 	}
 
@@ -861,7 +856,7 @@ public final class RocksDB {
 		try {
 			MH_DISABLE_MANUAL_COMPACTION.invokeExact(db);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("disableManualCompaction failed", t);
+			throw RocksDB.wrapInvokeFailure("disableManualCompaction failed", t);
 		}
 	}
 
@@ -869,7 +864,7 @@ public final class RocksDB {
 		try {
 			MH_ENABLE_MANUAL_COMPACTION.invokeExact(db);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("enableManualCompaction failed", t);
+			throw RocksDB.wrapInvokeFailure("enableManualCompaction failed", t);
 		}
 	}
 
@@ -879,7 +874,7 @@ public final class RocksDB {
 			MH_WAIT_FOR_COMPACT.invokeExact(db, options.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("waitForCompact failed", t);
+			throw RocksDB.wrapInvokeFailure("waitForCompact failed", t);
 		}
 	}
 
@@ -888,7 +883,7 @@ public final class RocksDB {
 			long seq = (long) MH_GET_LATEST_SEQUENCE_NUMBER.invokeExact(db);
 			return SequenceNumber.of(seq);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getLatestSequenceNumber failed", t);
+			throw RocksDB.wrapInvokeFailure("getLatestSequenceNumber failed", t);
 		}
 	}
 
@@ -900,7 +895,7 @@ public final class RocksDB {
 			checkError(err);
 			return WalIterator.wrap(iterPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getUpdatesSince failed", t);
+			throw RocksDB.wrapInvokeFailure("getUpdatesSince failed", t);
 		}
 	}
 
@@ -910,7 +905,7 @@ public final class RocksDB {
 			MH_FLUSH_WAL.invokeExact(db, toByte(sync), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flushWal failed", t);
+			throw RocksDB.wrapInvokeFailure("flushWal failed", t);
 		}
 	}
 
@@ -919,7 +914,7 @@ public final class RocksDB {
 			MemorySegment snapPtr = (MemorySegment) MH_CREATE_SNAPSHOT.invokeExact(db);
 			return new Snapshot(db, snapPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getSnapshot failed", t);
+			throw RocksDB.wrapInvokeFailure("getSnapshot failed", t);
 		}
 	}
 
@@ -929,7 +924,7 @@ public final class RocksDB {
 			MemorySegment result = (MemorySegment) MH_PROPERTY_VALUE.invokeExact(db, propSeg);
 			return toOptionalString(result);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getProperty failed", t);
+			throw RocksDB.wrapInvokeFailure("getProperty failed", t);
 		}
 	}
 
@@ -943,7 +938,7 @@ public final class RocksDB {
 			}
 			return OptionalLong.of(out.get(ValueLayout.JAVA_LONG, 0));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getLongProperty failed", t);
+			throw RocksDB.wrapInvokeFailure("getLongProperty failed", t);
 		}
 	}
 
@@ -960,7 +955,7 @@ public final class RocksDB {
 					toNative(arena, endKey), (long) endKey.length, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("deleteRange failed", t);
 		}
 	}
 
@@ -974,7 +969,7 @@ public final class RocksDB {
 					MemorySegment.ofBuffer(endKey), (long) endKey.remaining(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("deleteRange failed", t);
 		}
 	}
 
@@ -987,7 +982,7 @@ public final class RocksDB {
 					startKey, startKey.byteSize(), endKey, endKey.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("deleteRange failed", t);
 		}
 	}
 
@@ -997,7 +992,7 @@ public final class RocksDB {
 			MH_WRITE.invokeExact(db, writeOpts, batch.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("write failed", t);
+			throw RocksDB.wrapInvokeFailure("write failed", t);
 		}
 	}
 
@@ -1007,7 +1002,7 @@ public final class RocksDB {
 			MH_WRITE.invokeExact(db, writeOpts, batch.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("write failed", t);
+			throw RocksDB.wrapInvokeFailure("write failed", t);
 		}
 	}
 
@@ -1018,7 +1013,7 @@ public final class RocksDB {
 					MemorySegment.NULL, MemorySegment.NULL,
 					MemorySegment.NULL, 0L, MemorySegment.NULL));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("keyMayExist failed", t);
+			throw RocksDB.wrapInvokeFailure("keyMayExist failed", t);
 		}
 	}
 
@@ -1038,7 +1033,7 @@ public final class RocksDB {
 					s, startKey == null ? 0L : (long) startKey.length,
 					e, endKey == null ? 0L : (long) endKey.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("compactRange failed", t);
+			throw RocksDB.wrapInvokeFailure("compactRange failed", t);
 		}
 	}
 
@@ -1050,7 +1045,7 @@ public final class RocksDB {
 					s, startKey == null ? 0L : (long) startKey.remaining(),
 					e, endKey == null ? 0L : (long) endKey.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("compactRange failed", t);
+			throw RocksDB.wrapInvokeFailure("compactRange failed", t);
 		}
 	}
 
@@ -1062,7 +1057,7 @@ public final class RocksDB {
 					s, s == MemorySegment.NULL ? 0L : s.byteSize(),
 					e, e == MemorySegment.NULL ? 0L : e.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("compactRange failed", t);
+			throw RocksDB.wrapInvokeFailure("compactRange failed", t);
 		}
 	}
 
@@ -1074,7 +1069,7 @@ public final class RocksDB {
 					s, startKey == null ? 0L : (long) startKey.length,
 					e, endKey == null ? 0L : (long) endKey.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("compactRange failed", t);
+			throw RocksDB.wrapInvokeFailure("compactRange failed", t);
 		}
 	}
 
@@ -1088,7 +1083,7 @@ public final class RocksDB {
 					e, endKey == null ? 0L : (long) endKey.length, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("suggestCompactRange failed", t);
+			throw RocksDB.wrapInvokeFailure("suggestCompactRange failed", t);
 		}
 	}
 
@@ -1098,7 +1093,7 @@ public final class RocksDB {
 			MH_DISABLE_FILE_DELETIONS.invokeExact(db, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("disableFileDeletions failed", t);
+			throw RocksDB.wrapInvokeFailure("disableFileDeletions failed", t);
 		}
 	}
 
@@ -1108,7 +1103,7 @@ public final class RocksDB {
 			MH_ENABLE_FILE_DELETIONS.invokeExact(db, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("enableFileDeletions failed", t);
+			throw RocksDB.wrapInvokeFailure("enableFileDeletions failed", t);
 		}
 	}
 
@@ -1125,7 +1120,7 @@ public final class RocksDB {
 			MH_INGEST_EXTERNAL_FILE.invokeExact(db, fileArray, (long) files.size(), options.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("ingestExternalFile failed", t);
+			throw RocksDB.wrapInvokeFailure("ingestExternalFile failed", t);
 		}
 	}
 
@@ -1187,7 +1182,7 @@ public final class RocksDB {
 
 			return new ReadWriteDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openReadWrite failed", t);
+			throw RocksDB.wrapInvokeFailure("openReadWrite failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1251,7 +1246,7 @@ public final class RocksDB {
 			}
 			return new ReadOnlyDB(ptr, ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openReadOnly failed", t);
+			throw RocksDB.wrapInvokeFailure("openReadOnly failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1306,7 +1301,7 @@ public final class RocksDB {
 			Duration globalTtl = ttls.isEmpty() ? Duration.ZERO : ttls.getFirst();
 			return new TtlDB(ptr, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions(), globalTtl);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openTtl failed", t);
+			throw RocksDB.wrapInvokeFailure("openTtl failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1358,7 +1353,7 @@ public final class RocksDB {
 			MemorySegment baseDb = (MemorySegment) MH_TRANSACTION_GET_BASE_DB.invokeExact(ptr);
 			return new TransactionDB(ptr, baseDb, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openTransaction failed", t);
+			throw RocksDB.wrapInvokeFailure("openTransaction failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1407,7 +1402,7 @@ public final class RocksDB {
 			MemorySegment baseDb = (MemorySegment) MH_GET_BASE_DB.invokeExact(ptr);
 			return new OptimisticTransactionDB(ptr, baseDb, WriteOptions.newWriteOptions(), ReadOptions.newReadOptions());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("openOptimistic failed", t);
+			throw RocksDB.wrapInvokeFailure("openOptimistic failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1441,7 +1436,7 @@ public final class RocksDB {
 			MH_LIST_CF_DESTROY.invokeExact(namesPtr, count);
 			return result;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("listColumnFamilies failed", t);
+			throw RocksDB.wrapInvokeFailure("listColumnFamilies failed", t);
 		}
 	}
 
@@ -1465,7 +1460,7 @@ public final class RocksDB {
 			checkError(err);
 			return ColumnFamilyHandle.wrap(handle);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("createColumnFamily failed", t);
+			throw RocksDB.wrapInvokeFailure("createColumnFamily failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -1479,7 +1474,7 @@ public final class RocksDB {
 			MH_DROP_CF.invokeExact(db, handle.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("dropColumnFamily failed", t);
+			throw RocksDB.wrapInvokeFailure("dropColumnFamily failed", t);
 		}
 	}
 
@@ -1493,7 +1488,7 @@ public final class RocksDB {
 					toNative(arena, value), (long) value.length, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -1505,7 +1500,7 @@ public final class RocksDB {
 			MH_PUT_CF.invokeExact(db, writeOpts, cf.ptr(), key, keyLen, val, valLen, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -1528,7 +1523,7 @@ public final class RocksDB {
 				return ph.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -1553,7 +1548,7 @@ public final class RocksDB {
 			value.position(value.position() + (int) valLen);
 			return CopyResult.Copied.INSTANCE;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -1577,7 +1572,7 @@ public final class RocksDB {
 			}
 			return CopyResult.Copied.INSTANCE;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -1590,7 +1585,7 @@ public final class RocksDB {
 					toNative(arena, key), (long) key.length, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -1602,7 +1597,7 @@ public final class RocksDB {
 			MH_DELETE_CF.invokeExact(db, writeOpts, cf.ptr(), key, keyLen, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -1617,7 +1612,7 @@ public final class RocksDB {
 					toNative(arena, endKey), (long) endKey.length, err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("deleteRange failed", t);
 		}
 	}
 
@@ -1632,7 +1627,7 @@ public final class RocksDB {
 					MemorySegment.ofBuffer(endKey), (long) endKey.remaining(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("deleteRange failed", t);
 		}
 	}
 
@@ -1646,7 +1641,7 @@ public final class RocksDB {
 					startKey, startKey.byteSize(), endKey, endKey.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("deleteRange failed", t);
 		}
 	}
 
@@ -1658,7 +1653,7 @@ public final class RocksDB {
 					MemorySegment.NULL, MemorySegment.NULL,
 					MemorySegment.NULL, 0L, MemorySegment.NULL));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("keyMayExist failed", t);
+			throw RocksDB.wrapInvokeFailure("keyMayExist failed", t);
 		}
 	}
 
@@ -1678,7 +1673,7 @@ public final class RocksDB {
 					db, readOpts, cf.ptr());
 			return RocksIterator.create(iterPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("newIterator failed", t);
+			throw RocksDB.wrapInvokeFailure("newIterator failed", t);
 		}
 	}
 
@@ -1688,7 +1683,7 @@ public final class RocksDB {
 			MH_FLUSH_CF.invokeExact(db, flushOptions.ptr(), cf.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flush failed", t);
+			throw RocksDB.wrapInvokeFailure("flush failed", t);
 		}
 	}
 
@@ -1700,7 +1695,7 @@ public final class RocksDB {
 					db, cf.ptr(), propSeg);
 			return toOptionalString(result);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getProperty failed", t);
+			throw RocksDB.wrapInvokeFailure("getProperty failed", t);
 		}
 	}
 
@@ -1715,7 +1710,7 @@ public final class RocksDB {
 			}
 			return OptionalLong.of(out.get(ValueLayout.JAVA_LONG, 0));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getLongProperty failed", t);
+			throw RocksDB.wrapInvokeFailure("getLongProperty failed", t);
 		}
 	}
 
@@ -1764,6 +1759,38 @@ public final class RocksDB {
 			String msg = toJavaString(errPtr);
 			throw new RocksDBException(msg);
 		}
+	}
+
+	/// Classifies a `Throwable` caught from a `catch (Throwable t)` block wrapping an
+	/// `invokeExact` call on a downcall [MethodHandle]. RocksDB itself reports operational
+	/// failures via `errptr`, checked separately by [#checkError(MemorySegment)] -- typically
+	/// called right after `invokeExact` inside the same `try`, so a genuine [RocksDBException]
+	/// it throws reaches this method too, alongside whatever `invokeExact` itself might throw.
+	/// See [ADR 0004](https://github.com/dfa1/rocksdbffm/blob/main/docs/adr/0004-error-handling.md).
+	///
+	/// Every `RuntimeException` -- a [RocksDBException] from `checkError`, or one of the small,
+	/// fixed set `invokeExact` itself throws in practice for a downcall handle
+	/// (`NullPointerException`, `IllegalStateException` including `WrongThreadException`,
+	/// `WrongMethodTypeException`, `ClassCastException`, each indicating a concrete binding bug:
+	/// wrong argument, closed/wrong-thread arena, mismatched `FunctionDescriptor`, bad cast) --
+	/// propagates unwrapped, with its original type preserved. An [IOException] (not from
+	/// `invokeExact` itself, which never throws a checked exception, but possible from other
+	/// code sharing the same `try` block, e.g. file access) becomes an [UncheckedIOException],
+	/// the standard idiom for surfacing it as unchecked. Anything else reaching this method
+	/// should never actually happen for a correctly configured downcall handle, and becomes an
+	/// [AssertionError].
+	///
+	/// @param message description used for the [UncheckedIOException]/[AssertionError] fallbacks
+	/// @param t       the throwable caught from the `invokeExact` call's `try` block
+	/// @return never returns; declared non-void so callers can write `throw wrapInvokeFailure(...)`
+	static RuntimeException wrapInvokeFailure(String message, Throwable t) {
+		if (t instanceof RuntimeException e) {
+			throw e;
+		}
+		if (t instanceof IOException e) {
+			throw new UncheckedIOException(message, e);
+		}
+		throw new AssertionError(message, t);
 	}
 
 	/// Copies `len` bytes out of a length-prefixed, non-owned native pointer (e.g. a `const

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBException.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBException.java
@@ -1,36 +1,17 @@
 package io.github.dfa1.rocksdbffm;
 
-/// Unchecked exception thrown when a RocksDB native operation fails.
+/// Unchecked exception thrown when RocksDB itself reports a native operation failure via its
+/// `errptr` out-parameter — corruption, an IO error, an invalid argument at the DB level.
 ///
-/// No public constructors. The two-arg (message, cause) constructor is private, reachable only
-/// via [#wrap(String, Throwable)], so a [RocksDBException] can never be wrapped by itself. The
-/// single-arg (message-only) constructor is package-private instead: used directly by
-/// [RocksDB#checkError(java.lang.foreign.MemorySegment)] for RocksDB's own `errptr`-reported
-/// errors, which have no Java [Throwable] to wrap in the first place, so there is no
-/// double-wrap invariant to gate behind a factory method there.
+/// No public constructor: only [RocksDB#checkError(java.lang.foreign.MemorySegment)] constructs
+/// one, from the C string `errptr` reports. This type is never used to wrap an `invokeExact`
+/// failure — see [RocksDB#wrapInvokeFailure(String, Throwable)] and
+/// [ADR 0004](https://github.com/dfa1/rocksdbffm/blob/main/docs/adr/0004-error-handling.md) for
+/// why: an `invokeExact` failure is a bug in this library's own FFM plumbing, never a genuine
+/// RocksDB error, so catching `RocksDBException` means exactly one thing.
 public class RocksDBException extends RuntimeException {
 
 	RocksDBException(String message) {
 		super(message);
-	}
-
-	private RocksDBException(String message, Throwable cause) {
-		super(message, cause);
-	}
-
-	/// Re-throws `t` as-is if it is already a [RocksDBException],
-	/// otherwise wraps it. Use at the bottom of every `catch (Throwable t)` block:
-	/// <pre>
-	/// <code><jbr-internal-inline></jbr-internal-inline></code> catch (Throwable t) {
-	///     throw RocksDBException.wrap("operation failed", t);
-	/// }
-	/// }
-	/// </pre>
-	///
-	/// @param message description used if `t` is not already a [RocksDBException]
-	/// @param t       the throwable to promote or wrap
-	/// @return `t` cast to [RocksDBException], or a new one wrapping `t`
-	public static RocksDBException wrap(String message, Throwable t) {
-		return (t instanceof RocksDBException r) ? r : new RocksDBException(message, t);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
@@ -114,7 +114,7 @@ public final class RocksIterator extends NativeObject {
 			MemorySegment iterPtr = (MemorySegment) MH_CREATE.invokeExact(dbPtr, readOptions);
 			return new RocksIterator(iterPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("iterator create failed", t);
+			throw RocksDB.wrapInvokeFailure("iterator create failed", t);
 		}
 	}
 
@@ -132,7 +132,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			MH_SEEK_TO_FIRST.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("seekToFirst failed", t);
+			throw RocksDB.wrapInvokeFailure("seekToFirst failed", t);
 		}
 	}
 
@@ -141,7 +141,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			MH_SEEK_TO_LAST.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("seekToLast failed", t);
+			throw RocksDB.wrapInvokeFailure("seekToLast failed", t);
 		}
 	}
 
@@ -152,7 +152,7 @@ public final class RocksIterator extends NativeObject {
 		try (Arena arena = Arena.ofConfined()) {
 			MH_SEEK.invokeExact(ptr(), RocksDB.toNative(arena, target), (long) target.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("seek failed", t);
+			throw RocksDB.wrapInvokeFailure("seek failed", t);
 		}
 	}
 
@@ -163,7 +163,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			MH_SEEK.invokeExact(ptr(), MemorySegment.ofBuffer(target), (long) target.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("seek failed", t);
+			throw RocksDB.wrapInvokeFailure("seek failed", t);
 		}
 	}
 
@@ -174,7 +174,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			MH_SEEK.invokeExact(ptr(), target, target.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("seek failed", t);
+			throw RocksDB.wrapInvokeFailure("seek failed", t);
 		}
 	}
 
@@ -185,7 +185,7 @@ public final class RocksIterator extends NativeObject {
 		try (Arena arena = Arena.ofConfined()) {
 			MH_SEEK_FOR_PREV.invokeExact(ptr(), RocksDB.toNative(arena, target), (long) target.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("seekForPrev failed", t);
+			throw RocksDB.wrapInvokeFailure("seekForPrev failed", t);
 		}
 	}
 
@@ -196,7 +196,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			MH_SEEK_FOR_PREV.invokeExact(ptr(), MemorySegment.ofBuffer(target), (long) target.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("seekForPrev failed", t);
+			throw RocksDB.wrapInvokeFailure("seekForPrev failed", t);
 		}
 	}
 
@@ -207,7 +207,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			MH_SEEK_FOR_PREV.invokeExact(ptr(), target, target.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("seekForPrev failed", t);
+			throw RocksDB.wrapInvokeFailure("seekForPrev failed", t);
 		}
 	}
 
@@ -216,7 +216,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			MH_NEXT.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("next failed", t);
+			throw RocksDB.wrapInvokeFailure("next failed", t);
 		}
 	}
 
@@ -225,7 +225,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			MH_PREV.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("prev failed", t);
+			throw RocksDB.wrapInvokeFailure("prev failed", t);
 		}
 	}
 
@@ -240,7 +240,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_VALID.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isValid failed", t);
+			throw RocksDB.wrapInvokeFailure("isValid failed", t);
 		}
 	}
 
@@ -253,7 +253,7 @@ public final class RocksIterator extends NativeObject {
 			MH_GET_ERROR.invokeExact(ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getError failed", t);
+			throw RocksDB.wrapInvokeFailure("getError failed", t);
 		}
 	}
 
@@ -270,7 +270,7 @@ public final class RocksIterator extends NativeObject {
 			MemorySegment errPtr = err.get(ValueLayout.ADDRESS, 0);
 			return RocksDB.toOptionalString(errPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("error failed", t);
+			throw RocksDB.wrapInvokeFailure("error failed", t);
 		}
 	}
 
@@ -283,7 +283,7 @@ public final class RocksIterator extends NativeObject {
 			MH_REFRESH.invokeExact(ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("refresh failed", t);
+			throw RocksDB.wrapInvokeFailure("refresh failed", t);
 		}
 	}
 
@@ -407,7 +407,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			return (MemorySegment) MH_KEY.invokeExact(ptr(), lenSegment);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("key failed", t);
+			throw RocksDB.wrapInvokeFailure("key failed", t);
 		}
 	}
 
@@ -421,7 +421,7 @@ public final class RocksIterator extends NativeObject {
 		try {
 			return (MemorySegment) MH_VALUE.invokeExact(ptr(), lenSegment);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("value failed", t);
+			throw RocksDB.wrapInvokeFailure("value failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
@@ -65,7 +65,7 @@ public final class SecondaryDB extends NativeObject {
 			MH_CATCH_UP.invokeExact(ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("tryCatchUpWithPrimary failed", t);
+			throw RocksDB.wrapInvokeFailure("tryCatchUpWithPrimary failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Snapshot.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Snapshot.java
@@ -64,7 +64,7 @@ public final class Snapshot extends NativeObject {
 		try {
 			return SequenceNumber.of((long) MH_SEQUENCE_NUMBER.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("snapshot sequenceNumber failed", t);
+			throw RocksDB.wrapInvokeFailure("snapshot sequenceNumber failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileManager.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileManager.java
@@ -117,7 +117,7 @@ public final class SstFileManager extends NativeObject {
 			MemorySegment ptr = (MemorySegment) MH_CREATE.invokeExact(env.ptr());
 			return new SstFileManager(ptr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("SstFileManager create failed", t);
+			throw RocksDB.wrapInvokeFailure("SstFileManager create failed", t);
 		}
 	}
 
@@ -133,7 +133,7 @@ public final class SstFileManager extends NativeObject {
 			MH_SET_MAX_ALLOWED_SPACE_USAGE.invokeExact(ptr(), maxAllowedSpace.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMaxAllowedSpaceUsage failed", t);
+			throw RocksDB.wrapInvokeFailure("setMaxAllowedSpaceUsage failed", t);
 		}
 	}
 
@@ -148,7 +148,7 @@ public final class SstFileManager extends NativeObject {
 			MH_SET_COMPACTION_BUFFER_SIZE.invokeExact(ptr(), compactionBufferSize.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setCompactionBufferSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setCompactionBufferSize failed", t);
 		}
 	}
 
@@ -159,7 +159,7 @@ public final class SstFileManager extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_IS_MAX_ALLOWED_SPACE_REACHED.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isMaxAllowedSpaceReached failed", t);
+			throw RocksDB.wrapInvokeFailure("isMaxAllowedSpaceReached failed", t);
 		}
 	}
 
@@ -171,7 +171,7 @@ public final class SstFileManager extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_IS_MAX_ALLOWED_SPACE_REACHED_INCLUDING_COMPACTIONS.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isMaxAllowedSpaceReachedIncludingCompactions failed", t);
+			throw RocksDB.wrapInvokeFailure("isMaxAllowedSpaceReachedIncludingCompactions failed", t);
 		}
 	}
 
@@ -182,7 +182,7 @@ public final class SstFileManager extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_TOTAL_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getTotalSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getTotalSize failed", t);
 		}
 	}
 
@@ -193,7 +193,7 @@ public final class SstFileManager extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_TOTAL_TRASH_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getTotalTrashSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getTotalTrashSize failed", t);
 		}
 	}
 
@@ -205,7 +205,7 @@ public final class SstFileManager extends NativeObject {
 			long rate = (long) MH_GET_DELETE_RATE_BYTES_PER_SECOND.invokeExact(ptr());
 			return rate < 0 ? null : MemorySize.ofBytes(rate);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getDeleteRateBytesPerSecond failed", t);
+			throw RocksDB.wrapInvokeFailure("getDeleteRateBytesPerSecond failed", t);
 		}
 	}
 
@@ -224,7 +224,7 @@ public final class SstFileManager extends NativeObject {
 			MH_SET_DELETE_RATE_BYTES_PER_SECOND.invokeExact(ptr(), deleteRate == null ? -1L : deleteRate.toBytes());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setDeleteRateBytesPerSecond failed", t);
+			throw RocksDB.wrapInvokeFailure("setDeleteRateBytesPerSecond failed", t);
 		}
 	}
 
@@ -237,7 +237,7 @@ public final class SstFileManager extends NativeObject {
 		try {
 			return Ratio.of((double) MH_GET_MAX_TRASH_DB_RATIO.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMaxTrashDbRatio failed", t);
+			throw RocksDB.wrapInvokeFailure("getMaxTrashDbRatio failed", t);
 		}
 	}
 
@@ -252,7 +252,7 @@ public final class SstFileManager extends NativeObject {
 			MH_SET_MAX_TRASH_DB_RATIO.invokeExact(ptr(), ratio.toDouble());
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMaxTrashDbRatio failed", t);
+			throw RocksDB.wrapInvokeFailure("setMaxTrashDbRatio failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileWriter.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileWriter.java
@@ -111,7 +111,7 @@ public final class SstFileWriter extends NativeObject {
 				MH_ENVOPTIONS_DESTROY.invokeExact(envOpts);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter create failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter create failed", t);
 		}
 	}
 
@@ -126,7 +126,7 @@ public final class SstFileWriter extends NativeObject {
 			MH_OPEN.invokeExact(ptr(), pathSeg, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter open failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter open failed", t);
 		}
 	}
 
@@ -145,7 +145,7 @@ public final class SstFileWriter extends NativeObject {
 					err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter put failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter put failed", t);
 		}
 	}
 
@@ -162,7 +162,7 @@ public final class SstFileWriter extends NativeObject {
 					err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter put failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter put failed", t);
 		}
 	}
 
@@ -179,7 +179,7 @@ public final class SstFileWriter extends NativeObject {
 					err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter put failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter put failed", t);
 		}
 	}
 
@@ -193,7 +193,7 @@ public final class SstFileWriter extends NativeObject {
 			MH_DELETE.invokeExact(ptr(), keyNative, (long) key.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter delete failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter delete failed", t);
 		}
 	}
 
@@ -206,7 +206,7 @@ public final class SstFileWriter extends NativeObject {
 			MH_DELETE.invokeExact(ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter delete failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter delete failed", t);
 		}
 	}
 
@@ -219,7 +219,7 @@ public final class SstFileWriter extends NativeObject {
 			MH_DELETE.invokeExact(ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter delete failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter delete failed", t);
 		}
 	}
 
@@ -239,7 +239,7 @@ public final class SstFileWriter extends NativeObject {
 					err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter deleteRange failed", t);
 		}
 	}
 
@@ -256,7 +256,7 @@ public final class SstFileWriter extends NativeObject {
 					err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter deleteRange failed", t);
 		}
 	}
 
@@ -273,7 +273,7 @@ public final class SstFileWriter extends NativeObject {
 					err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter deleteRange failed", t);
 		}
 	}
 
@@ -285,7 +285,7 @@ public final class SstFileWriter extends NativeObject {
 			MH_FINISH.invokeExact(ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter finish failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter finish failed", t);
 		}
 	}
 
@@ -298,7 +298,7 @@ public final class SstFileWriter extends NativeObject {
 			MH_FILE_SIZE.invokeExact(ptr(), sizeSeg);
 			return MemorySize.ofBytes(sizeSeg.get(ValueLayout.JAVA_LONG, 0));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("sstfilewriter fileSize failed", t);
+			throw RocksDB.wrapInvokeFailure("sstfilewriter fileSize failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/StatisticsHistogramData.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/StatisticsHistogramData.java
@@ -67,7 +67,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return new StatisticsHistogramData((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("histogram data create failed", t);
+			throw RocksDB.wrapInvokeFailure("histogram data create failed", t);
 		}
 	}
 
@@ -78,7 +78,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (double) MH_GET_MEDIAN.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMedian failed", t);
+			throw RocksDB.wrapInvokeFailure("getMedian failed", t);
 		}
 	}
 
@@ -89,7 +89,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (double) MH_GET_P95.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getP95 failed", t);
+			throw RocksDB.wrapInvokeFailure("getP95 failed", t);
 		}
 	}
 
@@ -100,7 +100,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (double) MH_GET_P99.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getP99 failed", t);
+			throw RocksDB.wrapInvokeFailure("getP99 failed", t);
 		}
 	}
 
@@ -111,7 +111,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (double) MH_GET_AVERAGE.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getAverage failed", t);
+			throw RocksDB.wrapInvokeFailure("getAverage failed", t);
 		}
 	}
 
@@ -122,7 +122,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (double) MH_GET_STD_DEV.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getStdDev failed", t);
+			throw RocksDB.wrapInvokeFailure("getStdDev failed", t);
 		}
 	}
 
@@ -133,7 +133,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (double) MH_GET_MAX.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMax failed", t);
+			throw RocksDB.wrapInvokeFailure("getMax failed", t);
 		}
 	}
 
@@ -144,7 +144,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (long) MH_GET_COUNT.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getCount failed", t);
+			throw RocksDB.wrapInvokeFailure("getCount failed", t);
 		}
 	}
 
@@ -155,7 +155,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (long) MH_GET_SUM.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getSum failed", t);
+			throw RocksDB.wrapInvokeFailure("getSum failed", t);
 		}
 	}
 
@@ -166,7 +166,7 @@ public final class StatisticsHistogramData extends NativeObject {
 		try {
 			return (double) MH_GET_MIN.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMin failed", t);
+			throw RocksDB.wrapInvokeFailure("getMin failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -149,7 +149,7 @@ public final class Transaction extends NativeObject {
 			MH_PUT.invokeExact(ptr(), k, (long) key.length, v, (long) value.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -165,7 +165,7 @@ public final class Transaction extends NativeObject {
 					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -179,7 +179,7 @@ public final class Transaction extends NativeObject {
 			MH_PUT.invokeExact(ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -193,7 +193,7 @@ public final class Transaction extends NativeObject {
 			MH_DELETE.invokeExact(ptr(), k, (long) key.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -206,7 +206,7 @@ public final class Transaction extends NativeObject {
 			MH_DELETE.invokeExact(ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -219,7 +219,7 @@ public final class Transaction extends NativeObject {
 			MH_DELETE.invokeExact(ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -252,7 +252,7 @@ public final class Transaction extends NativeObject {
 				return slice.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -277,7 +277,7 @@ public final class Transaction extends NativeObject {
 				return slice.copyInto(value, err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -302,7 +302,7 @@ public final class Transaction extends NativeObject {
 				return slice.copyInto(value, value.byteSize(), err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -327,7 +327,7 @@ public final class Transaction extends NativeObject {
 			try {
 				pin = (MemorySegment) MH_GET_PINNED.invokeExact(ptr(), readOptions.ptr(), key, key.byteSize(), err);
 			} catch (Throwable t) {
-				throw RocksDBException.wrap("get_pinned failed", t);
+				throw RocksDB.wrapInvokeFailure("get_pinned failed", t);
 			}
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(pin)) {
@@ -360,7 +360,7 @@ public final class Transaction extends NativeObject {
 				return slice.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -388,7 +388,7 @@ public final class Transaction extends NativeObject {
 				return slice.copyInto(value, err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -416,7 +416,7 @@ public final class Transaction extends NativeObject {
 				return slice.copyInto(value, value.byteSize(), err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -437,7 +437,7 @@ public final class Transaction extends NativeObject {
 					RocksDB.toNative(arena, value), (long) value.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -454,7 +454,7 @@ public final class Transaction extends NativeObject {
 					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -469,7 +469,7 @@ public final class Transaction extends NativeObject {
 			MH_PUT_CF.invokeExact(ptr(), cf.ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -484,7 +484,7 @@ public final class Transaction extends NativeObject {
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -499,7 +499,7 @@ public final class Transaction extends NativeObject {
 			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(), MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -513,7 +513,7 @@ public final class Transaction extends NativeObject {
 			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -541,7 +541,7 @@ public final class Transaction extends NativeObject {
 				return slice.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -568,7 +568,7 @@ public final class Transaction extends NativeObject {
 				return slice.copyInto(value, err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -594,7 +594,7 @@ public final class Transaction extends NativeObject {
 				return slice.copyInto(value, value.byteSize(), err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -618,7 +618,7 @@ public final class Transaction extends NativeObject {
 				pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(
 						ptr(), readOptions.ptr(), cf.ptr(), key, key.byteSize(), err);
 			} catch (Throwable t) {
-				throw RocksDBException.wrap("get_pinned failed", t);
+				throw RocksDB.wrapInvokeFailure("get_pinned failed", t);
 			}
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(pin)) {
@@ -652,7 +652,7 @@ public final class Transaction extends NativeObject {
 				return slice.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -683,7 +683,7 @@ public final class Transaction extends NativeObject {
 				return slice.copyInto(value, err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -713,7 +713,7 @@ public final class Transaction extends NativeObject {
 				return slice.copyInto(value, value.byteSize(), err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -728,7 +728,7 @@ public final class Transaction extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr());
 			return RocksIterator.create(iterPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("newIterator failed", t);
+			throw RocksDB.wrapInvokeFailure("newIterator failed", t);
 		}
 	}
 
@@ -747,7 +747,7 @@ public final class Transaction extends NativeObject {
 			MemorySegment snapPtr = (MemorySegment) MH_GET_SNAPSHOT.invokeExact(ptr());
 			return new Snapshot(snapPtr); // released via rocksdb_free
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getSnapshot failed", t);
+			throw RocksDB.wrapInvokeFailure("getSnapshot failed", t);
 		}
 	}
 
@@ -762,7 +762,7 @@ public final class Transaction extends NativeObject {
 			MH_COMMIT.invokeExact(ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -773,7 +773,7 @@ public final class Transaction extends NativeObject {
 			MH_ROLLBACK.invokeExact(ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -782,7 +782,7 @@ public final class Transaction extends NativeObject {
 		try {
 			MH_SET_SAVEPOINT.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("transaction setSavePoint failed", t);
+			throw RocksDB.wrapInvokeFailure("transaction setSavePoint failed", t);
 		}
 	}
 
@@ -793,7 +793,7 @@ public final class Transaction extends NativeObject {
 			MH_ROLLBACK_TO_SAVEPOINT.invokeExact(ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -174,7 +174,7 @@ public final class TransactionDB extends NativeObject {
 			MH_FLUSH.invokeExact(ptr(), flushOptions.ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flush failed", t);
+			throw RocksDB.wrapInvokeFailure("flush failed", t);
 		}
 	}
 
@@ -187,7 +187,7 @@ public final class TransactionDB extends NativeObject {
 			MH_FLUSH_WAL.invokeExact(ptr(), RocksDB.toByte(sync), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flushWal failed", t);
+			throw RocksDB.wrapInvokeFailure("flushWal failed", t);
 		}
 	}
 
@@ -204,7 +204,7 @@ public final class TransactionDB extends NativeObject {
 			MemorySegment snapPtr = (MemorySegment) MH_CREATE_SNAPSHOT.invokeExact(ptr());
 			return new Snapshot(ptr(), snapPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getSnapshot failed", t);
+			throw RocksDB.wrapInvokeFailure("getSnapshot failed", t);
 		}
 	}
 
@@ -234,7 +234,7 @@ public final class TransactionDB extends NativeObject {
 					ptr(), writeOptions.ptr(), txnOptions.ptr(), MemorySegment.NULL);
 			return new Transaction(txnPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("beginTransaction failed", t);
+			throw RocksDB.wrapInvokeFailure("beginTransaction failed", t);
 		}
 	}
 
@@ -254,7 +254,7 @@ public final class TransactionDB extends NativeObject {
 			MH_PUT.invokeExact(ptr(), writeOpts.ptr(), k, (long) key.length, v, (long) value.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -271,7 +271,7 @@ public final class TransactionDB extends NativeObject {
 					err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -285,7 +285,7 @@ public final class TransactionDB extends NativeObject {
 			MH_PUT.invokeExact(ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -309,7 +309,7 @@ public final class TransactionDB extends NativeObject {
 				return slice.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("Native call failed", t);
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
 		}
 	}
 
@@ -332,7 +332,7 @@ public final class TransactionDB extends NativeObject {
 				return slice.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -357,7 +357,7 @@ public final class TransactionDB extends NativeObject {
 				return slice.copyInto(value, err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -381,7 +381,7 @@ public final class TransactionDB extends NativeObject {
 				return slice.copyInto(value, value.byteSize(), err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -405,7 +405,7 @@ public final class TransactionDB extends NativeObject {
 			try {
 				pin = (MemorySegment) MH_GET_PINNED.invokeExact(ptr(), readOpts.ptr(), key, key.byteSize(), err);
 			} catch (Throwable t) {
-				throw RocksDBException.wrap("get_pinned failed", t);
+				throw RocksDB.wrapInvokeFailure("get_pinned failed", t);
 			}
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(pin)) {
@@ -431,7 +431,7 @@ public final class TransactionDB extends NativeObject {
 			MemorySegment result = (MemorySegment) MH_PROPERTY_VALUE.invokeExact(ptr(), propSeg);
 			return RocksDB.toOptionalString(result);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getProperty failed", t);
+			throw RocksDB.wrapInvokeFailure("getProperty failed", t);
 		}
 	}
 
@@ -449,7 +449,7 @@ public final class TransactionDB extends NativeObject {
 			}
 			return OptionalLong.of(out.get(ValueLayout.JAVA_LONG, 0));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getLongProperty failed", t);
+			throw RocksDB.wrapInvokeFailure("getLongProperty failed", t);
 		}
 	}
 
@@ -463,7 +463,7 @@ public final class TransactionDB extends NativeObject {
 			MH_DELETE.invokeExact(ptr(), writeOpts.ptr(), k, (long) key.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -477,7 +477,7 @@ public final class TransactionDB extends NativeObject {
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -490,7 +490,7 @@ public final class TransactionDB extends NativeObject {
 			MH_DELETE.invokeExact(ptr(), writeOpts.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -521,7 +521,7 @@ public final class TransactionDB extends NativeObject {
 			RocksDB.checkError(err);
 			return ColumnFamilyHandle.wrap(handle);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("createColumnFamily failed", t);
+			throw RocksDB.wrapInvokeFailure("createColumnFamily failed", t);
 		} finally {
 			for (Options o : tempOptions) {
 				o.close();
@@ -553,7 +553,7 @@ public final class TransactionDB extends NativeObject {
 					RocksDB.toNative(arena, value), (long) value.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -570,7 +570,7 @@ public final class TransactionDB extends NativeObject {
 					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -586,7 +586,7 @@ public final class TransactionDB extends NativeObject {
 					key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("put failed", t);
+			throw RocksDB.wrapInvokeFailure("put failed", t);
 		}
 	}
 
@@ -623,7 +623,7 @@ public final class TransactionDB extends NativeObject {
 				return slice.toByteArray(err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -649,7 +649,7 @@ public final class TransactionDB extends NativeObject {
 				return slice.copyInto(value, err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -674,7 +674,7 @@ public final class TransactionDB extends NativeObject {
 				return slice.copyInto(value, value.byteSize(), err);
 			}
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("get failed", t);
+			throw RocksDB.wrapInvokeFailure("get failed", t);
 		}
 	}
 
@@ -694,7 +694,7 @@ public final class TransactionDB extends NativeObject {
 			try {
 				pin = (MemorySegment) MH_GET_PINNED_CF.invokeExact(ptr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			} catch (Throwable t) {
-				throw RocksDBException.wrap("get_pinned failed", t);
+				throw RocksDB.wrapInvokeFailure("get_pinned failed", t);
 			}
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(pin)) {
@@ -721,7 +721,7 @@ public final class TransactionDB extends NativeObject {
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -736,7 +736,7 @@ public final class TransactionDB extends NativeObject {
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -750,7 +750,7 @@ public final class TransactionDB extends NativeObject {
 			MH_DELETE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("delete failed", t);
+			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
@@ -768,7 +768,7 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOpts.ptr(), cf.ptr());
 			return RocksIterator.create(iterPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("newIterator failed", t);
+			throw RocksDB.wrapInvokeFailure("newIterator failed", t);
 		}
 	}
 
@@ -783,7 +783,7 @@ public final class TransactionDB extends NativeObject {
 					ptr(), readOptions.ptr(), cf.ptr());
 			return RocksIterator.create(iterPtr);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("newIterator failed", t);
+			throw RocksDB.wrapInvokeFailure("newIterator failed", t);
 		}
 	}
 
@@ -801,7 +801,7 @@ public final class TransactionDB extends NativeObject {
 			MH_FLUSH_CF.invokeExact(ptr(), flushOptions.ptr(), cf.ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("flush failed", t);
+			throw RocksDB.wrapInvokeFailure("flush failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDBOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDBOptions.java
@@ -171,7 +171,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return new TransactionDBOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("transactiondb options create failed", t);
+			throw RocksDB.wrapInvokeFailure("transactiondb options create failed", t);
 		}
 	}
 
@@ -183,7 +183,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_MAX_NUM_LOCKS.invokeExact(ptr(), maxNumLocks);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMaxNumLocks failed", t);
+			throw RocksDB.wrapInvokeFailure("setMaxNumLocks failed", t);
 		}
 		return this;
 	}
@@ -195,7 +195,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return (long) MH_GET_MAX_NUM_LOCKS.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMaxNumLocks failed", t);
+			throw RocksDB.wrapInvokeFailure("getMaxNumLocks failed", t);
 		}
 	}
 
@@ -207,7 +207,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_MAX_NUM_DEADLOCKS.invokeExact(ptr(), maxNumDeadlocks);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMaxNumDeadlocks failed", t);
+			throw RocksDB.wrapInvokeFailure("setMaxNumDeadlocks failed", t);
 		}
 		return this;
 	}
@@ -219,7 +219,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return (int) MH_GET_MAX_NUM_DEADLOCKS.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMaxNumDeadlocks failed", t);
+			throw RocksDB.wrapInvokeFailure("getMaxNumDeadlocks failed", t);
 		}
 	}
 
@@ -231,7 +231,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_NUM_STRIPES.invokeExact(ptr(), numStripes);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setNumStripes failed", t);
+			throw RocksDB.wrapInvokeFailure("setNumStripes failed", t);
 		}
 		return this;
 	}
@@ -243,7 +243,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return (long) MH_GET_NUM_STRIPES.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getNumStripes failed", t);
+			throw RocksDB.wrapInvokeFailure("getNumStripes failed", t);
 		}
 	}
 
@@ -258,7 +258,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_TRANSACTION_LOCK_TIMEOUT.invokeExact(ptr(), toMillisOrNoTimeout(transactionLockTimeout));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setTransactionLockTimeout failed", t);
+			throw RocksDB.wrapInvokeFailure("setTransactionLockTimeout failed", t);
 		}
 		return this;
 	}
@@ -270,7 +270,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return millisToDurationOrNull((long) MH_GET_TRANSACTION_LOCK_TIMEOUT.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getTransactionLockTimeout failed", t);
+			throw RocksDB.wrapInvokeFailure("getTransactionLockTimeout failed", t);
 		}
 	}
 
@@ -285,7 +285,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_DEFAULT_LOCK_TIMEOUT.invokeExact(ptr(), toMillisOrNoTimeout(defaultLockTimeout));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setDefaultLockTimeout failed", t);
+			throw RocksDB.wrapInvokeFailure("setDefaultLockTimeout failed", t);
 		}
 		return this;
 	}
@@ -297,7 +297,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return millisToDurationOrNull((long) MH_GET_DEFAULT_LOCK_TIMEOUT.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getDefaultLockTimeout failed", t);
+			throw RocksDB.wrapInvokeFailure("getDefaultLockTimeout failed", t);
 		}
 	}
 
@@ -334,7 +334,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_WRITE_POLICY.invokeExact(ptr(), writePolicy.getValue());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setWritePolicy failed", t);
+			throw RocksDB.wrapInvokeFailure("setWritePolicy failed", t);
 		}
 		return this;
 	}
@@ -347,7 +347,7 @@ public final class TransactionDBOptions extends NativeObject {
 			int value = (int) MH_GET_WRITE_POLICY.invokeExact(ptr());
 			return WritePolicy.fromValue(value);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getWritePolicy failed", t);
+			throw RocksDB.wrapInvokeFailure("getWritePolicy failed", t);
 		}
 	}
 
@@ -361,7 +361,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_ROLLBACK_MERGE_OPERANDS.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setRollbackMergeOperands failed", t);
+			throw RocksDB.wrapInvokeFailure("setRollbackMergeOperands failed", t);
 		}
 		return this;
 	}
@@ -373,7 +373,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_ROLLBACK_MERGE_OPERANDS.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getRollbackMergeOperands failed", t);
+			throw RocksDB.wrapInvokeFailure("getRollbackMergeOperands failed", t);
 		}
 	}
 
@@ -386,7 +386,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_USE_PER_KEY_POINT_LOCK_MGR.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setUsePerKeyPointLockMgr failed", t);
+			throw RocksDB.wrapInvokeFailure("setUsePerKeyPointLockMgr failed", t);
 		}
 		return this;
 	}
@@ -398,7 +398,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_USE_PER_KEY_POINT_LOCK_MGR.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getUsePerKeyPointLockMgr failed", t);
+			throw RocksDB.wrapInvokeFailure("getUsePerKeyPointLockMgr failed", t);
 		}
 	}
 
@@ -412,7 +412,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_SKIP_CONCURRENCY_CONTROL.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setSkipConcurrencyControl failed", t);
+			throw RocksDB.wrapInvokeFailure("setSkipConcurrencyControl failed", t);
 		}
 		return this;
 	}
@@ -424,7 +424,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_SKIP_CONCURRENCY_CONTROL.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getSkipConcurrencyControl failed", t);
+			throw RocksDB.wrapInvokeFailure("getSkipConcurrencyControl failed", t);
 		}
 	}
 
@@ -440,7 +440,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_DEFAULT_WRITE_BATCH_FLUSH_THRESHOLD.invokeExact(ptr(), defaultWriteBatchFlushThreshold.toBytes());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setDefaultWriteBatchFlushThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("setDefaultWriteBatchFlushThreshold failed", t);
 		}
 		return this;
 	}
@@ -452,7 +452,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_DEFAULT_WRITE_BATCH_FLUSH_THRESHOLD.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getDefaultWriteBatchFlushThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("getDefaultWriteBatchFlushThreshold failed", t);
 		}
 	}
 
@@ -465,7 +465,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_ENABLE_UDT_VALIDATION.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setEnableUdtValidation failed", t);
+			throw RocksDB.wrapInvokeFailure("setEnableUdtValidation failed", t);
 		}
 		return this;
 	}
@@ -477,7 +477,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_ENABLE_UDT_VALIDATION.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getEnableUdtValidation failed", t);
+			throw RocksDB.wrapInvokeFailure("getEnableUdtValidation failed", t);
 		}
 	}
 
@@ -492,7 +492,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			MH_SET_TXN_COMMIT_BYPASS_MEMTABLE_THRESHOLD.invokeExact(ptr(), txnCommitBypassMemtableThreshold);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setTxnCommitBypassMemtableThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("setTxnCommitBypassMemtableThreshold failed", t);
 		}
 		return this;
 	}
@@ -504,7 +504,7 @@ public final class TransactionDBOptions extends NativeObject {
 		try {
 			return (int) MH_GET_TXN_COMMIT_BYPASS_MEMTABLE_THRESHOLD.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getTxnCommitBypassMemtableThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("getTxnCommitBypassMemtableThreshold failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionOptions.java
@@ -200,7 +200,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return new TransactionOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("transaction options create failed", t);
+			throw RocksDB.wrapInvokeFailure("transaction options create failed", t);
 		}
 	}
 
@@ -213,7 +213,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_SET_SNAPSHOT.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setSetSnapshot failed", t);
+			throw RocksDB.wrapInvokeFailure("setSetSnapshot failed", t);
 		}
 		return this;
 	}
@@ -225,7 +225,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_SET_SNAPSHOT.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getSetSnapshot failed", t);
+			throw RocksDB.wrapInvokeFailure("getSetSnapshot failed", t);
 		}
 	}
 
@@ -238,7 +238,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_DEADLOCK_DETECT.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setDeadlockDetect failed", t);
+			throw RocksDB.wrapInvokeFailure("setDeadlockDetect failed", t);
 		}
 		return this;
 	}
@@ -250,7 +250,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_DEADLOCK_DETECT.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getDeadlockDetect failed", t);
+			throw RocksDB.wrapInvokeFailure("getDeadlockDetect failed", t);
 		}
 	}
 
@@ -264,7 +264,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_USE_ONLY_THE_LAST_COMMIT_TIME_BATCH_FOR_RECOVERY.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setUseOnlyTheLastCommitTimeBatchForRecovery failed", t);
+			throw RocksDB.wrapInvokeFailure("setUseOnlyTheLastCommitTimeBatchForRecovery failed", t);
 		}
 		return this;
 	}
@@ -276,7 +276,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_USE_ONLY_THE_LAST_COMMIT_TIME_BATCH_FOR_RECOVERY.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getUseOnlyTheLastCommitTimeBatchForRecovery failed", t);
+			throw RocksDB.wrapInvokeFailure("getUseOnlyTheLastCommitTimeBatchForRecovery failed", t);
 		}
 	}
 
@@ -292,7 +292,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_LOCK_TIMEOUT.invokeExact(ptr(), toMillisOrNoTimeout(lockTimeout));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setLockTimeout failed", t);
+			throw RocksDB.wrapInvokeFailure("setLockTimeout failed", t);
 		}
 		return this;
 	}
@@ -304,7 +304,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return millisToDurationOrNull((long) MH_GET_LOCK_TIMEOUT.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getLockTimeout failed", t);
+			throw RocksDB.wrapInvokeFailure("getLockTimeout failed", t);
 		}
 	}
 
@@ -325,7 +325,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_DEADLOCK_TIMEOUT_US.invokeExact(ptr(), deadlockTimeoutUs.toNanos() / 1_000L);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setDeadlockTimeoutUs failed", t);
+			throw RocksDB.wrapInvokeFailure("setDeadlockTimeoutUs failed", t);
 		}
 		return this;
 	}
@@ -338,7 +338,7 @@ public final class TransactionOptions extends NativeObject {
 			long micros = (long) MH_GET_DEADLOCK_TIMEOUT_US.invokeExact(ptr());
 			return Duration.ofNanos(micros * 1_000L);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getDeadlockTimeoutUs failed", t);
+			throw RocksDB.wrapInvokeFailure("getDeadlockTimeoutUs failed", t);
 		}
 	}
 
@@ -353,7 +353,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_EXPIRATION.invokeExact(ptr(), toMillisOrNoTimeout(expiration));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setExpiration failed", t);
+			throw RocksDB.wrapInvokeFailure("setExpiration failed", t);
 		}
 		return this;
 	}
@@ -365,7 +365,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return millisToDurationOrNull((long) MH_GET_EXPIRATION.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getExpiration failed", t);
+			throw RocksDB.wrapInvokeFailure("getExpiration failed", t);
 		}
 	}
 
@@ -402,7 +402,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_DEADLOCK_DETECT_DEPTH.invokeExact(ptr(), deadlockDetectDepth);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setDeadlockDetectDepth failed", t);
+			throw RocksDB.wrapInvokeFailure("setDeadlockDetectDepth failed", t);
 		}
 		return this;
 	}
@@ -414,7 +414,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return (long) MH_GET_DEADLOCK_DETECT_DEPTH.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getDeadlockDetectDepth failed", t);
+			throw RocksDB.wrapInvokeFailure("getDeadlockDetectDepth failed", t);
 		}
 	}
 
@@ -427,7 +427,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_MAX_WRITE_BATCH_SIZE.invokeExact(ptr(), maxWriteBatchSize.toBytes());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMaxWriteBatchSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setMaxWriteBatchSize failed", t);
 		}
 		return this;
 	}
@@ -439,7 +439,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_MAX_WRITE_BATCH_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getMaxWriteBatchSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getMaxWriteBatchSize failed", t);
 		}
 	}
 
@@ -452,7 +452,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_SKIP_CONCURRENCY_CONTROL.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setSkipConcurrencyControl failed", t);
+			throw RocksDB.wrapInvokeFailure("setSkipConcurrencyControl failed", t);
 		}
 		return this;
 	}
@@ -464,7 +464,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_SKIP_CONCURRENCY_CONTROL.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getSkipConcurrencyControl failed", t);
+			throw RocksDB.wrapInvokeFailure("getSkipConcurrencyControl failed", t);
 		}
 	}
 
@@ -478,7 +478,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_SKIP_PREPARE.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setSkipPrepare failed", t);
+			throw RocksDB.wrapInvokeFailure("setSkipPrepare failed", t);
 		}
 		return this;
 	}
@@ -490,7 +490,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_SKIP_PREPARE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getSkipPrepare failed", t);
+			throw RocksDB.wrapInvokeFailure("getSkipPrepare failed", t);
 		}
 	}
 
@@ -510,7 +510,7 @@ public final class TransactionOptions extends NativeObject {
 			MH_SET_WRITE_BATCH_FLUSH_THRESHOLD.invokeExact(ptr(),
 					writeBatchFlushThreshold == null ? -1L : writeBatchFlushThreshold.toBytes());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setWriteBatchFlushThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("setWriteBatchFlushThreshold failed", t);
 		}
 		return this;
 	}
@@ -524,7 +524,7 @@ public final class TransactionOptions extends NativeObject {
 			long threshold = (long) MH_GET_WRITE_BATCH_FLUSH_THRESHOLD.invokeExact(ptr());
 			return threshold < 0 ? null : MemorySize.ofBytes(threshold);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getWriteBatchFlushThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("getWriteBatchFlushThreshold failed", t);
 		}
 	}
 
@@ -537,7 +537,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_WRITE_BATCH_TRACK_TIMESTAMP_SIZE.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setWriteBatchTrackTimestampSize failed", t);
+			throw RocksDB.wrapInvokeFailure("setWriteBatchTrackTimestampSize failed", t);
 		}
 		return this;
 	}
@@ -549,7 +549,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_WRITE_BATCH_TRACK_TIMESTAMP_SIZE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getWriteBatchTrackTimestampSize failed", t);
+			throw RocksDB.wrapInvokeFailure("getWriteBatchTrackTimestampSize failed", t);
 		}
 	}
 
@@ -562,7 +562,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_COMMIT_BYPASS_MEMTABLE.invokeExact(ptr(), RocksDB.toByte(value));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setCommitBypassMemtable failed", t);
+			throw RocksDB.wrapInvokeFailure("setCommitBypassMemtable failed", t);
 		}
 		return this;
 	}
@@ -574,7 +574,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_COMMIT_BYPASS_MEMTABLE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getCommitBypassMemtable failed", t);
+			throw RocksDB.wrapInvokeFailure("getCommitBypassMemtable failed", t);
 		}
 	}
 
@@ -587,7 +587,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_LARGE_TXN_COMMIT_OPTIMIZE_THRESHOLD.invokeExact(ptr(), largeTxnCommitOptimizeThreshold);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setLargeTxnCommitOptimizeThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("setLargeTxnCommitOptimizeThreshold failed", t);
 		}
 		return this;
 	}
@@ -599,7 +599,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return (int) MH_GET_LARGE_TXN_COMMIT_OPTIMIZE_THRESHOLD.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getLargeTxnCommitOptimizeThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("getLargeTxnCommitOptimizeThreshold failed", t);
 		}
 	}
 
@@ -614,7 +614,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			MH_SET_LARGE_TXN_COMMIT_OPTIMIZE_BYTE_THRESHOLD.invokeExact(ptr(), largeTxnCommitOptimizeByteThreshold.toBytes());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setLargeTxnCommitOptimizeByteThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("setLargeTxnCommitOptimizeByteThreshold failed", t);
 		}
 		return this;
 	}
@@ -626,7 +626,7 @@ public final class TransactionOptions extends NativeObject {
 		try {
 			return MemorySize.ofBytes((long) MH_GET_LARGE_TXN_COMMIT_OPTIMIZE_BYTE_THRESHOLD.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getLargeTxnCommitOptimizeByteThreshold failed", t);
+			throw RocksDB.wrapInvokeFailure("getLargeTxnCommitOptimizeByteThreshold failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WaitForCompactOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WaitForCompactOptions.java
@@ -81,7 +81,7 @@ public final class WaitForCompactOptions extends NativeObject {
 		try {
 			return new WaitForCompactOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("WaitForCompactOptions create failed", t);
+			throw RocksDB.wrapInvokeFailure("WaitForCompactOptions create failed", t);
 		}
 	}
 
@@ -96,7 +96,7 @@ public final class WaitForCompactOptions extends NativeObject {
 			MH_SET_ABORT_ON_PAUSE.invokeExact(ptr(), RocksDB.toByte(value));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setAbortOnPause failed", t);
+			throw RocksDB.wrapInvokeFailure("setAbortOnPause failed", t);
 		}
 	}
 
@@ -107,7 +107,7 @@ public final class WaitForCompactOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_ABORT_ON_PAUSE.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isAbortOnPause failed", t);
+			throw RocksDB.wrapInvokeFailure("isAbortOnPause failed", t);
 		}
 	}
 
@@ -121,7 +121,7 @@ public final class WaitForCompactOptions extends NativeObject {
 			MH_SET_FLUSH.invokeExact(ptr(), RocksDB.toByte(value));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setFlush failed", t);
+			throw RocksDB.wrapInvokeFailure("setFlush failed", t);
 		}
 	}
 
@@ -132,7 +132,7 @@ public final class WaitForCompactOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_FLUSH.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isFlush failed", t);
+			throw RocksDB.wrapInvokeFailure("isFlush failed", t);
 		}
 	}
 
@@ -146,7 +146,7 @@ public final class WaitForCompactOptions extends NativeObject {
 			MH_SET_CLOSE_DB.invokeExact(ptr(), RocksDB.toByte(value));
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setCloseDb failed", t);
+			throw RocksDB.wrapInvokeFailure("setCloseDb failed", t);
 		}
 	}
 
@@ -157,7 +157,7 @@ public final class WaitForCompactOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_CLOSE_DB.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isCloseDb failed", t);
+			throw RocksDB.wrapInvokeFailure("isCloseDb failed", t);
 		}
 	}
 
@@ -171,7 +171,7 @@ public final class WaitForCompactOptions extends NativeObject {
 			MH_SET_TIMEOUT.invokeExact(ptr(), timeout.toNanos() / 1_000L);
 			return this;
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setTimeout failed", t);
+			throw RocksDB.wrapInvokeFailure("setTimeout failed", t);
 		}
 	}
 
@@ -183,7 +183,7 @@ public final class WaitForCompactOptions extends NativeObject {
 			long micros = (long) MH_GET_TIMEOUT.invokeExact(ptr());
 			return Duration.ofNanos(micros * 1000L);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getTimeout failed", t);
+			throw RocksDB.wrapInvokeFailure("getTimeout failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WalIterator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WalIterator.java
@@ -72,7 +72,7 @@ public final class WalIterator extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_VALID.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("wal_iter_valid failed", t);
+			throw RocksDB.wrapInvokeFailure("wal_iter_valid failed", t);
 		}
 	}
 
@@ -81,7 +81,7 @@ public final class WalIterator extends NativeObject {
 		try {
 			MH_NEXT.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("wal_iter_next failed", t);
+			throw RocksDB.wrapInvokeFailure("wal_iter_next failed", t);
 		}
 	}
 
@@ -95,7 +95,7 @@ public final class WalIterator extends NativeObject {
 			MH_STATUS.invokeExact(ptr(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("wal_iter_status failed", t);
+			throw RocksDB.wrapInvokeFailure("wal_iter_status failed", t);
 		}
 	}
 
@@ -111,7 +111,7 @@ public final class WalIterator extends NativeObject {
 			long seq = seqHolder.get(ValueLayout.JAVA_LONG, 0);
 			return new WalBatchResult(SequenceNumber.of(seq), WriteBatch.wrap(batchPtr));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("wal_iter_get_batch failed", t);
+			throw RocksDB.wrapInvokeFailure("wal_iter_get_batch failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WriteBatch.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WriteBatch.java
@@ -94,7 +94,7 @@ public final class WriteBatch extends NativeObject {
 		try {
 			return new WriteBatch((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch create failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch create failed", t);
 		}
 	}
 
@@ -116,7 +116,7 @@ public final class WriteBatch extends NativeObject {
 			MemorySegment v = RocksDB.toNative(arena, value);
 			MH_PUT.invokeExact(ptr(), k, (long) key.length, v, (long) value.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch put failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch put failed", t);
 		}
 	}
 
@@ -130,7 +130,7 @@ public final class WriteBatch extends NativeObject {
 			MemorySegment v = RocksDB.toNative(arena, value);
 			MH_PUT.invokeExact(ptr(), k, (long) key.length, v, (long) value.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch put failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch put failed", t);
 		}
 	}
 
@@ -144,7 +144,7 @@ public final class WriteBatch extends NativeObject {
 					MemorySegment.ofBuffer(key), (long) key.remaining(),
 					MemorySegment.ofBuffer(value), (long) value.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch put failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch put failed", t);
 		}
 	}
 
@@ -156,7 +156,7 @@ public final class WriteBatch extends NativeObject {
 		try {
 			MH_PUT.invokeExact(ptr(), key, key.byteSize(), value, value.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch put failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch put failed", t);
 		}
 	}
 
@@ -168,7 +168,7 @@ public final class WriteBatch extends NativeObject {
 			MemorySegment k = RocksDB.toNative(arena, key);
 			MH_DELETE.invokeExact(ptr(), k, (long) key.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch delete failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch delete failed", t);
 		}
 	}
 
@@ -179,7 +179,7 @@ public final class WriteBatch extends NativeObject {
 		try {
 			MH_DELETE.invokeExact(ptr(), MemorySegment.ofBuffer(key), (long) key.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch delete failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch delete failed", t);
 		}
 	}
 
@@ -190,7 +190,7 @@ public final class WriteBatch extends NativeObject {
 		try {
 			MH_DELETE.invokeExact(ptr(), key, key.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch delete failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch delete failed", t);
 		}
 	}
 
@@ -204,7 +204,7 @@ public final class WriteBatch extends NativeObject {
 					RocksDB.toNative(arena, startKey), (long) startKey.length,
 					RocksDB.toNative(arena, endKey), (long) endKey.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch deleteRange failed", t);
 		}
 	}
 
@@ -218,7 +218,7 @@ public final class WriteBatch extends NativeObject {
 					MemorySegment.ofBuffer(startKey), (long) startKey.remaining(),
 					MemorySegment.ofBuffer(endKey), (long) endKey.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch deleteRange failed", t);
 		}
 	}
 
@@ -232,7 +232,7 @@ public final class WriteBatch extends NativeObject {
 					startKey, startKey.byteSize(),
 					endKey, endKey.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch deleteRange failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch deleteRange failed", t);
 		}
 	}
 
@@ -251,7 +251,7 @@ public final class WriteBatch extends NativeObject {
 					RocksDB.toNative(arena, key), (long) key.length,
 					RocksDB.toNative(arena, value), (long) value.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch put_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch put_cf failed", t);
 		}
 	}
 
@@ -266,7 +266,7 @@ public final class WriteBatch extends NativeObject {
 					MemorySegment.ofBuffer(key), (long) key.remaining(),
 					MemorySegment.ofBuffer(value), (long) value.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch put_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch put_cf failed", t);
 		}
 	}
 
@@ -280,7 +280,7 @@ public final class WriteBatch extends NativeObject {
 			MH_PUT_CF.invokeExact(ptr(), cf.ptr(),
 					key, key.byteSize(), value, value.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch put_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch put_cf failed", t);
 		}
 	}
 
@@ -293,7 +293,7 @@ public final class WriteBatch extends NativeObject {
 			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(),
 					RocksDB.toNative(arena, key), (long) key.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch delete_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch delete_cf failed", t);
 		}
 	}
 
@@ -306,7 +306,7 @@ public final class WriteBatch extends NativeObject {
 			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch delete_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch delete_cf failed", t);
 		}
 	}
 
@@ -318,7 +318,7 @@ public final class WriteBatch extends NativeObject {
 		try {
 			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(), key, key.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch delete_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch delete_cf failed", t);
 		}
 	}
 
@@ -333,7 +333,7 @@ public final class WriteBatch extends NativeObject {
 					RocksDB.toNative(arena, startKey), (long) startKey.length,
 					RocksDB.toNative(arena, endKey), (long) endKey.length);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch deleteRange_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch deleteRange_cf failed", t);
 		}
 	}
 
@@ -348,7 +348,7 @@ public final class WriteBatch extends NativeObject {
 					MemorySegment.ofBuffer(startKey), (long) startKey.remaining(),
 					MemorySegment.ofBuffer(endKey), (long) endKey.remaining());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch deleteRange_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch deleteRange_cf failed", t);
 		}
 	}
 
@@ -362,7 +362,7 @@ public final class WriteBatch extends NativeObject {
 			MH_DELETE_RANGE_CF.invokeExact(ptr(), cf.ptr(),
 					startKey, startKey.byteSize(), endKey, endKey.byteSize());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch deleteRange_cf failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch deleteRange_cf failed", t);
 		}
 	}
 
@@ -371,7 +371,7 @@ public final class WriteBatch extends NativeObject {
 		try {
 			MH_CLEAR.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch clear failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch clear failed", t);
 		}
 	}
 
@@ -382,7 +382,7 @@ public final class WriteBatch extends NativeObject {
 		try {
 			return (int) MH_COUNT.invokeExact(ptr());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writebatch count failed", t);
+			throw RocksDB.wrapInvokeFailure("writebatch count failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WriteOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WriteOptions.java
@@ -116,7 +116,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			return new WriteOptions((MemorySegment) MH_CREATE.invokeExact());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("writeoptions create failed", t);
+			throw RocksDB.wrapInvokeFailure("writeoptions create failed", t);
 		}
 	}
 
@@ -129,7 +129,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			MH_SET_SYNC.invokeExact(ptr(), RocksDB.toByte(sync));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setSync failed", t);
+			throw RocksDB.wrapInvokeFailure("setSync failed", t);
 		}
 		return this;
 	}
@@ -141,7 +141,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_SYNC.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isSync failed", t);
+			throw RocksDB.wrapInvokeFailure("isSync failed", t);
 		}
 	}
 
@@ -154,7 +154,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			MH_DISABLE_WAL.invokeExact(ptr(), disableWal ? 1 : 0);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setDisableWal failed", t);
+			throw RocksDB.wrapInvokeFailure("setDisableWal failed", t);
 		}
 		return this;
 	}
@@ -166,7 +166,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_DISABLE_WAL.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isDisableWal failed", t);
+			throw RocksDB.wrapInvokeFailure("isDisableWal failed", t);
 		}
 	}
 
@@ -180,7 +180,7 @@ public final class WriteOptions extends NativeObject {
 			MH_SET_IGNORE_MISSING_COLUMN_FAMILIES.invokeExact(ptr(),
 					RocksDB.toByte(ignoreMissingColumnFamilies));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIgnoreMissingColumnFamilies failed", t);
+			throw RocksDB.wrapInvokeFailure("setIgnoreMissingColumnFamilies failed", t);
 		}
 		return this;
 	}
@@ -192,7 +192,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_IGNORE_MISSING_COLUMN_FAMILIES.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isIgnoreMissingColumnFamilies failed", t);
+			throw RocksDB.wrapInvokeFailure("isIgnoreMissingColumnFamilies failed", t);
 		}
 	}
 
@@ -205,7 +205,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			MH_SET_NO_SLOWDOWN.invokeExact(ptr(), RocksDB.toByte(noSlowdown));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setNoSlowdown failed", t);
+			throw RocksDB.wrapInvokeFailure("setNoSlowdown failed", t);
 		}
 		return this;
 	}
@@ -217,7 +217,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_NO_SLOWDOWN.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isNoSlowdown failed", t);
+			throw RocksDB.wrapInvokeFailure("isNoSlowdown failed", t);
 		}
 	}
 
@@ -230,7 +230,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			MH_SET_LOW_PRI.invokeExact(ptr(), RocksDB.toByte(lowPri));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setLowPri failed", t);
+			throw RocksDB.wrapInvokeFailure("setLowPri failed", t);
 		}
 		return this;
 	}
@@ -242,7 +242,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_LOW_PRI.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isLowPri failed", t);
+			throw RocksDB.wrapInvokeFailure("isLowPri failed", t);
 		}
 	}
 
@@ -256,7 +256,7 @@ public final class WriteOptions extends NativeObject {
 			MH_SET_MEMTABLE_INSERT_HINT_PER_BATCH.invokeExact(ptr(),
 					RocksDB.toByte(memtableInsertHintPerBatch));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setMemtableInsertHintPerBatch failed", t);
+			throw RocksDB.wrapInvokeFailure("setMemtableInsertHintPerBatch failed", t);
 		}
 		return this;
 	}
@@ -268,7 +268,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			return RocksDB.fromByte((byte) MH_GET_MEMTABLE_INSERT_HINT_PER_BATCH.invokeExact(ptr()));
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("isMemtableInsertHintPerBatch failed", t);
+			throw RocksDB.wrapInvokeFailure("isMemtableInsertHintPerBatch failed", t);
 		}
 	}
 
@@ -285,7 +285,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			MH_SET_RATE_LIMITER_PRIORITY.invokeExact(ptr(), rateLimiterPriority.getValue());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setRateLimiterPriority failed", t);
+			throw RocksDB.wrapInvokeFailure("setRateLimiterPriority failed", t);
 		}
 		return this;
 	}
@@ -298,7 +298,7 @@ public final class WriteOptions extends NativeObject {
 			int value = (int) MH_GET_RATE_LIMITER_PRIORITY.invokeExact(ptr());
 			return IOPriority.fromValue(value);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getRateLimiterPriority failed", t);
+			throw RocksDB.wrapInvokeFailure("getRateLimiterPriority failed", t);
 		}
 	}
 
@@ -311,7 +311,7 @@ public final class WriteOptions extends NativeObject {
 		try {
 			MH_SET_IO_ACTIVITY.invokeExact(ptr(), ioActivity.getValue());
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("setIoActivity failed", t);
+			throw RocksDB.wrapInvokeFailure("setIoActivity failed", t);
 		}
 		return this;
 	}
@@ -324,7 +324,7 @@ public final class WriteOptions extends NativeObject {
 			int value = (int) MH_GET_IO_ACTIVITY.invokeExact(ptr());
 			return IOActivity.fromValue(value);
 		} catch (Throwable t) {
-			throw RocksDBException.wrap("getIoActivity failed", t);
+			throw RocksDB.wrapInvokeFailure("getIoActivity failed", t);
 		}
 	}
 

--- a/docs/adr/0004-error-handling.md
+++ b/docs/adr/0004-error-handling.md
@@ -1,6 +1,6 @@
 # ADR 0004: Separating genuine RocksDB errors from FFM binding bugs
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-16
 - **Deciders:** project maintainer
 
@@ -34,60 +34,56 @@ including the `NullPointerException` `PinnableHandle#map` deliberately throws wh
 
 ## Decision
 
-*(Proposed — not yet implemented.)* Move the classification logic off `RocksDBException` entirely, and
-bake it into every downcall `MethodHandle` itself via `MethodHandles.catchException`, applied once,
-centrally, in `NativeLibrary.lookup(...)` — the single factory every `MH_` field already goes through
-— rather than repeated per call site or even per field:
+Move the wrap/rethrow decision off `RocksDBException` and onto `RocksDB`, as
+`RocksDB.wrapInvokeFailure(String, Throwable)` — alongside the other shared FFM plumbing already
+there (`errHolder`, `checkError`, `toNative`; see `CLAUDE.md`'s "Centralized Error Handling" section):
 
 ```java
-static MethodHandle lookup(String symbol, FunctionDescriptor fd, Linker.Option... options) {
-    MethodHandle raw = /* existing Linker.downcallHandle(...) lookup */;
-    MethodHandle thrower = MethodHandles.throwException(raw.type().returnType(), Throwable.class);
-    MethodHandle handler = MethodHandles.filterArguments(thrower, 0, MH_CLASSIFY);
-    return MethodHandles.catchException(raw, Throwable.class, handler);
-}
-
-// classify(t) returns t unchanged for the four binding-bug types, or a new
-// AssertionError wrapping t for anything else -- never a RocksDBException.
-private static Throwable classify(Throwable t) { ... }
-```
-
-`MethodHandles.throwException(returnType, Throwable.class)` builds a handle that always throws
-whatever `Throwable` it's given, declared to "return" any type — which is what lets one `classify`
-method compose with every `MH_` field regardless of that field's actual return type (`MemorySegment`,
-`long`, `boolean`, `void`, an enum, …), with no per-return-type handler needed.
-
-- `NullPointerException`, `IllegalStateException` (including `WrongThreadException`),
-  `WrongMethodTypeException`, and `ClassCastException` propagate **unwrapped, with their original
-  type preserved** — a caller who somehow sees `NullPointerException` from a misused API sees exactly
-  that, never a `RocksDBException` with an `NullPointerException` cause three lines down.
-- Anything else — which, per the analysis above, should never actually happen for a correctly
-  configured downcall handle — becomes an `AssertionError`, not a `RocksDBException`. `AssertionError`
-  signals "this should be impossible," distinct from both `RocksDBException` (real DB errors) and an
-  ordinary `RuntimeException` (which reads more like "expected, just unhandled").
-- `RocksDBException` becomes reserved exclusively for the `errHolder`/`checkError` path and is no
-  longer constructible from any `invokeExact` catch site at all; `RocksDBException.wrap(String,
-  Throwable)` is deleted outright.
-
-One important limit: `invokeExact`'s signature is `throws Throwable` at the *language* level
-regardless of what a given handle instance actually does at runtime, so javac still requires a
-`try`/`catch` (or a `throws Throwable` on the enclosing method) at every call site — this decision
-does not, and cannot, delete that syntactic wrapper. What it does remove is every call site's own
-*classification* logic and custom message: since `MH_GET_VALUE` (for example) has already classified
-and rethrown by the time an exception reaches the call site's `catch`, that block collapses to one
-fixed, uniform, effectively-unreachable line:
-
-```java
-try {
-    return (MemorySegment) MH_GET_VALUE.invokeExact(ptr(), vallenOut);
-} catch (Throwable t) {
-    throw new AssertionError(t); // unreachable: MH_GET_VALUE already classified via NativeLibrary.lookup
+static RuntimeException wrapInvokeFailure(String message, Throwable t) {
+    if (t instanceof RuntimeException e) {
+        throw e;
+    }
+    if (t instanceof IOException e) {
+        throw new UncheckedIOException(message, e);
+    }
+    throw new AssertionError(message, t);
 }
 ```
 
-Landing this touches exactly one method (`NativeLibrary.lookup`) plus every call site's `catch` body
-(mechanical, identical edit at each), rather than either the field-by-field or fully-manual sweep
-originally proposed here.
+- **Every `RuntimeException` propagates unwrapped, with its original type preserved** — this is one
+  check, not an enumerated list of the four binding-bug types originally proposed here, because
+  `checkError` typically runs *inside the same `try` block* as `invokeExact`, right after it (see
+  `getBytes` for the established shape), so the genuine `RocksDBException` it throws for a real
+  `errptr` error also reaches this method — and needs to pass through unchanged too, exactly like the
+  four binding-bug types. Missing this is a real bug the first implementation attempt hit: five
+  existing tests broke because their expected `RocksDBException` came back as an `AssertionError`
+  wrapping it, once the enumerated-type check stopped recognizing `RocksDBException` itself as
+  something to pass through. `RuntimeException` alone covers `NullPointerException`,
+  `IllegalStateException` (including `WrongThreadException`), `WrongMethodTypeException`,
+  `ClassCastException`, *and* `RocksDBException` — no enumeration needed, and no risk of a fifth case
+  being missed the same way in the future.
+- **An `IOException`** — not from `invokeExact` itself, which never throws a checked exception, but
+  possible from other code sharing the same `try` block (e.g. file access) — **becomes an
+  `UncheckedIOException`**, the standard JDK idiom for surfacing a checked I/O failure as unchecked.
+- **Anything else reaching this method** — which, per the analysis above, should never actually happen
+  for a correctly configured downcall handle — **becomes an `AssertionError`**, not a
+  `RocksDBException`. `AssertionError` signals "this should be impossible," distinct from both
+  `RocksDBException` (real DB errors) and an ordinary `RuntimeException` (which reads more like
+  "expected, just unhandled").
+- `RocksDBException` becomes reserved exclusively for the `errHolder`/`checkError` path — it has no
+  public constructor, and is no longer *constructed* from any `invokeExact` catch site (though a
+  `RocksDBException` already thrown by `checkError` still passes through, per the point above);
+  `RocksDBException.wrap(String, Throwable)` is deleted outright.
+
+Because every existing call site already funnels through one static method
+(`RocksDBException.wrap(...)`), landing this is a mechanical rename across the codebase
+(`RocksDBException.wrap(` → `RocksDB.wrapInvokeFailure(`), verified by a full compile and test run —
+not a redesign repeated at every site. `MethodHandles.catchException` (composing the classification
+into every downcall handle itself, in `NativeLibrary.lookup`, instead of at each call site) was tried
+first and rejected — see Alternatives — since `invokeExact`'s `throws Throwable` is a language-level
+constraint regardless of what a given handle instance does at runtime, so javac still requires a
+`try`/`catch` at every call site either way. Composing the handle bought no reduction in call-site
+boilerplate over a plain shared method, for real added complexity.
 
 ## Consequences
 
@@ -101,41 +97,43 @@ originally proposed here.
 - Caller-supplied callbacks (`Mapper`, `EventListener`-style hooks if added later) can safely throw
   without their exceptions being mistaken for native-call failures, as long as they sit outside the
   narrow `invokeExact`-only catch — the exact bug this ADR's motivating incident exposed.
-- The real decision logic lives in exactly one place (`NativeLibrary.lookup` plus `classify`), not
-  duplicated per field or per call site — every `MH_` field gets the behavior automatically the moment
-  it's constructed through the existing shared factory.
+- The real decision logic lives in exactly one place (`RocksDB.wrapInvokeFailure`), not duplicated at
+  every call site — even though every call site still *invokes* it, per the `invokeExact` constraint
+  below.
 
 ### Negative
 
-- Every call site's `catch` body still changes (to the fixed, uniform `AssertionError(t)` form) even
-  though it no longer does any real classification work — a smaller, more mechanical edit than a
-  full rethrow-clause sweep would have been, but still touches every file with an `invokeExact` call.
+- A large, mechanical diff across the whole codebase lands in one change (every
+  `RocksDBException.wrap(` becomes `RocksDB.wrapInvokeFailure(`), which needs the full test suite as
+  the verification story rather than per-site review.
 - `AssertionError` in a library's exception path is unusual for callers not expecting `Error`-hierarchy
-  types from a supposedly `RuntimeException`-only API surface — worth calling out prominently in
-  `RocksDBException`'s and `NativeLibrary.lookup`'s own Javadoc once implemented.
-- `MethodHandles.catchException`/`throwException`-composed handles are one more LambdaForm layer over
-  a raw downcall handle; expected to be negligible next to the native call itself, but not verified
-  against this project's own benchmarks yet — worth a before/after run once implemented.
+  types from a supposedly `RuntimeException`-only API surface — called out prominently in
+  `RocksDB.wrapInvokeFailure`'s own Javadoc.
+- Every call site keeps its own `try`/`catch (Throwable t)` — `invokeExact`'s `throws Throwable` is a
+  language-level constraint no amount of centralizing the *logic* removes (see Alternatives). What
+  moves is the classification, not the syntactic wrapper.
 
 ### Risks to manage
 
-- The classification logic (`classify` in `NativeLibrary`) is now load-bearing for every single native
-  call in the library — a bug there is a bug everywhere at once. Mitigated by it being a small, pure,
-  directly unit-testable function (`Throwable -> Throwable`), unlike the ~60+ scattered catch blocks
-  it replaces.
+- Every one of the ~60+ files with an `invokeExact` catch site needs the identical mechanical edit;
+  missing one leaves that site still wrapping binding bugs as `RocksDBException`, silently
+  reintroducing the exact problem this ADR exists to close. Mitigated by deleting the old
+  `RocksDBException.wrap(...)` outright once the sweep lands (rather than leaving both paths
+  available) — the compiler finds every straggler.
 - Any future caller-supplied callback added to the library (beyond `Mapper`) must be reviewed for the
   same widened-catch mistake `withPinned`/`withPinnedCf` made — this is a pattern to watch for in
-  review, not something the type system prevents by itself, since it happens inside a method body
-  `NativeLibrary.lookup`'s wrapping has no visibility into.
+  review, not something the type system prevents by itself.
 
 ## Alternatives considered
 
-- **Rename every call site to a shared `RocksDB.wrapInvokeFailure(String, Throwable)` helper**, doing
-  the classification at each `catch (Throwable t)` block instead of inside the `MethodHandle` itself:
-  same end behavior, and still centralizes the *logic* in one method, but leaves every call site
-  needing its own custom message string and doesn't get the "automatically applied to every `MH_`
-  field via the existing factory" property — a real mechanical sweep instead of a single-method change
-  plus a cosmetic catch-body cleanup.
+- **Compose the classification into every downcall `MethodHandle` itself**, via
+  `MethodHandles.catchException`/`throwException`/`filterArguments`, applied once in
+  `NativeLibrary.lookup(...)` rather than at each call site. Tried first; rejected once it became
+  clear it doesn't actually reduce call-site boilerplate: `invokeExact`'s `throws Throwable` still
+  forces a `try`/`catch` at every syntactic call site regardless of what the specific handle instance
+  does at runtime, so the catch body just becomes a different (still mandatory) fixed line — real
+  added complexity (a `classify` combinator wired through three `MethodHandles` factory methods) for
+  no reduction in the thing actually being optimized for.
 - **Touch every call site individually** with its own explicit rethrow clause before
   `catch (Throwable t)`, no shared helper at all: same end behavior, but ~60+ places to get right
   instead of one, with no benefit over centralizing given a single chokepoint already exists.
@@ -152,6 +150,4 @@ originally proposed here.
 ## References
 
 - [explanation.md#errors-are-always-loud](../explanation.md#errors-are-always-loud)
-- `RocksDBException.java`, `RocksDB.java` (`errHolder`/`checkError`/`toNative`), `NativeLibrary.java`
-  (`lookup`)
-- `java.lang.invoke.MethodHandles#catchException`, `#throwException`, `#filterArguments`
+- `RocksDBException.java`, `RocksDB.java` (`errHolder`/`checkError`/`toNative`/`wrapInvokeFailure`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,4 +24,4 @@ ADR is a point-in-time snapshot: context, the decision, and its known consequenc
 | [0001](0001-ffm-instead-of-jni.md) | FFM bindings over JNI                          | Accepted |
 | [0002](0002-why-zig.md)            | Build the native library with `zig cc`/`zig c++` | Accepted |
 | [0003](0003-ownership-model.md)    | `NativeObject`: `AutoCloseable`, idempotent close, ownership transfer | Accepted |
-| [0004](0004-error-handling.md)     | Separating genuine RocksDB errors from FFM binding bugs | Proposed |
+| [0004](0004-error-handling.md)     | Separating genuine RocksDB errors from FFM binding bugs | Accepted |

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -115,11 +115,16 @@ matrix is in [reference.md#db-types](reference.md#db-types).
 
 ## Errors are always loud
 
-See [ADR-0004](adr/0004-error-handling.md) (proposed) for an open question this section doesn't cover
-yet: separating genuine RocksDB errors from bugs in this library's own FFM plumbing.
+Every operation that can fail throws, unchecked. There is no `Status` object to inspect, no `-1`
+return, no error code a caller can forget to check.
 
-Every operation that can fail throws `RocksDBException`, unchecked. There is no `Status` object to
-inspect, no `-1` return, no error code a caller can forget to check.
+`RocksDBException` means exactly one thing: RocksDB itself reported an operational failure through
+its `errptr` out-parameter — corruption, an IO error, an invalid argument at the DB level. It is never
+thrown for a bug in this library's own FFM plumbing. A misused API surfaces as its own natural
+exception type instead (`NullPointerException`, `IllegalStateException`, …), and anything that should
+be structurally impossible for a correctly configured native call becomes an `AssertionError`. See
+[ADR-0004](adr/0004-error-handling.md) for the full reasoning — this split exists so that
+`catch (RocksDBException e)` is always meaningful, never a library bug wearing a "real error" costume.
 
 `null` survives in exactly one place: `byte[] get(byte[])` returns `null` for a missing key, because
 a miss is a normal outcome on the hot read path and boxing it in an `Optional` would allocate on

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -308,7 +308,7 @@ listing every existing column family, `default` included.
 | `BackupId`        | Backup identity (native `uint32`). `of(long)`, `toLong()`; `Comparable`                      |
 | `Ratio`           | Fraction in `[0.0, 1.0]`. `of(double)`, `toDouble()`, `ZERO`, `ONE`; immutable, `Comparable` |
 | `CopyResult`      | Sealed: `Copied()`, `NotEnoughCapacity(long required)`, `NotFound()`                         |
-| `RocksDBException`| Unchecked; thrown by every operation that can fail                                            |
+| `RocksDBException`| Unchecked; thrown for a genuine RocksDB-reported error (see [explanation.md#errors-are-always-loud](explanation.md#errors-are-always-loud)) |
 | `NativeObject`    | Base class of every native wrapper; `ptr()`, `close()` (idempotent), abstract `tryClose`      |
 
 `Path` is used for every filesystem argument; there is no `String` path overload anywhere.


### PR DESCRIPTION
## Summary
Implements [ADR 0004](docs/adr/0004-error-handling.md).

- `RocksDBException.wrap(String, Throwable)` is deleted; `RocksDBException` now has no public constructor and is only ever constructed by `RocksDB.checkError`, for a genuine `errptr`-reported error.
- Every `invokeExact` catch site now calls the new `RocksDB.wrapInvokeFailure(String, Throwable)`:
  - any `RuntimeException` propagates unwrapped, original type preserved — covers the FFM binding-bug types `invokeExact` itself can throw, *and* a genuine `RocksDBException` `checkError` already threw earlier in the same `try` block (an enumerated-type check that didn't also recognize `RocksDBException` broke 5 existing tests during development — see the ADR's Decision section for the story)
  - `IOException` becomes `UncheckedIOException`
  - anything else — which should never happen for a correctly configured downcall handle — becomes `AssertionError`
- `RocksDB.withPinned`/`withPinnedCf` collapse back to a single `try`-with-resources with one `catch` at the bottom: the narrower double-nested try/catch previously needed to protect the caller-supplied `Mapper`'s exceptions is no longer necessary, since `wrapInvokeFailure` now passes any `RuntimeException` through unwrapped regardless of source.
- Updates `CLAUDE.md`, `docs/explanation.md`, and `docs/reference.md` to document the new convention, and finalizes ADR 0004 as Accepted (including the `MethodHandles.catchException` alternative tried first and rejected — it doesn't reduce call-site boilerplate, since `invokeExact`'s `throws Throwable` is a language-level constraint regardless of what a given handle instance does at runtime).

## Test plan
- [x] `./mvnw test` — full suite green
- [x] `./mvnw verify -pl integration-tests -am` — integration tests green
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] Mechanical sweep verified by compilation: all 451 `RocksDBException.wrap(` call sites across 38 files renamed to `RocksDB.wrapInvokeFailure(`

🤖 Generated with [Claude Code](https://claude.com/claude-code)