### PR TITLE
Add Property.COMPACTION_ABORT_COUNT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `metadataWriteTemperature`, `walWriteTemperature`, `lastLevelTemperature`,
   `defaultWriteTemperature`, `defaultTemperature`. EXPERIMENTAL upstream; a no-op unless a
   custom `FileSystem` inspects it.
+- `Property.COMPACTION_ABORT_COUNT` (`rocksdb.compaction-abort-count`), found missing during a
+  post-version-bump audit of the mapped property set against `rocksdb/include/rocksdb/db.h`.
 
 ### Changed
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Property.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Property.java
@@ -62,6 +62,8 @@ public enum Property {
 	NUM_RUNNING_COMPACTIONS("rocksdb.num-running-compactions", Type.NUMERIC),
 	/// Number of sorted runs in compactions currently running.
 	NUM_RUNNING_COMPACTION_SORTED_RUNS("rocksdb.num-running-compaction-sorted-runs", Type.NUMERIC),
+	/// Current value of the compaction abort counter.
+	COMPACTION_ABORT_COUNT("rocksdb.compaction-abort-count", Type.NUMERIC),
 	/// Accumulated number of background errors since the DB was opened.
 	BACKGROUND_ERRORS("rocksdb.background-errors", Type.NUMERIC),
 	/// Approximate size (bytes) of the active memtable.

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PropertyTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PropertyTest.java
@@ -87,6 +87,15 @@ class PropertyTest {
 	}
 
 	@Test
+	void getLongProperty_compactionAbortCount_isPresent(@TempDir Path dir) {
+		try (var db = RocksDB.openReadWrite(dir)) {
+			assertThat(db.getLongProperty(Property.COMPACTION_ABORT_COUNT)).isPresent();
+			assertThat(db.getLongProperty(Property.COMPACTION_ABORT_COUNT).getAsLong())
+					.isGreaterThanOrEqualTo(0);
+		}
+	}
+
+	@Test
 	void getLongProperty_numSnapshots_incrementsWithSnapshot(@TempDir Path dir) {
 		// Given
 		try (var db = RocksDB.openReadWrite(dir)) {

--- a/docs/c-api-gaps.md
+++ b/docs/c-api-gaps.md
@@ -25,6 +25,7 @@ rocksdbffm wraps `rocksdb/c.h` — the official RocksDB C API — not C++ direct
 | CuckooTable options | `rocksdb_cuckoo_table_options_t` + setters | Medium | Hash-based SST format; efficient for fixed-size keys |
 | Advanced memtable config | Various `rocksdb_options_set_*` memtable setters | Low | SkipList tuning, hash-memtable variants |
 | Advanced column family options | CF-scoped option setters | Low | Per-CF compaction style, level multiplier, etc. |
+| `rocksdb.live_sst_files_size_at_temperature` property | `rocksdb_property_value()` (existing, generic) | Low | Needs a `Temperature` enum (no Java type yet, matches C++'s `kUnknown`/`kHot`/`kWarm`/`kCold`) and a suffixed-property call shape (`name:kWarm`) `getProperty(Property)`'s flat enum doesn't support — every other property is a plain constant, this one alone takes a parameter |
 
 ---
 


### PR DESCRIPTION
## Summary
Post-version-bump audit of the mapped `Property` set against `rocksdb/include/rocksdb/db.h` (pinned to v11.8.1). Diffed all 60 documented `rocksdb.*` property names against the 61 currently mapped (accounting for the `<N>`-level-suffixed ones) — found two gaps:

- **`rocksdb.compaction-abort-count`** — added here. Plain numeric counter (`HandleCompactionAbortCount`), identical registration shape to every other numeric property already mapped (`NUM_RUNNING_COMPACTIONS`, `ACTUAL_DELAYED_WRITE_RATE`, etc.).
- **`rocksdb.live_sst_files_size_at_temperature`** — filed in `docs/c-api-gaps.md` instead. Its C++ registration uses the "suffix" handler slot (`HandleLiveSstFilesSizeAtTemperature`), meaning it needs a temperature name appended (`name:kWarm`) — a parameterized property, unlike every other flat-constant one. No `Temperature` type exists in this codebase yet, and `getProperty(Property)`'s enum-based shape doesn't support a suffix argument at all. Real gap, bigger scope than a one-line addition.

## Test plan
- [x] `./mvnw test` — full suite green (`PropertyTest`: 10/10, up from 9)
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)