### PR TITLE
feat: add Temperature enum, wire into Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Temperature` enum (storage-tier hint) wired into 5 `Options` setter/getter pairs:
+  `metadataWriteTemperature`, `walWriteTemperature`, `lastLevelTemperature`,
+  `defaultWriteTemperature`, `defaultTemperature`. EXPERIMENTAL upstream; a no-op unless a
+  custom `FileSystem` inspects it.
+
 ### Changed
 
 - **Breaking:** `RateLimiter.create`/`createAutoTuned`/`createWithMode`'s refill period is now a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ instance method listed below lives on the DB type (`ReadWriteDB`, `TtlDB`, …),
 | Checkpoints             | `Checkpoint.java`                                                                                                         |
 | Table Options           | `BlockBasedTableOptions.java`, `Cache.java`, `LRUCache.java`, `HyperClockCache.java`, `FilterPolicy.java`                 |
 | Compression             | `CompressionType.java`; `Options.setCompression`, `Options.getCompression`                                                |
+| Temperature hints       | `Temperature.java`; 5 setter/getter pairs on `Options` (metadata/WAL/last-level/default-write/default write temperature)  |
 | Iterators               | `RocksIterator.java`                                                                                                      |
 | Snapshots               | `Snapshot.java`; `ReadOptions.setSnapshot`; `ReadWriteDB.getSnapshot`, `TransactionDB.getSnapshot`, `Transaction.getSnapshot` |
 | Flush                   | `FlushOptions.java`; `ReadWriteDB.flush`, `ReadWriteDB.flushWal`, `TransactionDB.flush`, `TransactionDB.flushWal`                 |

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
@@ -99,6 +99,26 @@ public final class Options extends NativeObject {
 	private static final MethodHandle MH_SET_ENV;
 	/// `void rocksdb_options_set_sst_file_manager(rocksdb_options_t* opt, rocksdb_sst_file_manager_t* sfm);`
 	private static final MethodHandle MH_SET_SST_FILE_MANAGER;
+	/// `void rocksdb_options_set_metadata_write_temperature(rocksdb_options_t* opt, int v);`
+	private static final MethodHandle MH_SET_METADATA_WRITE_TEMPERATURE;
+	/// `int rocksdb_options_get_metadata_write_temperature(rocksdb_options_t* opt);`
+	private static final MethodHandle MH_GET_METADATA_WRITE_TEMPERATURE;
+	/// `void rocksdb_options_set_wal_write_temperature(rocksdb_options_t* opt, int v);`
+	private static final MethodHandle MH_SET_WAL_WRITE_TEMPERATURE;
+	/// `int rocksdb_options_get_wal_write_temperature(rocksdb_options_t* opt);`
+	private static final MethodHandle MH_GET_WAL_WRITE_TEMPERATURE;
+	/// `void rocksdb_options_set_last_level_temperature(rocksdb_options_t* opt, int v);`
+	private static final MethodHandle MH_SET_LAST_LEVEL_TEMPERATURE;
+	/// `int rocksdb_options_get_last_level_temperature(rocksdb_options_t* opt);`
+	private static final MethodHandle MH_GET_LAST_LEVEL_TEMPERATURE;
+	/// `void rocksdb_options_set_default_write_temperature(rocksdb_options_t* opt, int v);`
+	private static final MethodHandle MH_SET_DEFAULT_WRITE_TEMPERATURE;
+	/// `int rocksdb_options_get_default_write_temperature(rocksdb_options_t* opt);`
+	private static final MethodHandle MH_GET_DEFAULT_WRITE_TEMPERATURE;
+	/// `void rocksdb_options_set_default_temperature(rocksdb_options_t* opt, int v);`
+	private static final MethodHandle MH_SET_DEFAULT_TEMPERATURE;
+	/// `int rocksdb_options_get_default_temperature(rocksdb_options_t* opt);`
+	private static final MethodHandle MH_GET_DEFAULT_TEMPERATURE;
 	static {
 		MH_CREATE = NativeLibrary.lookup("rocksdb_options_create",
 				FunctionDescriptor.of(ValueLayout.ADDRESS));
@@ -222,6 +242,36 @@ public final class Options extends NativeObject {
 
 		MH_SET_SST_FILE_MANAGER = NativeLibrary.lookup("rocksdb_options_set_sst_file_manager",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+		MH_SET_METADATA_WRITE_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_set_metadata_write_temperature",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_METADATA_WRITE_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_get_metadata_write_temperature",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_WAL_WRITE_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_set_wal_write_temperature",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_WAL_WRITE_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_get_wal_write_temperature",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_LAST_LEVEL_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_set_last_level_temperature",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_LAST_LEVEL_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_get_last_level_temperature",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_DEFAULT_WRITE_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_set_default_write_temperature",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_DEFAULT_WRITE_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_get_default_write_temperature",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_DEFAULT_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_set_default_temperature",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_DEFAULT_TEMPERATURE = NativeLibrary.lookup("rocksdb_options_get_default_temperature",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
 
 	}
 
@@ -736,6 +786,138 @@ public final class Options extends NativeObject {
 			return this;
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("setRateLimiter failed", t);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Temperature options
+	// -----------------------------------------------------------------------
+
+	/// Sets the temperature hint for metadata block-based tables (index, filter, etc.).
+	/// EXPERIMENTAL. Default: [Temperature#UNKNOWN].
+	///
+	/// @param temperature the temperature hint to use for metadata files
+	/// @return `this` for chaining
+	public Options setMetadataWriteTemperature(Temperature temperature) {
+		try {
+			MH_SET_METADATA_WRITE_TEMPERATURE.invokeExact(ptr(), temperature.getValue());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setMetadataWriteTemperature failed", t);
+		}
+	}
+
+	/// Returns the temperature hint configured for metadata block-based tables.
+	///
+	/// @return the active [Temperature] hint for metadata files
+	public Temperature getMetadataWriteTemperature() {
+		try {
+			return Temperature.fromValue((int) MH_GET_METADATA_WRITE_TEMPERATURE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getMetadataWriteTemperature failed", t);
+		}
+	}
+
+	/// Sets the temperature hint for WAL files.
+	/// EXPERIMENTAL. Default: [Temperature#UNKNOWN].
+	///
+	/// @param temperature the temperature hint to use for WAL files
+	/// @return `this` for chaining
+	public Options setWalWriteTemperature(Temperature temperature) {
+		try {
+			MH_SET_WAL_WRITE_TEMPERATURE.invokeExact(ptr(), temperature.getValue());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setWalWriteTemperature failed", t);
+		}
+	}
+
+	/// Returns the temperature hint configured for WAL files.
+	///
+	/// @return the active [Temperature] hint for WAL files
+	public Temperature getWalWriteTemperature() {
+		try {
+			return Temperature.fromValue((int) MH_GET_WAL_WRITE_TEMPERATURE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getWalWriteTemperature failed", t);
+		}
+	}
+
+	/// Sets the temperature hint for SST files placed on the last level.
+	/// EXPERIMENTAL. Default: [Temperature#UNKNOWN].
+	///
+	/// @param temperature the temperature hint to use for last-level files
+	/// @return `this` for chaining
+	public Options setLastLevelTemperature(Temperature temperature) {
+		try {
+			MH_SET_LAST_LEVEL_TEMPERATURE.invokeExact(ptr(), temperature.getValue());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setLastLevelTemperature failed", t);
+		}
+	}
+
+	/// Returns the temperature hint configured for SST files on the last level.
+	///
+	/// @return the active [Temperature] hint for last-level files
+	public Temperature getLastLevelTemperature() {
+		try {
+			return Temperature.fromValue((int) MH_GET_LAST_LEVEL_TEMPERATURE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getLastLevelTemperature failed", t);
+		}
+	}
+
+	/// Sets the temperature hint used when a new SST file is written, for levels
+	/// that don't otherwise have an explicit temperature configured.
+	/// EXPERIMENTAL. Default: [Temperature#UNKNOWN].
+	///
+	/// @param temperature the temperature hint to use for newly written files
+	/// @return `this` for chaining
+	public Options setDefaultWriteTemperature(Temperature temperature) {
+		try {
+			MH_SET_DEFAULT_WRITE_TEMPERATURE.invokeExact(ptr(), temperature.getValue());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setDefaultWriteTemperature failed", t);
+		}
+	}
+
+	/// Returns the temperature hint configured for newly written SST files.
+	///
+	/// @return the active default write [Temperature] hint
+	public Temperature getDefaultWriteTemperature() {
+		try {
+			return Temperature.fromValue((int) MH_GET_DEFAULT_WRITE_TEMPERATURE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getDefaultWriteTemperature failed", t);
+		}
+	}
+
+	/// Sets the temperature hint assumed for existing SST files that have no
+	/// temperature recorded in their metadata (e.g. files created before this
+	/// option existed).
+	/// EXPERIMENTAL. Default: [Temperature#UNKNOWN].
+	///
+	/// @param temperature the fallback temperature hint for files without a recorded temperature
+	/// @return `this` for chaining
+	public Options setDefaultTemperature(Temperature temperature) {
+		try {
+			MH_SET_DEFAULT_TEMPERATURE.invokeExact(ptr(), temperature.getValue());
+			return this;
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setDefaultTemperature failed", t);
+		}
+	}
+
+	/// Returns the fallback temperature hint for files without a recorded temperature.
+	///
+	/// @return the active default [Temperature] hint
+	public Temperature getDefaultTemperature() {
+		try {
+			return Temperature.fromValue((int) MH_GET_DEFAULT_TEMPERATURE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getDefaultTemperature failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Temperature.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Temperature.java
@@ -1,0 +1,46 @@
+package io.github.dfa1.rocksdbffm;
+
+/// Filesystem/storage temperature hint, matching RocksDB's `Temperature` enum. Lets a
+/// pluggable `FileSystem` place files on different storage tiers (e.g. local SSD vs. cheaper
+/// object storage) based on how "hot" the data is expected to be. A no-op for the default
+/// `FileSystem` — only takes effect with a custom one that inspects it.
+///
+/// Every option this is used with is EXPERIMENTAL per `rocksdb/include/rocksdb/advanced_options.h`
+/// and `options.h`, and defaults to [#UNKNOWN].
+public enum Temperature {
+	/// No temperature hint (default).
+	UNKNOWN(0x00),
+	/// Frequently accessed data.
+	HOT(0x04),
+	/// Infrequently accessed data.
+	WARM(0x08),
+	/// Rarely accessed data, colder than [#WARM].
+	COOL(0x0A),
+	/// Rarely accessed data, colder than [#COOL].
+	COLD(0x0C),
+	/// The coldest tier.
+	ICE(0x10);
+
+	private final int value;
+
+	Temperature(int value) {
+		this.value = value;
+	}
+
+	// don't expose the raw value
+	int getValue() {
+		return value;
+	}
+
+	static Temperature fromValue(int v) {
+		return switch (v) {
+			case 0x00 -> UNKNOWN;
+			case 0x04 -> HOT;
+			case 0x08 -> WARM;
+			case 0x0A -> COOL;
+			case 0x0C -> COLD;
+			case 0x10 -> ICE;
+			default -> UNKNOWN;
+		};
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TemperatureTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TemperatureTest.java
@@ -1,0 +1,124 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TemperatureTest {
+
+	@ParameterizedTest
+	@EnumSource(Temperature.class)
+	void fromValue_roundTrips(Temperature temperature) {
+		// Given / When
+		var result = Temperature.fromValue(temperature.getValue());
+
+		// Then
+		assertThat(result).isEqualTo(temperature);
+	}
+
+	@Test
+	void fromValue_unknownValueFallsBackToUnknown() {
+		// Given / When
+		var result = Temperature.fromValue(-1);
+
+		// Then
+		assertThat(result).isEqualTo(Temperature.UNKNOWN);
+	}
+
+	// -----------------------------------------------------------------------
+	// Options integration
+	// -----------------------------------------------------------------------
+
+	@Test
+	void options_defaultTemperature_isUnknown() {
+		// Given / When
+		try (Options opts = Options.newOptions()) {
+
+			// Then
+			assertThat(opts.getMetadataWriteTemperature()).isEqualTo(Temperature.UNKNOWN);
+			assertThat(opts.getWalWriteTemperature()).isEqualTo(Temperature.UNKNOWN);
+			assertThat(opts.getLastLevelTemperature()).isEqualTo(Temperature.UNKNOWN);
+			assertThat(opts.getDefaultWriteTemperature()).isEqualTo(Temperature.UNKNOWN);
+			assertThat(opts.getDefaultTemperature()).isEqualTo(Temperature.UNKNOWN);
+		}
+	}
+
+	@Test
+	void options_setMetadataWriteTemperature_roundTrips() {
+		// Given
+		try (Options opts = Options.newOptions()) {
+
+			// When
+			opts.setMetadataWriteTemperature(Temperature.HOT);
+
+			// Then
+			assertThat(opts.getMetadataWriteTemperature()).isEqualTo(Temperature.HOT);
+		}
+	}
+
+	@Test
+	void options_setWalWriteTemperature_roundTrips() {
+		// Given
+		try (Options opts = Options.newOptions()) {
+
+			// When
+			opts.setWalWriteTemperature(Temperature.WARM);
+
+			// Then
+			assertThat(opts.getWalWriteTemperature()).isEqualTo(Temperature.WARM);
+		}
+	}
+
+	@Test
+	void options_setLastLevelTemperature_roundTrips() {
+		// Given
+		try (Options opts = Options.newOptions()) {
+
+			// When
+			opts.setLastLevelTemperature(Temperature.COLD);
+
+			// Then
+			assertThat(opts.getLastLevelTemperature()).isEqualTo(Temperature.COLD);
+		}
+	}
+
+	@Test
+	void options_setDefaultWriteTemperature_roundTrips() {
+		// Given
+		try (Options opts = Options.newOptions()) {
+
+			// When
+			opts.setDefaultWriteTemperature(Temperature.COOL);
+
+			// Then
+			assertThat(opts.getDefaultWriteTemperature()).isEqualTo(Temperature.COOL);
+		}
+	}
+
+	@Test
+	void options_setDefaultTemperature_roundTrips() {
+		// Given
+		try (Options opts = Options.newOptions()) {
+
+			// When
+			opts.setDefaultTemperature(Temperature.ICE);
+
+			// Then
+			assertThat(opts.getDefaultTemperature()).isEqualTo(Temperature.ICE);
+		}
+	}
+
+	@Test
+	void options_setTemperature_chaining() {
+		// Given / When
+		try (Options opts = Options.newOptions()
+				.setCreateIfMissing(true)
+				.setDefaultTemperature(Temperature.HOT)) {
+
+			// Then
+			assertThat(opts.getDefaultTemperature()).isEqualTo(Temperature.HOT);
+		}
+	}
+}

--- a/docs/c-api-gaps.md
+++ b/docs/c-api-gaps.md
@@ -16,6 +16,7 @@ rocksdbffm wraps `rocksdb/c.h` — the official RocksDB C API — not C++ direct
 | Feature | Key C functions | Priority | Notes |
 |:---|:---|:---:|:---|
 | MultiGet | `rocksdb_multi_get()` | High | Bulk key lookup; important for throughput |
+| CompactFiles | `rocksdb_compact_files()`, `rocksdb_compaction_options_t` + setters (incl. `output_temperature_override`) | Low | A second, unrelated options opaque type from `CompactOptions`'s `rocksdb_compactoptions_t` (used by `compactRange`) — needs its own wrapper class, not an extension of `CompactOptions.java` |
 | CompactionFilter | `rocksdb_compactionfilter_create()`, `rocksdb_compactionfilterfactory_create()` | High | Callback-based; enables custom retention/deletion policies during compaction |
 | EventListener | `rocksdb_eventlistener_create()` (~12 callbacks) | High | Flush, compaction, file creation/deletion events; needed for monitoring |
 | Custom Comparator | `rocksdb_comparator_create()`, `rocksdb_comparator_with_ts_create()` | High | Custom key ordering; note: key shortening not exposed in C API |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -136,6 +136,11 @@ Other read/write methods on the read-write types:
 | `setEnv`                                    | `Env`                   |
 | `setRateLimiter`                            | `RateLimiter`           |
 | `setSstFileManager`                         | `SstFileManager`        |
+| `setMetadataWriteTemperature` / `getMetadataWriteTemperature` | `Temperature` |
+| `setWalWriteTemperature` / `getWalWriteTemperature` | `Temperature`   |
+| `setLastLevelTemperature` / `getLastLevelTemperature` | `Temperature` |
+| `setDefaultWriteTemperature` / `getDefaultWriteTemperature` | `Temperature` |
+| `setDefaultTemperature` / `getDefaultTemperature` | `Temperature`      |
 
 Blob options (used with `RocksDB.openBlob`, each with a matching getter):
 
@@ -322,6 +327,7 @@ listing every existing column family, `default` included.
 | `StatsLevel`                        | `DISABLE_ALL`, `EXCEPT_TICKERS`, `EXCEPT_HISTOGRAM_OR_TIMERS`, `EXCEPT_TIMERS`, `EXCEPT_DETAILED_TIMERS`, `EXCEPT_TIME_FOR_MUTEX`, `ALL` |
 | `PerfLevel`                         | `UNINITIALIZED`, `DISABLE`, `ENABLE_COUNT`, `ENABLE_TIME_EXCEPT_FOR_MUTEX`, `ENABLE_TIME`      |
 | `PrepopulateBlobCache`              | `DISABLE`, `FLUSH_ONLY`                                                                        |
+| `Temperature`                       | `UNKNOWN`, `HOT`, `WARM`, `COOL`, `COLD`, `ICE` — storage-tier hint, no-op for the default `FileSystem` |
 | `RateLimiter.Mode`                  | `READS_ONLY`, `WRITES_ONLY`, `ALL_IO`                                                          |
 | `IOPriority`                        | `LOW`, `MID`, `HIGH`, `USER`, `TOTAL`                                                          |
 | `IOActivity`                        | `FLUSH`, `COMPACTION`, `DB_OPEN`, `GET`, `MULTI_GET`, `DB_ITERATOR`, `VERIFY_DB_CHECKSUM`, `VERIFY_FILE_CHECKSUMS`, `GET_ENTITY`, `MULTI_GET_ENTITY`, `GET_FILE_CHECKSUMS_FROM_CURRENT_MANIFEST`, `UNKNOWN` |
@@ -360,6 +366,7 @@ Parity tracking against `rocksdbjni`. ✅ implemented · 🚧 partial · ❌ not
 | Column families            |   ✅    | Multi-CF open for every DB type; CF overloads on all data methods and `WriteBatch`          |
 | DeleteRange                |   ✅    | Range tombstones on the DB and in `WriteBatch`; all three tiers                             |
 | Compaction control         |   ✅    | `compactRange` (+`CompactOptions`), `suggestCompactRange`, file-deletion toggles            |
+| Temperature hints          |   ✅    | `Temperature`; 5 `Options` setter/getter pairs (metadata/WAL/last-level/default-write/default). EXPERIMENTAL upstream, no-op for the default `FileSystem` |
 | SST file ingest            |   ✅    | `SstFileWriter`, `ingestExternalFile`, `IngestExternalFileOptions`                          |
 | Backup engine              |   ✅    | Incremental backup/restore, purge, verify                                                   |
 | TTL DB                     |   ✅    | `openTtl(path, Duration)`; lazy expiry via compaction                                   |


### PR DESCRIPTION
## Summary
- New `Temperature` enum matching RocksDB's `Temperature` (`rocksdb/include/rocksdb/types.h`) — storage-tier hint for pluggable `FileSystem`s, defaults to `UNKNOWN`, falls back to `UNKNOWN` for unmapped int values (matches `LogLevel`'s established fallback pattern).
- Wired into 5 `Options` setter/getter pairs: `metadataWriteTemperature`, `walWriteTemperature`, `lastLevelTemperature`, `defaultWriteTemperature`, `defaultTemperature`. All EXPERIMENTAL upstream, no-op for the default `FileSystem`.
- `output_temperature_override` (`CompactOptions`-adjacent) is **not** wired: it belongs to `rocksdb_compaction_options_t`, a distinct unwrapped opaque type used by `CompactFiles`, not `CompactOptions`'s `rocksdb_compactoptions_t` (used by `compactRange`). Filed as a new Type A row in `docs/c-api-gaps.md` instead of forcing it into the wrong class.
- Docs updated: `CLAUDE.md` source map, `docs/reference.md` (Options table, enum table, feature-status table), `CHANGELOG.md`.

## Test plan
- [x] `./mvnw test -pl core -am` — full suite green, including new `TemperatureTest`
- [x] `./mvnw javadoc:javadoc -pl core` — zero output (javadoc gate passes)
- [x] Round-trip tests for all 5 setter/getter pairs plus default-value and `fromValue` fallback coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)