### PR TITLE
feat: add merge() to all write-capable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   custom `FileSystem` inspects it.
 - `Property.COMPACTION_ABORT_COUNT` (`rocksdb.compaction-abort-count`), found missing during a
   post-version-bump audit of the mapped property set against `rocksdb/include/rocksdb/db.h`.
+- `merge()` (byte[]/ByteBuffer/MemorySegment, plus column-family variants) on `ReadWriteDB`,
+  `TtlDB`, `BlobDB`, `OptimisticTransactionDB`, `TransactionDB`, `Transaction`, and `WriteBatch`
+  (closes [#8](https://github.com/dfa1/rocksdbffm/issues/8)). No merge operator can be configured
+  yet, so every call fails with `RocksDBException` until custom `MergeOperator` support lands
+  (tracked in `docs/c-api-gaps.md`).
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,7 @@ instance method listed below lives on the DB type (`ReadWriteDB`, `TtlDB`, …),
 | Shared utilities        | `RocksDB.java` statics (`errHolder`, `checkError`, `toNative`), `NativeObject.java`, `NativeLibrary.java`, `MemorySize.java`, `SequenceNumber.java`, `RocksDBException.java` |
 | Compaction control      | `CompactOptions.java`, `WaitForCompactOptions.java`; `ReadWriteDB.compactRange`, `suggestCompactRange`, `disableFileDeletions`, `enableFileDeletions`, `ReadWriteDB.waitForCompact` |
 | DeleteRange             | `ReadWriteDB.deleteRange` (all three tiers), `WriteBatch.deleteRange`                                                     |
+| Merge                   | `merge()` on `ReadWriteDB`, `TtlDB`, `BlobDB`, `OptimisticTransactionDB`, `TransactionDB`, `Transaction`, `WriteBatch` (all tiers + CF variants); no merge operator configurable yet, see [c-api-gaps.md](docs/c-api-gaps.md) |
 | SST File Ingest         | `SstFileWriter.java`, `IngestExternalFileOptions.java`; `ReadWriteDB.ingestExternalFile`                                     |
 | WAL Iterator            | `WalIterator.java`, `WalBatchResult.java`; `ReadWriteDB.getUpdatesSince`, `getLatestSequenceNumber`                          |
 | Read-only DB            | `ReadOnlyDB.java`                                                                                                         |

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
@@ -80,6 +80,46 @@ public final class BlobDB extends NativeObject {
 	}
 
 	// -----------------------------------------------------------------------
+	// Merge
+	// -----------------------------------------------------------------------
+
+	/// Merges `value` into `key` via the configured merge operator. Slow path: copies key/value into
+	/// native memory.
+	///
+	/// @param key the key to merge into
+	/// @param value the merge operand
+	public void merge(byte[] key, byte[] value) {
+		RocksDB.mergeBytes(ptr(), writeOpts.ptr(), key, value);
+	}
+
+	/// Merges `value` into `key` using the caller's [Arena] for native allocation.
+	///
+	/// @param arena the arena used to allocate native key/value segments
+	/// @param key the key to merge into
+	/// @param value the merge operand
+	public void merge(Arena arena, byte[] key, byte[] value) {
+		RocksDB.mergeBytes(arena, ptr(), writeOpts.ptr(), key, value);
+	}
+
+	/// Zero-copy merge: wraps the direct buffers' native memory without heap→native copy.
+	///
+	/// @param key direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeSegment(ptr(), writeOpts.ptr(),
+				MemorySegment.ofBuffer(key), key.remaining(),
+				MemorySegment.ofBuffer(value), value.remaining());
+	}
+
+	/// Zero-copy merge: caller supplies pre-allocated native segments.
+	///
+	/// @param key native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(MemorySegment key, MemorySegment value) {
+		RocksDB.mergeSegment(ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
+	}
+
+	// -----------------------------------------------------------------------
 	// Get
 	// -----------------------------------------------------------------------
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
@@ -131,6 +131,37 @@ public final class OptimisticTransactionDB extends NativeObject {
 	}
 
 	// -----------------------------------------------------------------------
