### PR TITLE
RateLimiter refill period and BackupInfo.timestamp use domain types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **rocksdbffm** are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking:** `RateLimiter.create`/`createAutoTuned`/`createWithMode`'s refill period is now a
+  `Duration` instead of a raw `long` of microseconds; rejects `null` and negative values.
+
 ## [0.8] — 2026-08-16
 
 Hermetic ZSTD/LZ4 on all five platforms including Windows, local builds now cross-compile only the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking:** `RateLimiter.create`/`createAutoTuned`/`createWithMode`'s refill period is now a
   `Duration` instead of a raw `long` of microseconds; rejects `null` and negative values.
+- **Breaking:** `BackupInfo.timestamp` is now an `Instant` instead of a raw `long` Unix timestamp.
 
 ## [0.8] — 2026-08-16
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngine.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BackupEngine.java
@@ -6,6 +6,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -377,7 +378,7 @@ public final class BackupEngine extends NativeObject {
 			List<BackupInfo> result = new ArrayList<>(count);
 			for (int i = 0; i < count; i++) {
 				BackupId backupId = BackupId.fromNative((int) MH_INFO_BACKUP_ID.invokeExact(infoPtr, i));
-				long timestamp = (long) MH_INFO_TIMESTAMP.invokeExact(infoPtr, i);
+				Instant timestamp = Instant.ofEpochSecond((long) MH_INFO_TIMESTAMP.invokeExact(infoPtr, i));
 				MemorySize size = MemorySize.ofBytes((long) MH_INFO_SIZE.invokeExact(infoPtr, i));
 				long numberOfFiles = Integer.toUnsignedLong((int) MH_INFO_NUMBER_FILES.invokeExact(infoPtr, i));
 				result.add(new BackupInfo(backupId, timestamp, size, numberOfFiles));

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BackupInfo.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BackupInfo.java
@@ -1,5 +1,7 @@
 package io.github.dfa1.rocksdbffm;
 
+import java.time.Instant;
+
 /// Immutable snapshot of a single RocksDB backup entry.
 ///
 /// Instances are obtained from [BackupEngine#getBackupInfo()].
@@ -15,12 +17,12 @@ package io.github.dfa1.rocksdbffm;
 /// ```
 ///
 /// @param backupId unique identifier assigned by the engine
-/// @param timestamp Unix timestamp (seconds since epoch) when the backup was created
+/// @param timestamp point in time when the backup was created
 /// @param size total size of all files belonging to this backup
 /// @param numberOfFiles number of SST/WAL/MANIFEST files in this backup
 public record BackupInfo(
 		BackupId backupId,
-		long timestamp,
+		Instant timestamp,
 		MemorySize size,
 		long numberOfFiles
 ) {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RateLimiter.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RateLimiter.java
@@ -4,6 +4,8 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.time.Duration;
+import java.util.Objects;
 
 /// FFM wrapper for `rocksdb_ratelimiter_t`.
 ///
@@ -82,20 +84,29 @@ public final class RateLimiter extends NativeObject {
 	/// @param rateBytesPerSec maximum I/O rate in bytes per second
 	/// @return a new [RateLimiter]; caller must close it
 	public static RateLimiter create(MemorySize rateBytesPerSec) {
-		return create(rateBytesPerSec, 100_000L, 10);
+		return create(rateBytesPerSec, Duration.ofMillis(100), 10);
 	}
 
 	/// Creates a rate limiter limiting writes only.
 	///
-	/// @param rateBytesPerSec  maximum I/O rate in bytes per second
-	/// @param refillPeriodUs   refill interval in microseconds (default 100,000)
-	/// @param fairness         RateLimiter will allow at most 1 / fairness high-priority
-	///                         requests to wait when there are low-priority requests in flight (default 10)
+	/// RocksDB documents no special meaning for a negative refill period, so this does not
+	/// accept `null`.
+	///
+	/// @param rateBytesPerSec maximum I/O rate in bytes per second
+	/// @param refillPeriod    refill interval, at microsecond resolution (default 100 ms)
+	/// @param fairness        RateLimiter will allow at most 1 / fairness high-priority
+	///                        requests to wait when there are low-priority requests in flight (default 10)
 	/// @return a new [RateLimiter]; caller must close it
-	public static RateLimiter create(MemorySize rateBytesPerSec, long refillPeriodUs, int fairness) {
+	/// @throws NullPointerException     if `refillPeriod` is `null`
+	/// @throws IllegalArgumentException if `refillPeriod` is negative
+	public static RateLimiter create(MemorySize rateBytesPerSec, Duration refillPeriod, int fairness) {
+		Objects.requireNonNull(refillPeriod, "refillPeriod must not be null");
+		if (refillPeriod.isNegative()) {
+			throw new IllegalArgumentException("refillPeriod must not be negative: " + refillPeriod);
+		}
 		try {
 			MemorySegment ptr = (MemorySegment) MH_CREATE.invokeExact(
-					rateBytesPerSec.toBytes(), refillPeriodUs, fairness);
+					rateBytesPerSec.toBytes(), refillPeriod.toNanos() / 1_000L, fairness);
 			return new RateLimiter(ptr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("RateLimiter create failed", t);
@@ -105,14 +116,23 @@ public final class RateLimiter extends NativeObject {
 	/// Creates an auto-tuned rate limiter that automatically adjusts the rate to
 	/// achieve the target rate. Limits writes only.
 	///
-	/// @param rateBytesPerSec  target I/O rate in bytes per second
-	/// @param refillPeriodUs   refill interval in microseconds (default 100,000)
-	/// @param fairness         see [#create(MemorySize, long, int)] (default 10)
+	/// RocksDB documents no special meaning for a negative refill period, so this does not
+	/// accept `null`.
+	///
+	/// @param rateBytesPerSec target I/O rate in bytes per second
+	/// @param refillPeriod    refill interval, at microsecond resolution (default 100 ms)
+	/// @param fairness        see [#create(MemorySize, Duration, int)] (default 10)
 	/// @return a new auto-tuned [RateLimiter]; caller must close it
-	public static RateLimiter createAutoTuned(MemorySize rateBytesPerSec, long refillPeriodUs, int fairness) {
+	/// @throws NullPointerException     if `refillPeriod` is `null`
+	/// @throws IllegalArgumentException if `refillPeriod` is negative
+	public static RateLimiter createAutoTuned(MemorySize rateBytesPerSec, Duration refillPeriod, int fairness) {
+		Objects.requireNonNull(refillPeriod, "refillPeriod must not be null");
+		if (refillPeriod.isNegative()) {
+			throw new IllegalArgumentException("refillPeriod must not be negative: " + refillPeriod);
+		}
 		try {
 			MemorySegment ptr = (MemorySegment) MH_CREATE_AUTO_TUNED.invokeExact(
-					rateBytesPerSec.toBytes(), refillPeriodUs, fairness);
+					rateBytesPerSec.toBytes(), refillPeriod.toNanos() / 1_000L, fairness);
 			return new RateLimiter(ptr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("RateLimiter createAutoTuned failed", t);
@@ -125,22 +145,31 @@ public final class RateLimiter extends NativeObject {
 	/// @param rateBytesPerSec target I/O rate in bytes per second
 	/// @return a new auto-tuned [RateLimiter]; caller must close it
 	public static RateLimiter createAutoTuned(MemorySize rateBytesPerSec) {
-		return createAutoTuned(rateBytesPerSec, 100_000L, 10);
+		return createAutoTuned(rateBytesPerSec, Duration.ofMillis(100), 10);
 	}
 
 	/// Creates a rate limiter with explicit mode and auto-tuning flag.
 	///
-	/// @param rateBytesPerSec  maximum I/O rate in bytes per second
-	/// @param refillPeriodUs   refill interval in microseconds
-	/// @param fairness         see [#create(MemorySize, long, int)]
-	/// @param mode             which I/O types to rate-limit
-	/// @param autoTuned        whether to enable automatic rate adjustment
+	/// RocksDB documents no special meaning for a negative refill period, so this does not
+	/// accept `null`.
+	///
+	/// @param rateBytesPerSec maximum I/O rate in bytes per second
+	/// @param refillPeriod    refill interval, at microsecond resolution
+	/// @param fairness        see [#create(MemorySize, Duration, int)]
+	/// @param mode            which I/O types to rate-limit
+	/// @param autoTuned       whether to enable automatic rate adjustment
 	/// @return a new [RateLimiter]; caller must close it
-	public static RateLimiter createWithMode(MemorySize rateBytesPerSec, long refillPeriodUs,
+	/// @throws NullPointerException     if `refillPeriod` is `null`
+	/// @throws IllegalArgumentException if `refillPeriod` is negative
+	public static RateLimiter createWithMode(MemorySize rateBytesPerSec, Duration refillPeriod,
 			int fairness, Mode mode, boolean autoTuned) {
+		Objects.requireNonNull(refillPeriod, "refillPeriod must not be null");
+		if (refillPeriod.isNegative()) {
+			throw new IllegalArgumentException("refillPeriod must not be negative: " + refillPeriod);
+		}
 		try {
 			MemorySegment ptr = (MemorySegment) MH_CREATE_WITH_MODE.invokeExact(
-					rateBytesPerSec.toBytes(), refillPeriodUs, fairness,
+					rateBytesPerSec.toBytes(), refillPeriod.toNanos() / 1_000L, fairness,
 					mode.value, RocksDB.toByte(autoTuned));
 			return new RateLimiter(ptr);
 		} catch (Throwable t) {

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BackupInfoTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BackupInfoTest.java
@@ -2,6 +2,8 @@ package io.github.dfa1.rocksdbffm;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BackupInfoTest {
@@ -11,13 +13,14 @@ class BackupInfoTest {
 		// Given
 		var backupId = BackupId.of(3);
 		var size = MemorySize.ofMB(5);
+		var timestamp = Instant.ofEpochSecond(1_700_000_000L);
 
 		// When
-		var sut = new BackupInfo(backupId, 1_700_000_000L, size, 12L);
+		var sut = new BackupInfo(backupId, timestamp, size, 12L);
 
 		// Then
 		assertThat(sut.backupId()).isEqualTo(backupId);
-		assertThat(sut.timestamp()).isEqualTo(1_700_000_000L);
+		assertThat(sut.timestamp()).isEqualTo(timestamp);
 		assertThat(sut.size()).isEqualTo(size);
 		assertThat(sut.numberOfFiles()).isEqualTo(12L);
 	}
@@ -25,9 +28,10 @@ class BackupInfoTest {
 	@Test
 	void equals_isByValue() {
 		// Given
-		var a = new BackupInfo(BackupId.of(1), 100L, MemorySize.ofBytes(50), 2L);
-		var b = new BackupInfo(BackupId.of(1), 100L, MemorySize.ofBytes(50), 2L);
-		var c = new BackupInfo(BackupId.of(2), 100L, MemorySize.ofBytes(50), 2L);
+		var timestamp = Instant.ofEpochSecond(100L);
+		var a = new BackupInfo(BackupId.of(1), timestamp, MemorySize.ofBytes(50), 2L);
+		var b = new BackupInfo(BackupId.of(1), timestamp, MemorySize.ofBytes(50), 2L);
+		var c = new BackupInfo(BackupId.of(2), timestamp, MemorySize.ofBytes(50), 2L);
 
 		// When / Then
 		assertThat(a).isEqualTo(b);

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +28,7 @@ class RateLimiterTest {
 	@Test
 	void create_withExplicitRefillAndFairness(@TempDir Path dir) {
 		// Given
-		try (var sut = RateLimiter.create(MemorySize.ofMB(100), 50_000L, 5);
+		try (var sut = RateLimiter.create(MemorySize.ofMB(100), Duration.ofMillis(50), 5);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
 		     var db = RocksDB.openReadWrite(opts, dir)) {
 
@@ -51,7 +52,7 @@ class RateLimiterTest {
 	@Test
 	void createAutoTuned_withExplicitRefillAndFairness(@TempDir Path dir) {
 		// Given
-		try (var sut = RateLimiter.createAutoTuned(MemorySize.ofMB(100), 100_000L, 10);
+		try (var sut = RateLimiter.createAutoTuned(MemorySize.ofMB(100), Duration.ofMillis(100), 10);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
 		     var db = RocksDB.openReadWrite(opts, dir)) {
 
@@ -64,7 +65,7 @@ class RateLimiterTest {
 	void createWithMode_readsOnly(@TempDir Path dir) {
 		// Given
 		try (var sut = RateLimiter.createWithMode(
-				MemorySize.ofMB(100), 100_000L, 10, RateLimiter.Mode.READS_ONLY, false);
+				MemorySize.ofMB(100), Duration.ofMillis(100), 10, RateLimiter.Mode.READS_ONLY, false);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
 		     var db = RocksDB.openReadWrite(opts, dir)) {
 
@@ -77,7 +78,7 @@ class RateLimiterTest {
 	void createWithMode_allIoAutoTuned(@TempDir Path dir) {
 		// Given
 		try (var sut = RateLimiter.createWithMode(
-				MemorySize.ofMB(100), 100_000L, 10, RateLimiter.Mode.ALL_IO, true);
+				MemorySize.ofMB(100), Duration.ofMillis(100), 10, RateLimiter.Mode.ALL_IO, true);
 		     var opts = Options.newOptions().setCreateIfMissing(true).setRateLimiter(sut);
 		     var db = RocksDB.openReadWrite(opts, dir)) {
 

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineIntegrationTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +31,7 @@ class BackupEngineIntegrationTest {
 			assertThat(infos).hasSize(1);
 			assertThat(infos.getFirst().backupId()).isEqualTo(BackupId.of(1));
 			assertThat(infos.getFirst().numberOfFiles()).isGreaterThan(0);
-			assertThat(infos.getFirst().timestamp()).isGreaterThan(0);
+			assertThat(infos.getFirst().timestamp()).isAfter(Instant.EPOCH);
 			assertThat(infos.getFirst().size().toBytes()).isGreaterThan(0);
 		}
 

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/RateLimiterIntegrationTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,7 +48,7 @@ class RateLimiterIntegrationTest {
 	void rateLimiterWithAllIoMode(@TempDir Path dir) {
 		// Given
 		try (var limiter = RateLimiter.createWithMode(
-				MemorySize.ofMB(200), 100_000L, 10,
+				MemorySize.ofMB(200), Duration.ofMillis(100), 10,
 				RateLimiter.Mode.ALL_IO, false);
 		     var opts = Options.newOptions()
 				     .setCreateIfMissing(true)


### PR DESCRIPTION
## Summary
Two independent domain-type fixes, each its own commit:

- **`RateLimiter.create`/`createAutoTuned`/`createWithMode`**: `refillPeriodUs` (raw `long` microseconds) → `Duration refillPeriod`. RocksDB documents no sentinel meaning for a negative value, so this rejects `null` and negative durations rather than treating either specially — same pattern already established for `TransactionOptions`/`TransactionDBOptions`'s lock/deadlock/expiration timeouts. Renamed away the `Us` suffix since it's redundant once the type is `Duration`.
- **`BackupInfo.timestamp`**: raw `long` (documented only as "Unix timestamp, seconds since epoch") → `Instant`, via `Instant.ofEpochSecond`.

Also did a broader sweep for other raw-long-with-a-time-unit-in-the-name violations across the mapped API surface — found none. It did surface ~7 genuinely *unmapped* C API functions with time semantics (`delete_obsolete_files_period_micros`, `follower_catchup_retry_wait_ms`, `periodic_compaction_seconds`, etc.) — that's new feature work, not a domain-type fix, so out of scope here.

## Test plan
- [x] `./mvnw test` — full suite green
- [x] `./mvnw verify -pl integration-tests -am` — integration tests green
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] CHANGELOG updated with both breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)