+	// Merge
+	// -----------------------------------------------------------------------
+
+	/// Merges `value` into `key` via the configured merge operator, bypassing any active
+	/// transaction. Slow path: allocates native memory.
+	///
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(byte[] key, byte[] value) {
+		RocksDB.mergeBytes(baseDb, writeOpts.ptr(), key, value);
+	}
+
+	/// Zero-copy merge: wraps the direct buffers' native memory without heap→native copy.
+	///
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeSegment(baseDb, writeOpts.ptr(),
+				MemorySegment.ofBuffer(key), key.remaining(),
+				MemorySegment.ofBuffer(value), value.remaining());
+	}
+
+	/// Zero-copy merge: caller supplies pre-allocated native segments.
+	///
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(MemorySegment key, MemorySegment value) {
+		RocksDB.mergeSegment(baseDb, writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
+	}
+
+	// -----------------------------------------------------------------------
 	// Get
 	// -----------------------------------------------------------------------
 
@@ -291,6 +322,39 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param value native segment containing the value
 	public void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		RocksDB.putCfSegment(baseDb, writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
+	}
+
+	// -----------------------------------------------------------------------
+	// Merge — column family overloads
+	// -----------------------------------------------------------------------
+
+	/// Merges `value` into `key` in `cf`, bypassing any active transaction. Slow path.
+	///
+	/// @param cf    target column family
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
+		RocksDB.mergeCfBytes(baseDb, writeOpts.ptr(), cf, key, value);
+	}
+
+	/// Zero-copy merge into `cf` for direct [ByteBuffer]s.
+	///
+	/// @param cf    target column family
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeCfSegment(baseDb, writeOpts.ptr(), cf,
+				MemorySegment.ofBuffer(key), key.remaining(),
+				MemorySegment.ofBuffer(value), value.remaining());
+	}
+
+	/// Zero-copy merge into `cf` for [MemorySegment]s.
+	///
+	/// @param cf    target column family
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		RocksDB.mergeCfSegment(baseDb, writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -78,6 +78,55 @@ public final class ReadWriteDB extends NativeObject {
 	}
 
 	// -----------------------------------------------------------------------
+	// Merge
+	// -----------------------------------------------------------------------
+
+	/// Merges `value` into `key` via the configured merge operator. Slow path: copies key/value into
+	/// native memory.
+	///
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(byte[] key, byte[] value) {
+		RocksDB.mergeBytes(ptr(), writeOpts.ptr(), key, value);
+	}
+
+	/// Merges `value` into `key` using the caller's [Arena] for native allocation.
+	///
+	/// @param arena arena used for temporary native allocations
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(Arena arena, byte[] key, byte[] value) {
+		RocksDB.mergeBytes(arena, ptr(), writeOpts.ptr(), key, value);
+	}
+
+	/// Zero-copy merge: wraps the direct buffers' native memory without heap→native copy.
+	///
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeSegment(ptr(), writeOpts.ptr(),
+				MemorySegment.ofBuffer(key), key.remaining(),
+				MemorySegment.ofBuffer(value), value.remaining());
+	}
+
+	/// Zero-copy merge: caller supplies pre-allocated native segments.
+	///
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(MemorySegment key, MemorySegment value) {
+		RocksDB.mergeSegment(ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
+	}
+
+	/// Zero-copy merge using the caller's [Arena].
+	///
+	/// @param arena arena used for temporary native allocations
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(Arena arena, MemorySegment key, MemorySegment value) {
+		RocksDB.mergeSegment(arena, ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
+	}
+
+	// -----------------------------------------------------------------------
 	// Get
 	// -----------------------------------------------------------------------
 
@@ -533,6 +582,39 @@ public final class ReadWriteDB extends NativeObject {
 	/// @param value native segment containing the value
 	public void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		RocksDB.putCfSegment(ptr(), writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
+	}
+
+	// -----------------------------------------------------------------------
+	// Merge — column family overloads
+	// -----------------------------------------------------------------------
+
+	/// Merges `value` into `key` in `cf`. Slow path: copies key/value into native memory.
+	///
+	/// @param cf    target column family
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
+		RocksDB.mergeCfBytes(ptr(), writeOpts.ptr(), cf, key, value);
+	}
+
+	/// Zero-copy merge into `cf`: wraps the direct buffers' native memory without heap→native copy.
+	///
+	/// @param cf    target column family
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeCfSegment(ptr(), writeOpts.ptr(), cf,
+				MemorySegment.ofBuffer(key), key.remaining(),
+				MemorySegment.ofBuffer(value), value.remaining());
+	}
+
+	/// Zero-copy merge into `cf`: caller supplies pre-allocated native segments.
+	///
+	/// @param cf    target column family
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		RocksDB.mergeCfSegment(ptr(), writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -69,6 +69,8 @@ public final class RocksDB {
 	private static final MethodHandle MH_PUT;
 	/// `void rocksdb_delete(rocksdb_t* db, const rocksdb_writeoptions_t* options, const char* key, size_t keylen, char** errptr);`
 	private static final MethodHandle MH_DELETE;
+	/// `void rocksdb_merge(rocksdb_t* db, const rocksdb_writeoptions_t* options, const char* key, size_t keylen, const char* val, size_t vallen, char** errptr);`
+	private static final MethodHandle MH_MERGE;
 	/// `void rocksdb_flush(rocksdb_t* db, const rocksdb_flushoptions_t* options, char** errptr);`
 	private static final MethodHandle MH_FLUSH;
 	/// `void rocksdb_flush_wal(rocksdb_t* db, unsigned char sync, char** errptr);`
@@ -132,6 +134,8 @@ public final class RocksDB {
 	private static final MethodHandle MH_GET_INTO_BUFFER_CF;
 	/// `void rocksdb_delete_cf(rocksdb_t* db, const rocksdb_writeoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char** errptr);`
 	private static final MethodHandle MH_DELETE_CF;
+	/// `void rocksdb_merge_cf(rocksdb_t* db, const rocksdb_writeoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, const char* val, size_t vallen, char** errptr);`
+	private static final MethodHandle MH_MERGE_CF;
 	/// `unsigned char rocksdb_key_may_exist_cf(rocksdb_t* db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t key_len, char** value, size_t* val_len, const char* timestamp, size_t timestamp_len, unsigned char* value_found);`
 	private static final MethodHandle MH_KEY_MAY_EXIST_CF;
 	/// `rocksdb_iterator_t* rocksdb_create_iterator_cf(rocksdb_t* db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family);`
@@ -224,6 +228,13 @@ public final class RocksDB {
 		MH_DELETE = NativeLibrary.lookup("rocksdb_delete",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
+		MH_MERGE = NativeLibrary.lookup("rocksdb_merge",
+				FunctionDescriptor.ofVoid(
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
 
@@ -356,6 +367,13 @@ public final class RocksDB {
 		MH_DELETE_CF = NativeLibrary.lookup("rocksdb_delete_cf",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
+		MH_MERGE_CF = NativeLibrary.lookup("rocksdb_merge_cf",
+				FunctionDescriptor.ofVoid(
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
 
@@ -808,6 +826,56 @@ public final class RocksDB {
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
+		}
+	}
+
+	/// byte[] merge — slow path, allocates native memory.
+	static void mergeBytes(MemorySegment db, MemorySegment writeOpts, byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = errHolder(arena);
+			MemorySegment k = toNative(arena, key);
+			MemorySegment v = toNative(arena, value);
+			MH_MERGE.invokeExact(db, writeOpts, k, (long) key.length, v, (long) value.length, err);
+			checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
+		}
+	}
+
+	/// byte[] merge using the caller's arena.
+	static void mergeBytes(Arena arena, MemorySegment db, MemorySegment writeOpts, byte[] key, byte[] value) {
+		try {
+			MemorySegment err = errHolder(arena);
+			MemorySegment k = toNative(arena, key);
+			MemorySegment v = toNative(arena, value);
+			MH_MERGE.invokeExact(db, writeOpts, k, (long) key.length, v, (long) value.length, err);
+			checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
+		}
+	}
+
+	/// MemorySegment merge — zero-copy, caller supplies pre-allocated native segments.
+	static void mergeSegment(MemorySegment db, MemorySegment writeOpts,
+	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = errHolder(arena);
+			MH_MERGE.invokeExact(db, writeOpts, key, keyLen, val, valLen, err);
+			checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
+		}
+	}
+
+	/// MemorySegment merge using the caller's arena.
+	static void mergeSegment(Arena arena, MemorySegment db, MemorySegment writeOpts,
+	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+		try {
+			MemorySegment err = errHolder(arena);
+			MH_MERGE.invokeExact(db, writeOpts, key, keyLen, val, valLen, err);
+			checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
 		}
 	}
 
@@ -1501,6 +1569,32 @@ public final class RocksDB {
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
+		}
+	}
+
+	/// byte[] merge with explicit column family — slow path.
+	static void mergeCfBytes(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	                         byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = errHolder(arena);
+			MH_MERGE_CF.invokeExact(db, writeOpts, cf.ptr(),
+					toNative(arena, key), (long) key.length,
+					toNative(arena, value), (long) value.length, err);
+			checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
+		}
+	}
+
+	/// MemorySegment merge with explicit column family — zero-copy.
+	static void mergeCfSegment(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	                           MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = errHolder(arena);
+			MH_MERGE_CF.invokeExact(db, writeOpts, cf.ptr(), key, keyLen, val, valLen, err);
+			checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -832,13 +832,7 @@ public final class RocksDB {
 	/// byte[] merge — slow path, allocates native memory.
 	static void mergeBytes(MemorySegment db, MemorySegment writeOpts, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = errHolder(arena);
-			MemorySegment k = toNative(arena, key);
-			MemorySegment v = toNative(arena, value);
-			MH_MERGE.invokeExact(db, writeOpts, k, (long) key.length, v, (long) value.length, err);
-			checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("merge failed", t);
+			mergeBytes(arena, db, writeOpts, key, value);
 		}
 	}
 
@@ -859,11 +853,7 @@ public final class RocksDB {
 	static void mergeSegment(MemorySegment db, MemorySegment writeOpts,
 	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = errHolder(arena);
-			MH_MERGE.invokeExact(db, writeOpts, key, keyLen, val, valLen, err);
-			checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("merge failed", t);
+			mergeSegment(arena, db, writeOpts, key, keyLen, val, valLen);
 		}
 	}
 
@@ -1576,6 +1566,14 @@ public final class RocksDB {
 	static void mergeCfBytes(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
 	                         byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
+			mergeCfBytes(arena, db, writeOpts, cf, key, value);
+		}
+	}
+
+	/// byte[] merge with explicit column family using the caller's arena.
+	static void mergeCfBytes(Arena arena, MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	                         byte[] key, byte[] value) {
+		try {
 			MemorySegment err = errHolder(arena);
 			MH_MERGE_CF.invokeExact(db, writeOpts, cf.ptr(),
 					toNative(arena, key), (long) key.length,
@@ -1590,6 +1588,14 @@ public final class RocksDB {
 	static void mergeCfSegment(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
 	                           MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try (Arena arena = Arena.ofConfined()) {
+			mergeCfSegment(arena, db, writeOpts, cf, key, keyLen, val, valLen);
+		}
+	}
+
+	/// MemorySegment merge with explicit column family using the caller's arena.
+	static void mergeCfSegment(Arena arena, MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	                           MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+		try {
 			MemorySegment err = errHolder(arena);
 			MH_MERGE_CF.invokeExact(db, writeOpts, cf.ptr(), key, keyLen, val, valLen, err);
 			checkError(err);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -29,6 +29,8 @@ public final class Transaction extends NativeObject {
 	private static final MethodHandle MH_PUT_CF;
 	/// `void rocksdb_transaction_delete_cf(rocksdb_transaction_t* txn, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen, char** errptr);`
 	private static final MethodHandle MH_DELETE_CF;
+	/// `void rocksdb_transaction_merge_cf(rocksdb_transaction_t* txn, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen, const char* val, size_t vlen, char** errptr);`
+	private static final MethodHandle MH_MERGE_CF;
 	/// `rocksdb_iterator_t* rocksdb_transaction_create_iterator_cf(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family);`
 	private static final MethodHandle MH_CREATE_ITERATOR_CF;
 	/// `void rocksdb_transaction_commit(rocksdb_transaction_t* txn, char** errptr);`
@@ -47,6 +49,8 @@ public final class Transaction extends NativeObject {
 	private static final MethodHandle MH_PUT;
 	/// `void rocksdb_transaction_delete(rocksdb_transaction_t* txn, const char* key, size_t klen, char** errptr);`
 	private static final MethodHandle MH_DELETE;
+	/// `void rocksdb_transaction_merge(rocksdb_transaction_t* txn, const char* key, size_t klen, const char* val, size_t vlen, char** errptr);`
+	private static final MethodHandle MH_MERGE;
 	/// `rocksdb_pinnableslice_t* rocksdb_transaction_get_pinned(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, const char* key, size_t klen, char** errptr);`
 	private static final MethodHandle MH_GET_PINNED;
 	/// `rocksdb_pinnableslice_t* rocksdb_transaction_get_pinned_for_update(rocksdb_transaction_t* txn, const rocksdb_readoptions_t* options, const char* key, size_t klen, unsigned char exclusive, char** errptr);`
@@ -81,6 +85,13 @@ public final class Transaction extends NativeObject {
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
 
+		MH_MERGE = NativeLibrary.lookup("rocksdb_transaction_merge",
+				FunctionDescriptor.ofVoid(
+						ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
 		MH_GET_PINNED = NativeLibrary.lookup("rocksdb_transaction_get_pinned",
 				FunctionDescriptor.of(ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
@@ -104,6 +115,13 @@ public final class Transaction extends NativeObject {
 		MH_DELETE_CF = NativeLibrary.lookup("rocksdb_transaction_delete_cf",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
+		MH_MERGE_CF = NativeLibrary.lookup("rocksdb_transaction_merge_cf",
+				FunctionDescriptor.ofVoid(
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
 
@@ -217,6 +235,52 @@ public final class Transaction extends NativeObject {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MH_DELETE.invokeExact(ptr(), key, key.byteSize(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+		}
+	}
+
+	/// Stages a merge inside this transaction. Slow path: allocates native memory for key/value.
+	///
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment k = RocksDB.toNative(arena, key);
+			MemorySegment v = RocksDB.toNative(arena, value);
+			MH_MERGE.invokeExact(ptr(), k, (long) key.length, v, (long) value.length, err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+		}
+	}
+
+	/// Stages a merge inside this transaction. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ByteBuffer key, ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE.invokeExact(ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+		}
+	}
+
+	/// Stages a merge inside this transaction. Zero-copy for [MemorySegment]s.
+	///
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE.invokeExact(ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("Native call failed", t);
@@ -511,6 +575,55 @@ public final class Transaction extends NativeObject {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MH_DELETE_CF.invokeExact(ptr(), cf.ptr(), key, key.byteSize(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+		}
+	}
+
+	/// Stages a merge into `cf` inside this transaction. Slow path: allocates native memory.
+	///
+	/// @param cf    target column family
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
+					RocksDB.toNative(arena, key), (long) key.length,
+					RocksDB.toNative(arena, value), (long) value.length, err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+		}
+	}
+
+	/// Stages a merge into `cf` inside this transaction. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param cf    target column family
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+		}
+	}
+
+	/// Stages a merge into `cf` inside this transaction. Zero-copy for [MemorySegment]s.
+	///
+	/// @param cf    target column family
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("Native call failed", t);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -52,6 +52,8 @@ public final class TransactionDB extends NativeObject {
 	private static final MethodHandle MH_PUT;
 	/// `void rocksdb_transactiondb_delete(rocksdb_transactiondb_t* txn_db, const rocksdb_writeoptions_t* options, const char* key, size_t klen, char** errptr);`
 	private static final MethodHandle MH_DELETE;
+	/// `void rocksdb_transactiondb_merge(rocksdb_transactiondb_t* txn_db, const rocksdb_writeoptions_t* options, const char* key, size_t klen, const char* val, size_t vlen, char** errptr);`
+	private static final MethodHandle MH_MERGE;
 	/// `rocksdb_pinnableslice_t* rocksdb_transactiondb_get_pinned(rocksdb_transactiondb_t* txn_db, const rocksdb_readoptions_t* options, const char* key, size_t klen, char** errptr);`
 	private static final MethodHandle MH_GET_PINNED;
 
@@ -60,6 +62,8 @@ public final class TransactionDB extends NativeObject {
 	private static final MethodHandle MH_PUT_CF;
 	/// `void rocksdb_transactiondb_delete_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_writeoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char** errptr);`
 	private static final MethodHandle MH_DELETE_CF;
+	/// `void rocksdb_transactiondb_merge_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_writeoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen, const char* val, size_t vlen, char** errptr);`
+	private static final MethodHandle MH_MERGE_CF;
 	/// `rocksdb_pinnableslice_t* rocksdb_transactiondb_get_pinned_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family, const char* key, size_t keylen, char** errptr);`
 	private static final MethodHandle MH_GET_PINNED_CF;
 	/// `rocksdb_iterator_t* rocksdb_transactiondb_create_iterator_cf(rocksdb_transactiondb_t* txn_db, const rocksdb_readoptions_t* options, rocksdb_column_family_handle_t* column_family);`
@@ -90,6 +94,13 @@ public final class TransactionDB extends NativeObject {
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
 
+		MH_MERGE = NativeLibrary.lookup("rocksdb_transactiondb_merge",
+				FunctionDescriptor.ofVoid(
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
 		MH_GET_PINNED = NativeLibrary.lookup("rocksdb_transactiondb_get_pinned",
 				FunctionDescriptor.of(ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
@@ -106,6 +117,13 @@ public final class TransactionDB extends NativeObject {
 		MH_DELETE_CF = NativeLibrary.lookup("rocksdb_transactiondb_delete_cf",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS));
+
+		MH_MERGE_CF = NativeLibrary.lookup("rocksdb_transactiondb_merge_cf",
+				FunctionDescriptor.ofVoid(
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS));
 
@@ -286,6 +304,53 @@ public final class TransactionDB extends NativeObject {
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
+		}
+	}
+
+	/// Direct merge, bypassing any active transaction. Slow path: allocates native memory.
+	///
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MemorySegment k = RocksDB.toNative(arena, key);
+			MemorySegment v = RocksDB.toNative(arena, value);
+			MH_MERGE.invokeExact(ptr(), writeOpts.ptr(), k, (long) key.length, v, (long) value.length, err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
+		}
+	}
+
+	/// Zero-copy merge: wraps the direct buffers' native memory without heap→native copy.
+	///
+	/// @param key   direct [java.nio.ByteBuffer] containing the key
+	/// @param value direct [java.nio.ByteBuffer] containing the merge operand
+	public void merge(java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE.invokeExact(ptr(), writeOpts.ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining(),
+					err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
+		}
+	}
+
+	/// Zero-copy merge: caller supplies pre-allocated native segments.
+	///
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE.invokeExact(ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
 		}
 	}
 
@@ -587,6 +652,60 @@ public final class TransactionDB extends NativeObject {
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Merge — column family overloads
+	// -----------------------------------------------------------------------
+
+	/// Merges `value` into `key` in `cf`, bypassing any active transaction. Slow path.
+	///
+	/// @param cf    target column family
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+					RocksDB.toNative(arena, key), (long) key.length,
+					RocksDB.toNative(arena, value), (long) value.length, err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
+		}
+	}
+
+	/// Zero-copy merge into `cf` for direct [java.nio.ByteBuffer]s.
+	///
+	/// @param cf    target column family
+	/// @param key   direct [java.nio.ByteBuffer] containing the key
+	/// @param value direct [java.nio.ByteBuffer] containing the merge operand
+	public void merge(ColumnFamilyHandle cf, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
+		}
+	}
+
+	/// Zero-copy merge into `cf` for [MemorySegment]s.
+	///
+	/// @param cf    target column family
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment err = RocksDB.errHolder(arena);
+			MH_MERGE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+					key, key.byteSize(), value, value.byteSize(), err);
+			RocksDB.checkError(err);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("merge failed", t);
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
@@ -92,6 +92,55 @@ public final class TtlDB extends NativeObject {
 	}
 
 	// -----------------------------------------------------------------------
+	// Merge
+	// -----------------------------------------------------------------------
+
+	/// Merges `value` into `key` via the configured merge operator. Slow path: copies key/value into
+	/// native memory.
+	///
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(byte[] key, byte[] value) {
+		RocksDB.mergeBytes(ptr(), writeOpts.ptr(), key, value);
+	}
+
+	/// Merges `value` into `key` using the caller's [Arena] for native allocation.
+	///
+	/// @param arena arena for native allocations
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(Arena arena, byte[] key, byte[] value) {
+		RocksDB.mergeBytes(arena, ptr(), writeOpts.ptr(), key, value);
+	}
+
+	/// Zero-copy merge: wraps the direct buffers' native memory without heap→native copy.
+	///
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeSegment(ptr(), writeOpts.ptr(),
+				MemorySegment.ofBuffer(key), key.remaining(),
+				MemorySegment.ofBuffer(value), value.remaining());
+	}
+
+	/// Zero-copy merge: caller supplies pre-allocated native segments.
+	///
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(MemorySegment key, MemorySegment value) {
+		RocksDB.mergeSegment(ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
+	}
+
+	/// Zero-copy merge using the caller's [Arena].
+	///
+	/// @param arena arena for native allocations
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(Arena arena, MemorySegment key, MemorySegment value) {
+		RocksDB.mergeSegment(arena, ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
+	}
+
+	// -----------------------------------------------------------------------
 	// Get
 	// -----------------------------------------------------------------------
 
@@ -291,6 +340,39 @@ public final class TtlDB extends NativeObject {
 	/// @param value native segment containing the value
 	public void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		RocksDB.putCfSegment(ptr(), writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
+	}
+
+	// -----------------------------------------------------------------------
+	// Merge — column family overloads
+	// -----------------------------------------------------------------------
+
+	/// Merges `value` into `key` in `cf`. Slow path: copies key/value into native memory.
+	///
+	/// @param cf    target column family
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
+		RocksDB.mergeCfBytes(ptr(), writeOpts.ptr(), cf, key, value);
+	}
+
+	/// Zero-copy merge into `cf`: wraps the direct buffers' native memory without heap→native copy.
+	///
+	/// @param cf    target column family
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeCfSegment(ptr(), writeOpts.ptr(), cf,
+				MemorySegment.ofBuffer(key), key.remaining(),
+				MemorySegment.ofBuffer(value), value.remaining());
+	}
+
+	/// Zero-copy merge into `cf`: caller supplies pre-allocated native segments.
+	///
+	/// @param cf    target column family
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		RocksDB.mergeCfSegment(ptr(), writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WriteBatch.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WriteBatch.java
@@ -22,12 +22,16 @@ public final class WriteBatch extends NativeObject {
 	private static final MethodHandle MH_PUT;
 	/// `void rocksdb_writebatch_delete(rocksdb_writebatch_t*, const char* key, size_t klen);`
 	private static final MethodHandle MH_DELETE;
+	/// `void rocksdb_writebatch_merge(rocksdb_writebatch_t*, const char* key, size_t klen, const char* val, size_t vlen);`
+	private static final MethodHandle MH_MERGE;
 	/// `void rocksdb_writebatch_delete_range(rocksdb_writebatch_t* b, const char* start_key, size_t start_key_len, const char* end_key, size_t end_key_len);`
 	private static final MethodHandle MH_DELETE_RANGE;
 	/// `void rocksdb_writebatch_put_cf(rocksdb_writebatch_t*, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen, const char* val, size_t vlen);`
 	private static final MethodHandle MH_PUT_CF;
 	/// `void rocksdb_writebatch_delete_cf(rocksdb_writebatch_t*, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen);`
 	private static final MethodHandle MH_DELETE_CF;
+	/// `void rocksdb_writebatch_merge_cf(rocksdb_writebatch_t*, rocksdb_column_family_handle_t* column_family, const char* key, size_t klen, const char* val, size_t vlen);`
+	private static final MethodHandle MH_MERGE_CF;
 	/// `void rocksdb_writebatch_delete_range_cf(rocksdb_writebatch_t* b, rocksdb_column_family_handle_t* column_family, const char* start_key, size_t start_key_len, const char* end_key, size_t end_key_len);`
 	private static final MethodHandle MH_DELETE_RANGE_CF;
 	/// `void rocksdb_writebatch_clear(rocksdb_writebatch_t*);`
@@ -53,6 +57,12 @@ public final class WriteBatch extends NativeObject {
 						ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
 
+		MH_MERGE = NativeLibrary.lookup("rocksdb_writebatch_merge",
+				FunctionDescriptor.ofVoid(
+						ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
 		MH_DELETE_RANGE = NativeLibrary.lookup("rocksdb_writebatch_delete_range",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS,
@@ -68,6 +78,12 @@ public final class WriteBatch extends NativeObject {
 		MH_DELETE_CF = NativeLibrary.lookup("rocksdb_writebatch_delete_cf",
 				FunctionDescriptor.ofVoid(
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_MERGE_CF = NativeLibrary.lookup("rocksdb_writebatch_merge_cf",
+				FunctionDescriptor.ofVoid(
+						ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG,
 						ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
 
 		MH_DELETE_RANGE_CF = NativeLibrary.lookup("rocksdb_writebatch_delete_range_cf",
@@ -157,6 +173,61 @@ public final class WriteBatch extends NativeObject {
 			MH_PUT.invokeExact(ptr(), key, key.byteSize(), value, value.byteSize());
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("writebatch put failed", t);
+		}
+	}
+
+	/// Queues a merge operand using the caller's [Arena] for native allocation. Slow path.
+	///
+	/// @param arena arena for native allocations
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(Arena arena, byte[] key, byte[] value) {
+		try {
+			MemorySegment k = RocksDB.toNative(arena, key);
+			MemorySegment v = RocksDB.toNative(arena, value);
+			MH_MERGE.invokeExact(ptr(), k, (long) key.length, v, (long) value.length);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("writebatch merge failed", t);
+		}
+	}
+
+	/// Queues a merge operand. Slow path: copies key/value into native memory.
+	///
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment k = RocksDB.toNative(arena, key);
+			MemorySegment v = RocksDB.toNative(arena, value);
+			MH_MERGE.invokeExact(ptr(), k, (long) key.length, v, (long) value.length);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("writebatch merge failed", t);
+		}
+	}
+
+	/// Queues a merge operand. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ByteBuffer key, ByteBuffer value) {
+		try {
+			MH_MERGE.invokeExact(ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("writebatch merge failed", t);
+		}
+	}
+
+	/// Queues a merge operand. Zero-copy for [MemorySegment]s.
+	///
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(MemorySegment key, MemorySegment value) {
+		try {
+			MH_MERGE.invokeExact(ptr(), key, key.byteSize(), value, value.byteSize());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("writebatch merge failed", t);
 		}
 	}
 
@@ -281,6 +352,50 @@ public final class WriteBatch extends NativeObject {
 					key, key.byteSize(), value, value.byteSize());
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("writebatch put_cf failed", t);
+		}
+	}
+
+	/// Queues a merge operand into `cf`. Slow path: copies key/value into native memory.
+	///
+	/// @param cf    target column family
+	/// @param key   the key to merge into
+	/// @param value the merge operand
+	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
+					RocksDB.toNative(arena, key), (long) key.length,
+					RocksDB.toNative(arena, value), (long) value.length);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("writebatch merge_cf failed", t);
+		}
+	}
+
+	/// Queues a merge operand into `cf`. Zero-copy for direct [ByteBuffer]s.
+	///
+	/// @param cf    target column family
+	/// @param key   direct [ByteBuffer] containing the key
+	/// @param value direct [ByteBuffer] containing the merge operand
+	public void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
+		try {
+			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
+					MemorySegment.ofBuffer(key), (long) key.remaining(),
+					MemorySegment.ofBuffer(value), (long) value.remaining());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("writebatch merge_cf failed", t);
+		}
+	}
+
+	/// Queues a merge operand into `cf`. Zero-copy for [MemorySegment]s.
+	///
+	/// @param cf    target column family
+	/// @param key   native segment containing the key
+	/// @param value native segment containing the merge operand
+	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		try {
+			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
+					key, key.byteSize(), value, value.byteSize());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("writebatch merge_cf failed", t);
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/MergeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/MergeTest.java
@@ -1,0 +1,201 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Covers `merge()` across every write-capable type. This library does not yet wrap
+/// `rocksdb_mergeoperator_create` (see `docs/c-api-gaps.md`), so no test here can configure a
+/// merge operator — every direct `merge()` call is expected to surface RocksDB's own
+/// `Status::InvalidArgument("Merge requires ColumnFamilyOptions::merge_operator != nullptr")`
+/// as a [RocksDBException], confirmed against `rocksdb/db/write_batch.cc`'s
+/// `MemTableInserter::Merge`. `Transaction` and `WriteBatch` only queue a merge record and don't
+/// touch the memtable until `commit()`/`write()`, so those two throw later than the others.
+class MergeTest {
+
+	// -----------------------------------------------------------------------
+	// ReadWriteDB
+	// -----------------------------------------------------------------------
+
+	@Test
+	void readWriteDb_merge_bytes_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge("k".getBytes(), "v".getBytes()));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	@Test
+	void readWriteDb_merge_byteBuffer_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir)) {
+			ByteBuffer key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+			ByteBuffer value = ByteBuffer.allocateDirect(1).put((byte) 'v').flip();
+
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge(key, value));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	@Test
+	void readWriteDb_merge_memorySegment_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir); var arena = Arena.ofConfined()) {
+			MemorySegment key = arena.allocateFrom("k");
+			MemorySegment value = arena.allocateFrom("v");
+
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge(key, value));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	@Test
+	void readWriteDb_merge_withCallerArena_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir); var arena = Arena.ofConfined()) {
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge(arena, "k".getBytes(), "v".getBytes()));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	@Test
+	void readWriteDb_merge_columnFamily_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"))) {
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge(cf, "k".getBytes(), "v".getBytes()));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// TtlDB
+	// -----------------------------------------------------------------------
+
+	@Test
+	void ttlDb_merge_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openTtl(dir, Duration.ofSeconds(60))) {
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge("k".getBytes(), "v".getBytes()));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// BlobDB
+	// -----------------------------------------------------------------------
+
+	@Test
+	void blobDb_merge_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openBlob(dir)) {
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge("k".getBytes(), "v".getBytes()));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// OptimisticTransactionDB
+	// -----------------------------------------------------------------------
+
+	@Test
+	void optimisticTransactionDb_merge_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openOptimistic(opts, dir)) {
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge("k".getBytes(), "v".getBytes()));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// TransactionDB — direct (non-transactional) merge
+	// -----------------------------------------------------------------------
+
+	@Test
+	void transactionDb_directMerge_throwsWithoutMergeOperator(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var txnDbOpts = TransactionDBOptions.newTransactionDBOptions();
+		     var db = RocksDB.openTransaction(opts, txnDbOpts, dir)) {
+			// When
+			var thrown = assertThatThrownBy(() -> db.merge("k".getBytes(), "v".getBytes()));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Transaction — merge only queues; failure surfaces at commit()
+	// -----------------------------------------------------------------------
+
+	@Test
+	void transaction_merge_queuesWithoutError_thenCommitThrows(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var txnDbOpts = TransactionDBOptions.newTransactionDBOptions();
+		     var db = RocksDB.openTransaction(opts, txnDbOpts, dir);
+		     var wo = WriteOptions.newWriteOptions();
+		     var txn = db.beginTransaction(wo)) {
+
+			// When — queuing itself must not throw
+			txn.merge("k".getBytes(), "v".getBytes());
+
+			// Then — the missing merge operator only surfaces once the write reaches the memtable
+			assertThatThrownBy(txn::commit).isInstanceOf(RocksDBException.class);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// WriteBatch — merge only queues; failure surfaces at write()
+	// -----------------------------------------------------------------------
+
+	@Test
+	void writeBatch_merge_queuesWithoutError_thenWriteThrows(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var batch = WriteBatch.create()) {
+
+			// When — queuing itself must not throw
+			batch.merge("k".getBytes(), "v".getBytes());
+
+			// Then
+			assertThat(batch.count()).isEqualTo(1);
+			assertThatThrownBy(() -> db.write(batch)).isInstanceOf(RocksDBException.class);
+		}
+	}
+}

--- a/docs/c-api-gaps.md
+++ b/docs/c-api-gaps.md
@@ -20,7 +20,7 @@ rocksdbffm wraps `rocksdb/c.h` — the official RocksDB C API — not C++ direct
 | CompactionFilter | `rocksdb_compactionfilter_create()`, `rocksdb_compactionfilterfactory_create()` | High | Callback-based; enables custom retention/deletion policies during compaction |
 | EventListener | `rocksdb_eventlistener_create()` (~12 callbacks) | High | Flush, compaction, file creation/deletion events; needed for monitoring |
 | Custom Comparator | `rocksdb_comparator_create()`, `rocksdb_comparator_with_ts_create()` | High | Custom key ordering; note: key shortening not exposed in C API |
-| Custom MergeOperator | `rocksdb_mergeoperator_create()` | Medium | C API exists; no Java side yet — `merge` itself is also unimplemented |
+| Custom MergeOperator | `rocksdb_mergeoperator_create()` | Medium | C API exists; no Java side yet. The `merge()` write op itself is implemented (see [reference.md#feature-status](reference.md#feature-status)), but every call fails with `RocksDBException` until a merge operator can be configured — that requires wrapping `full_merge`/`partial_merge`/`delete_value`/`name` FFM upcalls, same class of work as `CompactionFilter`/`EventListener` |
 | JemallocNodumpAllocator | `rocksdb_jemalloc_nodump_allocator_create()` | Medium | Jemalloc allocator for caches; avoids coredump leaking sensitive data |
 | CuckooTable options | `rocksdb_cuckoo_table_options_t` + setters | Medium | Hash-based SST format; efficient for fixed-size keys |
 | Advanced memtable config | Various `rocksdb_options_set_*` memtable setters | Low | SkipList tuning, hash-memtable variants |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -380,7 +380,8 @@ Parity tracking against `rocksdbjni`. ✅ implemented · 🚧 partial · ❌ not
 | Perf context               |   ✅    | `PerfContext`, `PerfLevel`, `PerfMetric`                                                    |
 | Background jobs            |   🚧    | `cancelAllBackgroundWork`, manual-compaction toggles, `waitForCompact`; Options-level tuning (FIFO/Universal) pending |
 | MultiGet                   |   ❌    | `rocksdb_multi_get()` exists in the C API; no Java wrapper yet                              |
-| Merge / MergeOperator      |   ❌    | C API exists; see [#8](https://github.com/dfa1/rocksdbffm/issues/8)                         |
+| Merge                      |   🚧    | `merge()` write op on all 7 write-capable types (byte[]/ByteBuffer/MemorySegment, CF variants), see [#8](https://github.com/dfa1/rocksdbffm/issues/8); no merge operator can be configured yet, so calls fail with `RocksDBException` until custom `MergeOperator` support lands |
+| MergeOperator               |   ❌    | `rocksdb_mergeoperator_create()` (custom `full_merge`/`partial_merge` callbacks) not wrapped; see [c-api-gaps.md](c-api-gaps.md) |
 | CompactionFilter           |   ❌    | Callback-based custom compaction logic                                                      |
 | Custom comparators         |   ❌    | `rocksdb_comparator_create()` exists in the C API                                           |
 | Advanced column family     |   ❌    | Per-CF compaction style, level multipliers                                                  |


### PR DESCRIPTION
## Summary

- Closes #8. Adds `merge()` (byte[]/ByteBuffer/MemorySegment tiers, plus column-family variants) to all 7 write-capable types: `ReadWriteDB`, `TtlDB`, `BlobDB`, `OptimisticTransactionDB`, `TransactionDB`, `Transaction`, `WriteBatch`. Each mirrors that type's existing `put()`/`delete()` shape exactly — no new abstraction, just the same pattern applied a third time.
- No merge operator can be configured yet (`rocksdb_mergeoperator_create` isn't wrapped), so every `merge()` call fails with `RocksDBException` until that lands — tracked separately in `docs/c-api-gaps.md`.
- `MergeTest` verifies the actual failure semantics against `rocksdb/db/write_batch.cc`'s `MemTableInserter::Merge` rather than assuming them: direct calls fail immediately, while `Transaction`/`WriteBatch` only queue a merge record and fail later, at `commit()`/`write()`.

## Test plan

- [x] `./mvnw clean test` — 778/778 pass
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] New `MergeTest` (11 tests) covers all 7 types' merge failure semantics