### PR TITLE
feat: add MergeOperator (uint64Add built-in + custom callback-based)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   post-version-bump audit of the mapped property set against `rocksdb/include/rocksdb/db.h`.
 - `merge()` (byte[]/ByteBuffer/MemorySegment, plus column-family variants) on `ReadWriteDB`,
   `TtlDB`, `BlobDB`, `OptimisticTransactionDB`, `TransactionDB`, `Transaction`, and `WriteBatch`
-  (closes [#8](https://github.com/dfa1/rocksdbffm/issues/8)). No merge operator can be configured
-  yet, so every call fails with `RocksDBException` until custom `MergeOperator` support lands
-  (tracked in `docs/c-api-gaps.md`).
+  (closes [#8](https://github.com/dfa1/rocksdbffm/issues/8)).
+- `MergeOperator`: `uint64Add()` wraps the built-in little-endian-uint64-sum operator;
+  `custom(String, FullMergeFn)` wraps RocksDB's general callback-based merge operator, so
+  `merge()` can be given real semantics instead of always failing with `RocksDBException`.
+  Attached via `Options.setMergeOperator`.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ instance method listed below lives on the DB type (`ReadWriteDB`, `TtlDB`, …),
 | Shared utilities        | `RocksDB.java` statics (`errHolder`, `checkError`, `toNative`), `NativeObject.java`, `NativeLibrary.java`, `MemorySize.java`, `SequenceNumber.java`, `RocksDBException.java` |
 | Compaction control      | `CompactOptions.java`, `WaitForCompactOptions.java`; `ReadWriteDB.compactRange`, `suggestCompactRange`, `disableFileDeletions`, `enableFileDeletions`, `ReadWriteDB.waitForCompact` |
 | DeleteRange             | `ReadWriteDB.deleteRange` (all three tiers), `WriteBatch.deleteRange`                                                     |
-| Merge                   | `merge()` on `ReadWriteDB`, `TtlDB`, `BlobDB`, `OptimisticTransactionDB`, `TransactionDB`, `Transaction`, `WriteBatch` (all tiers + CF variants); no merge operator configurable yet, see [c-api-gaps.md](docs/c-api-gaps.md) |
+| Merge                   | `merge()` on `ReadWriteDB`, `TtlDB`, `BlobDB`, `OptimisticTransactionDB`, `TransactionDB`, `Transaction`, `WriteBatch` (all tiers + CF variants); `MergeOperator.java` (`uint64Add()` built-in, `custom(String, FullMergeFn)` callback-based), wired via `Options.setMergeOperator` |
 | SST File Ingest         | `SstFileWriter.java`, `IngestExternalFileOptions.java`; `ReadWriteDB.ingestExternalFile`                                     |
 | WAL Iterator            | `WalIterator.java`, `WalBatchResult.java`; `ReadWriteDB.getUpdatesSince`, `getLatestSequenceNumber`                          |
 | Read-only DB            | `ReadOnlyDB.java`                                                                                                         |

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/MergeOperator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/MergeOperator.java
@@ -76,7 +76,7 @@ public sealed interface MergeOperator {
 	/// the [Options] in a single native call.
 	record Uint64Add() implements MergeOperator {
 
-		/// `void rocksdb_options_set_uint64add_merge_operator(rocksdb_options_t*)`
+		/// `void rocksdb_options_set_uint64add_merge_operator(rocksdb_options_t*);`
 		private static final MethodHandle MH_SET_UINT64ADD_MERGE_OPERATOR = NativeLibrary.lookup(
 				"rocksdb_options_set_uint64add_merge_operator",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
@@ -93,7 +93,7 @@ public sealed interface MergeOperator {
 	/// A Java-implemented merge operator, backed by a real `rocksdb_mergeoperator_t*` handle.
 	final class Custom extends NativeObject implements MergeOperator {
 
-		/// `rocksdb_mergeoperator_t* rocksdb_mergeoperator_create(void* state, void (*destructor)(void*), char* (*full_merge)(void*, const char*, size_t, const char*, size_t, const char* const*, const size_t*, int, unsigned char*, size_t*), char* (*partial_merge)(void*, const char*, size_t, const char* const*, const size_t*, int, unsigned char*, size_t*), void (*delete_value)(void*, const char*, size_t), const char* (*name)(void*))`
+		/// `rocksdb_mergeoperator_t* rocksdb_mergeoperator_create(void* state, void (*destructor)(void*), char* (*full_merge)(void*, const char* key, size_t key_length, const char* existing_value, size_t existing_value_length, const char* const* operands_list, const size_t* operands_list_length, int num_operands, unsigned char* success, size_t* new_value_length), char* (*partial_merge)(void*, const char* key, size_t key_length, const char* const* operands_list, const size_t* operands_list_length, int num_operands, unsigned char* success, size_t* new_value_length), void (*delete_value)(void*, const char* value, size_t value_length), const char* (*name)(void*));`
 		private static final MethodHandle MH_MERGEOPERATOR_CREATE = NativeLibrary.lookup(
 				"rocksdb_mergeoperator_create",
 				FunctionDescriptor.of(ValueLayout.ADDRESS,
@@ -104,12 +104,12 @@ public sealed interface MergeOperator {
 						ValueLayout.ADDRESS,  // delete_value
 						ValueLayout.ADDRESS)); // name
 
-		/// `void rocksdb_mergeoperator_destroy(rocksdb_mergeoperator_t*)`
+		/// `void rocksdb_mergeoperator_destroy(rocksdb_mergeoperator_t*);`
 		private static final MethodHandle MH_MERGEOPERATOR_DESTROY = NativeLibrary.lookup(
 				"rocksdb_mergeoperator_destroy",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
-		/// `void rocksdb_options_set_merge_operator(rocksdb_options_t*, rocksdb_mergeoperator_t*)`
+		/// `void rocksdb_options_set_merge_operator(rocksdb_options_t*, rocksdb_mergeoperator_t*);`
 		private static final MethodHandle MH_SET_MERGE_OPERATOR = NativeLibrary.lookup(
 				"rocksdb_options_set_merge_operator",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
@@ -243,9 +243,12 @@ public sealed interface MergeOperator {
 			if (MemorySegment.NULL.equals(ptr) || len <= 0) {
 				return new byte[0];
 			}
-			byte[] bytes = new byte[(int) len];
-			MemorySegment.copy(ptr.reinterpret(len), ValueLayout.JAVA_BYTE, 0, bytes, 0, (int) len);
-			return bytes;
+			return RocksDB.toByteArray(ptr, len);
+		}
+
+		private static void writeMergeFailure(MemorySegment successPtr, MemorySegment newValueLenPtr) {
+			successPtr.set(ValueLayout.JAVA_BYTE, 0, (byte) 0);
+			newValueLenPtr.set(ValueLayout.JAVA_LONG, 0, 0L);
 		}
 
 		private static List<byte[]> readOperands(MemorySegment operandsList, MemorySegment operandsLen, int numOperands) {
@@ -281,8 +284,7 @@ public sealed interface MergeOperator {
 				// (assertions are on by default under Surefire) would abort the JVM, not just
 				// this call, so report failure to RocksDB instead of asserting.
 				t.printStackTrace();
-				successPtr.set(ValueLayout.JAVA_BYTE, 0, (byte) 0);
-				newValueLenPtr.set(ValueLayout.JAVA_LONG, 0, 0L);
+				writeMergeFailure(successPtr, newValueLenPtr);
 				return mallocCopy(new byte[0]);
 			}
 		}
@@ -292,9 +294,17 @@ public sealed interface MergeOperator {
 		private static MemorySegment partialMergeDispatch(MemorySegment state, MemorySegment key, long keyLen,
 				MemorySegment operandsList, MemorySegment operandsLen, int numOperands,
 				MemorySegment success, MemorySegment newValueLen) {
-			success.reinterpret(ValueLayout.JAVA_BYTE.byteSize()).set(ValueLayout.JAVA_BYTE, 0, (byte) 0);
-			newValueLen.reinterpret(ValueLayout.JAVA_LONG.byteSize()).set(ValueLayout.JAVA_LONG, 0, 0L);
-			return mallocCopy(new byte[0]);
+			MemorySegment successPtr = success.reinterpret(ValueLayout.JAVA_BYTE.byteSize());
+			MemorySegment newValueLenPtr = newValueLen.reinterpret(ValueLayout.JAVA_LONG.byteSize());
+			try {
+				writeMergeFailure(successPtr, newValueLenPtr);
+				return mallocCopy(new byte[0]);
+			} catch (Throwable t) {
+				// same "must not throw" contract as fullMergeDispatch.
+				t.printStackTrace();
+				writeMergeFailure(successPtr, newValueLenPtr);
+				return mallocCopy(new byte[0]);
+			}
 		}
 
 		/// Called from [#DESTRUCTOR_STUB] when RocksDB's internal `shared_ptr` refcount hits zero.

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/MergeOperator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/MergeOperator.java
@@ -1,0 +1,313 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/// A merge operator, attached to a database or column family via [Options#setMergeOperator(MergeOperator)].
+///
+/// Two ways to obtain one:
+///
+/// - [#uint64Add()] — RocksDB's built-in operator: sums 8-byte little-endian `uint64` operands.
+///   No callback involved; the cheapest option for a counter.
+/// - [#custom(String, FullMergeFn)] — a merge operator implemented in Java, wired through
+///   RocksDB's general callback-based `rocksdb_mergeoperator_create`. Use this for anything the
+///   built-in doesn't cover (string concatenation, min/max, JSON patching, ...).
+///
+/// ```
+/// try (var opts = Options.newOptions().setCreateIfMissing(true)
+///             .setMergeOperator(MergeOperator.uint64Add());
+///      var db = RocksDB.openReadWrite(opts, dbPath)) {
+///     db.merge("views".getBytes(), encode(1));
+///     db.merge("views".getBytes(), encode(1));
+///     long total = decode(db.get("views".getBytes()));   // 2
+/// }
+/// ```
+public sealed interface MergeOperator {
+
+	/// Returns RocksDB's built-in merge operator that sums 8-byte little-endian `uint64` operands.
+	///
+	/// @return the uint64-add merge operator
+	static MergeOperator uint64Add() {
+		return new Uint64Add();
+	}
+
+	/// Wraps a Java-implemented merge function via RocksDB's general callback-based merge operator.
+	///
+	/// @param name stable identifier for this operator; RocksDB persists and checks it against the
+	///             column family's stored options on every open, so it must not change across runs
+	/// @param fn   folds merge operands into a value; see [FullMergeFn] for the threading contract
+	/// @return a new merge operator backed by `fn`; caller must pass it to
+	/// [Options#setMergeOperator(MergeOperator)] or close it
+	static MergeOperator custom(String name, FullMergeFn fn) {
+		return Custom.create(name, fn);
+	}
+
+	/// Folds RocksDB merge operands into a value, in Java.
+	///
+	/// Invoked whenever RocksDB needs the merged value for a key — on `get()`, and internally
+	/// during flush/compaction — including from RocksDB's own background threads. Implementations
+	/// must be thread-safe and must not throw: an exception here is caught and reported to
+	/// RocksDB as a merge failure (surfaces as corruption to the caller) rather than crashing
+	/// the JVM.
+	@FunctionalInterface
+	interface FullMergeFn {
+
+		/// Folds `operands` (oldest first) into `existingValue`.
+		///
+		/// @param key           the key being merged
+		/// @param existingValue the current value, or `null` if the key does not exist yet
+		/// @param operands      merge operands queued for this key, oldest first
+		/// @return the folded value to store
+		byte[] fullMerge(byte[] key, byte[] existingValue, List<byte[]> operands);
+	}
+
+	/// RocksDB's built-in `uint64add` merge operator. Stateless — has no native handle of its own,
+	/// since `rocksdb_options_set_uint64add_merge_operator` creates and attaches the operator to
+	/// the [Options] in a single native call.
+	record Uint64Add() implements MergeOperator {
+
+		/// `void rocksdb_options_set_uint64add_merge_operator(rocksdb_options_t*)`
+		private static final MethodHandle MH_SET_UINT64ADD_MERGE_OPERATOR = NativeLibrary.lookup(
+				"rocksdb_options_set_uint64add_merge_operator",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+		void applyTo(MemorySegment optionsPtr) {
+			try {
+				MH_SET_UINT64ADD_MERGE_OPERATOR.invokeExact(optionsPtr);
+			} catch (Throwable t) {
+				throw RocksDB.wrapInvokeFailure("MergeOperator.uint64Add failed", t);
+			}
+		}
+	}
+
+	/// A Java-implemented merge operator, backed by a real `rocksdb_mergeoperator_t*` handle.
+	final class Custom extends NativeObject implements MergeOperator {
+
+		/// `rocksdb_mergeoperator_t* rocksdb_mergeoperator_create(void* state, void (*destructor)(void*), char* (*full_merge)(void*, const char*, size_t, const char*, size_t, const char* const*, const size_t*, int, unsigned char*, size_t*), char* (*partial_merge)(void*, const char*, size_t, const char* const*, const size_t*, int, unsigned char*, size_t*), void (*delete_value)(void*, const char*, size_t), const char* (*name)(void*))`
+		private static final MethodHandle MH_MERGEOPERATOR_CREATE = NativeLibrary.lookup(
+				"rocksdb_mergeoperator_create",
+				FunctionDescriptor.of(ValueLayout.ADDRESS,
+						ValueLayout.ADDRESS,  // state
+						ValueLayout.ADDRESS,  // destructor
+						ValueLayout.ADDRESS,  // full_merge
+						ValueLayout.ADDRESS,  // partial_merge
+						ValueLayout.ADDRESS,  // delete_value
+						ValueLayout.ADDRESS)); // name
+
+		/// `void rocksdb_mergeoperator_destroy(rocksdb_mergeoperator_t*)`
+		private static final MethodHandle MH_MERGEOPERATOR_DESTROY = NativeLibrary.lookup(
+				"rocksdb_mergeoperator_destroy",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+		/// `void rocksdb_options_set_merge_operator(rocksdb_options_t*, rocksdb_mergeoperator_t*)`
+		private static final MethodHandle MH_SET_MERGE_OPERATOR = NativeLibrary.lookup(
+				"rocksdb_options_set_merge_operator",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+		/// libc `void* malloc(size_t size)` — `full_merge`/`partial_merge` hand a malloc'd buffer
+		/// back to RocksDB, which copies it out and frees it with plain `free()` (`delete_value` is
+		/// passed as `NULL`, see [#create(String, FullMergeFn)]).
+		private static final MethodHandle MH_MALLOC = Linker.nativeLinker().downcallHandle(
+				Linker.nativeLinker().defaultLookup().find("malloc")
+						.orElseThrow(() -> new UnsatisfiedLinkError("Symbol not found: malloc")),
+				FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		private static final FunctionDescriptor FULL_MERGE_DESC = FunctionDescriptor.of(ValueLayout.ADDRESS,
+				ValueLayout.ADDRESS,   // state
+				ValueLayout.ADDRESS,   // key
+				ValueLayout.JAVA_LONG, // key_length
+				ValueLayout.ADDRESS,   // existing_value
+				ValueLayout.JAVA_LONG, // existing_value_length
+				ValueLayout.ADDRESS,   // operands_list
+				ValueLayout.ADDRESS,   // operands_list_length
+				ValueLayout.JAVA_INT,  // num_operands
+				ValueLayout.ADDRESS,   // success
+				ValueLayout.ADDRESS);  // new_value_length
+
+		private static final FunctionDescriptor PARTIAL_MERGE_DESC = FunctionDescriptor.of(ValueLayout.ADDRESS,
+				ValueLayout.ADDRESS,   // state
+				ValueLayout.ADDRESS,   // key
+				ValueLayout.JAVA_LONG, // key_length
+				ValueLayout.ADDRESS,   // operands_list
+				ValueLayout.ADDRESS,   // operands_list_length
+				ValueLayout.JAVA_INT,  // num_operands
+				ValueLayout.ADDRESS,   // success
+				ValueLayout.ADDRESS);  // new_value_length
+
+		private static final FunctionDescriptor DESTRUCTOR_DESC = FunctionDescriptor.ofVoid(ValueLayout.ADDRESS);
+
+		private static final FunctionDescriptor NAME_DESC = FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS);
+
+		// One global upcall stub per callback shape, shared by every Custom instance. Lives for the
+		// JVM lifetime so the function pointers are always valid; dispatch is keyed off the `state`
+		// pointer, which carries a registry ID rather than real memory (same trick as Logger).
+		private static final MemorySegment FULL_MERGE_STUB;
+		private static final MemorySegment PARTIAL_MERGE_STUB;
+		private static final MemorySegment DESTRUCTOR_STUB;
+		private static final MemorySegment NAME_STUB;
+
+		static {
+			try {
+				MethodHandles.Lookup lookup = MethodHandles.lookup();
+				FULL_MERGE_STUB = Linker.nativeLinker().upcallStub(
+						lookup.findStatic(Custom.class, "fullMergeDispatch", MethodType.methodType(
+								MemorySegment.class, MemorySegment.class, MemorySegment.class, long.class,
+								MemorySegment.class, long.class, MemorySegment.class, MemorySegment.class,
+								int.class, MemorySegment.class, MemorySegment.class)),
+						FULL_MERGE_DESC, Arena.global());
+				PARTIAL_MERGE_STUB = Linker.nativeLinker().upcallStub(
+						lookup.findStatic(Custom.class, "partialMergeDispatch", MethodType.methodType(
+								MemorySegment.class, MemorySegment.class, MemorySegment.class, long.class,
+								MemorySegment.class, MemorySegment.class, int.class, MemorySegment.class,
+								MemorySegment.class)),
+						PARTIAL_MERGE_DESC, Arena.global());
+				DESTRUCTOR_STUB = Linker.nativeLinker().upcallStub(
+						lookup.findStatic(Custom.class, "destructorDispatch",
+								MethodType.methodType(void.class, MemorySegment.class)),
+						DESTRUCTOR_DESC, Arena.global());
+				NAME_STUB = Linker.nativeLinker().upcallStub(
+						lookup.findStatic(Custom.class, "nameDispatch",
+								MethodType.methodType(MemorySegment.class, MemorySegment.class)),
+						NAME_DESC, Arena.global());
+			} catch (ReflectiveOperationException e) {
+				throw new ExceptionInInitializerError(e);
+			}
+		}
+
+		private record State(FullMergeFn fn, MemorySegment nameSeg) {
+		}
+
+		// Registry: id (smuggled through the `state` pointer) -> Java-side merge function.
+		// Unregistered from destructorDispatch, not from tryClose: once ownership transfers to
+		// Options via applyTo, the native shared_ptr controls this object's real lifetime, which
+		// can outlive this Java wrapper.
+		private static final ConcurrentHashMap<Long, State> REGISTRY = new ConcurrentHashMap<>();
+		private static final AtomicLong NEXT_ID = new AtomicLong(1);
+
+		private Custom(MemorySegment ptr) {
+			super(ptr);
+		}
+
+		static Custom create(String name, FullMergeFn fn) {
+			long id = NEXT_ID.getAndIncrement();
+			MemorySegment nameSeg = Arena.global().allocateFrom(name);
+			REGISTRY.put(id, new State(fn, nameSeg));
+			try {
+				MemorySegment statePtr = MemorySegment.ofAddress(id);
+				MemorySegment ptr = (MemorySegment) MH_MERGEOPERATOR_CREATE.invokeExact(
+						statePtr, DESTRUCTOR_STUB, FULL_MERGE_STUB, PARTIAL_MERGE_STUB,
+						MemorySegment.NULL, NAME_STUB);
+				return new Custom(ptr);
+			} catch (Throwable t) {
+				REGISTRY.remove(id);
+				throw RocksDB.wrapInvokeFailure("MergeOperator.custom failed", t);
+			}
+		}
+
+		void applyTo(MemorySegment optionsPtr) {
+			try {
+				MH_SET_MERGE_OPERATOR.invokeExact(optionsPtr, ptr());
+				transferOwnership();
+			} catch (Throwable t) {
+				throw RocksDB.wrapInvokeFailure("MergeOperator.custom applyTo failed", t);
+			}
+		}
+
+		@Override
+		protected void tryClose(MemorySegment ptr) throws Throwable {
+			MH_MERGEOPERATOR_DESTROY.invokeExact(ptr);
+		}
+
+		private static MemorySegment mallocCopy(byte[] data) {
+			try {
+				int len = Math.max(1, data.length);
+				MemorySegment buf = ((MemorySegment) MH_MALLOC.invokeExact((long) len)).reinterpret(len);
+				MemorySegment.copy(data, 0, buf, ValueLayout.JAVA_BYTE, 0, data.length);
+				return buf;
+			} catch (Throwable t) {
+				throw new AssertionError(t);
+			}
+		}
+
+		private static byte[] readBytes(MemorySegment ptr, long len) {
+			if (MemorySegment.NULL.equals(ptr) || len <= 0) {
+				return new byte[0];
+			}
+			byte[] bytes = new byte[(int) len];
+			MemorySegment.copy(ptr.reinterpret(len), ValueLayout.JAVA_BYTE, 0, bytes, 0, (int) len);
+			return bytes;
+		}
+
+		private static List<byte[]> readOperands(MemorySegment operandsList, MemorySegment operandsLen, int numOperands) {
+			List<byte[]> operands = new ArrayList<>(numOperands);
+			if (numOperands == 0) {
+				return operands;
+			}
+			MemorySegment listArr = operandsList.reinterpret(ValueLayout.ADDRESS.byteSize() * numOperands);
+			MemorySegment lenArr = operandsLen.reinterpret(ValueLayout.JAVA_LONG.byteSize() * numOperands);
+			for (int i = 0; i < numOperands; i++) {
+				operands.add(readBytes(listArr.getAtIndex(ValueLayout.ADDRESS, i), lenArr.getAtIndex(ValueLayout.JAVA_LONG, i)));
+			}
+			return operands;
+		}
+
+		/// Called from [#FULL_MERGE_STUB]. Must not throw.
+		private static MemorySegment fullMergeDispatch(MemorySegment state, MemorySegment key, long keyLen,
+				MemorySegment existingValue, long existingValueLen, MemorySegment operandsList,
+				MemorySegment operandsLen, int numOperands, MemorySegment success, MemorySegment newValueLen) {
+			MemorySegment successPtr = success.reinterpret(ValueLayout.JAVA_BYTE.byteSize());
+			MemorySegment newValueLenPtr = newValueLen.reinterpret(ValueLayout.JAVA_LONG.byteSize());
+			try {
+				State s = REGISTRY.get(state.address());
+				byte[] keyBytes = readBytes(key, keyLen);
+				byte[] existing = MemorySegment.NULL.equals(existingValue) ? null : readBytes(existingValue, existingValueLen);
+				List<byte[]> operands = readOperands(operandsList, operandsLen, numOperands);
+				byte[] result = s.fn().fullMerge(keyBytes, existing, operands);
+				successPtr.set(ValueLayout.JAVA_BYTE, 0, (byte) 1);
+				newValueLenPtr.set(ValueLayout.JAVA_LONG, 0, (long) result.length);
+				return mallocCopy(result);
+			} catch (Throwable t) {
+				// must not throw across the upcall boundary — an escaping AssertionError here
+				// (assertions are on by default under Surefire) would abort the JVM, not just
+				// this call, so report failure to RocksDB instead of asserting.
+				t.printStackTrace();
+				successPtr.set(ValueLayout.JAVA_BYTE, 0, (byte) 0);
+				newValueLenPtr.set(ValueLayout.JAVA_LONG, 0, 0L);
+				return mallocCopy(new byte[0]);
+			}
+		}
+
+		/// Called from [#PARTIAL_MERGE_STUB]. Always declines: RocksDB then keeps accumulating
+		/// operands and calls [#fullMergeDispatch] later instead. Must not throw.
+		private static MemorySegment partialMergeDispatch(MemorySegment state, MemorySegment key, long keyLen,
+				MemorySegment operandsList, MemorySegment operandsLen, int numOperands,
+				MemorySegment success, MemorySegment newValueLen) {
+			success.reinterpret(ValueLayout.JAVA_BYTE.byteSize()).set(ValueLayout.JAVA_BYTE, 0, (byte) 0);
+			newValueLen.reinterpret(ValueLayout.JAVA_LONG.byteSize()).set(ValueLayout.JAVA_LONG, 0, 0L);
+			return mallocCopy(new byte[0]);
+		}
+
+		/// Called from [#DESTRUCTOR_STUB] when RocksDB's internal `shared_ptr` refcount hits zero.
+		/// This is the only reliable unregistration point: ownership transfer via [#applyTo] means
+		/// [#tryClose(MemorySegment)] may never run for this instance. Must not throw.
+		private static void destructorDispatch(MemorySegment state) {
+			REGISTRY.remove(state.address());
+		}
+
+		/// Called from [#NAME_STUB]. Must not throw.
+		private static MemorySegment nameDispatch(MemorySegment state) {
+			State s = REGISTRY.get(state.address());
+			return s != null ? s.nameSeg() : MemorySegment.NULL;
+		}
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
@@ -789,6 +789,22 @@ public final class Options extends NativeObject {
 		}
 	}
 
+	/// Attaches a [MergeOperator] so `merge()` calls have a defined semantics for this column
+	/// family. Without one configured, every `merge()` call fails with [RocksDBException].
+	///
+	/// A [MergeOperator.Custom] transfers ownership: its `close()` becomes a no-op afterward.
+	/// [MergeOperator#uint64Add()] holds no native handle and needs no ownership transfer.
+	///
+	/// @param mergeOperator the merge operator to attach
+	/// @return `this` for chaining
+	public Options setMergeOperator(MergeOperator mergeOperator) {
+		switch (mergeOperator) {
+			case MergeOperator.Uint64Add u -> u.applyTo(ptr());
+			case MergeOperator.Custom c -> c.applyTo(ptr());
+		}
+		return this;
+	}
+
 	// -----------------------------------------------------------------------
 	// Temperature options
 	// -----------------------------------------------------------------------

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/MergeOperatorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/MergeOperatorTest.java
@@ -1,0 +1,186 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Covers `merge()` once a [MergeOperator] is actually configured — the counterpart to
+/// `MergeTest`, which documents the no-operator-configured (always throws) default.
+class MergeOperatorTest {
+
+	// -----------------------------------------------------------------------
+	// uint64Add
+	// -----------------------------------------------------------------------
+
+	@Test
+	void uint64Add_sumsOperandsIntoAFreshKey(@TempDir Path dir) throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+			db.merge("views".getBytes(), encodeUint64(1));
+			db.merge("views".getBytes(), encodeUint64(1));
+			db.merge("views".getBytes(), encodeUint64(3));
+
+			// When
+			long total = decodeUint64(db.get("views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(5);
+		}
+	}
+
+	@Test
+	void uint64Add_addsOnTopOfAnExistingPutValue(@TempDir Path dir) throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+			db.put("views".getBytes(), encodeUint64(10));
+			db.merge("views".getBytes(), encodeUint64(5));
+
+			// When
+			long total = decodeUint64(db.get("views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(15);
+		}
+	}
+
+	private static byte[] encodeUint64(long value) {
+		return ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array();
+	}
+
+	private static long decodeUint64(byte[] bytes) {
+		return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getLong();
+	}
+
+	// -----------------------------------------------------------------------
+	// custom — StringMax / StringMin, built on MergeOperator.custom(...)
+	// -----------------------------------------------------------------------
+
+	private static final MergeOperator.FullMergeFn STRING_MAX = (key, existingValue, operands) -> {
+		byte[] max = existingValue;
+		for (byte[] operand : operands) {
+			if (max == null || Arrays.compare(operand, max) > 0) {
+				max = operand;
+			}
+		}
+		return max;
+	};
+
+	private static final MergeOperator.FullMergeFn STRING_MIN = (key, existingValue, operands) -> {
+		byte[] min = existingValue;
+		for (byte[] operand : operands) {
+			if (min == null || Arrays.compare(operand, min) < 0) {
+				min = operand;
+			}
+		}
+		return min;
+	};
+
+	@Test
+	void custom_stringMax_keepsTheLargestOperand(@TempDir Path dir) throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.custom("string-max", STRING_MAX));
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+			db.merge("high-score".getBytes(), "b".getBytes());
+			db.merge("high-score".getBytes(), "z".getBytes());
+			db.merge("high-score".getBytes(), "m".getBytes());
+
+			// When
+			String result = new String(db.get("high-score".getBytes()), StandardCharsets.UTF_8);
+
+			// Then
+			assertThat(result).isEqualTo("z");
+		}
+	}
+
+	@Test
+	void custom_stringMin_keepsTheSmallestOperand(@TempDir Path dir) throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.custom("string-min", STRING_MIN));
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+			db.merge("low-score".getBytes(), "b".getBytes());
+			db.merge("low-score".getBytes(), "z".getBytes());
+			db.merge("low-score".getBytes(), "m".getBytes());
+
+			// When
+			String result = new String(db.get("low-score".getBytes()), StandardCharsets.UTF_8);
+
+			// Then
+			assertThat(result).isEqualTo("b");
+		}
+	}
+
+	@Test
+	void custom_fullMergeFn_seesTheExistingPutValue(@TempDir Path dir) throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.custom("string-max", STRING_MAX));
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+			db.put("high-score".getBytes(), "z".getBytes());
+			db.merge("high-score".getBytes(), "a".getBytes());
+
+			// When
+			String result = new String(db.get("high-score".getBytes()), StandardCharsets.UTF_8);
+
+			// Then
+			assertThat(result).isEqualTo("z");
+		}
+	}
+
+	@Test
+	void custom_fullMergeFn_seesOperandsOldestFirst(@TempDir Path dir) throws RocksDBException {
+		// Given
+		var seen = new java.util.concurrent.atomic.AtomicReference<List<byte[]>>();
+		MergeOperator.FullMergeFn capturing = (key, existingValue, operands) -> {
+			seen.set(operands);
+			return operands.get(operands.size() - 1);
+		};
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.custom("capturing", capturing));
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+			db.merge("k".getBytes(), "1".getBytes());
+			db.merge("k".getBytes(), "2".getBytes());
+			db.merge("k".getBytes(), "3".getBytes());
+
+			// When
+			db.get("k".getBytes());
+
+			// Then
+			assertThat(seen.get()).extracting(b -> new String(b, StandardCharsets.UTF_8))
+					.containsExactly("1", "2", "3");
+		}
+	}
+
+	@Test
+	void custom_fullMergeFn_thatThrows_surfacesAsRocksDBException(@TempDir Path dir) {
+		// Given
+		MergeOperator.FullMergeFn throwing = (key, existingValue, operands) -> {
+			throw new RuntimeException("boom");
+		};
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.custom("throwing", throwing));
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+			db.merge("k".getBytes(), "v".getBytes());
+
+			// When
+			var thrown = assertThatThrownBy(() -> db.get("k".getBytes()));
+
+			// Then
+			thrown.isInstanceOf(RocksDBException.class);
+		}
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/MergeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/MergeTest.java
@@ -12,13 +12,15 @@ import java.time.Duration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/// Covers `merge()` across every write-capable type. This library does not yet wrap
-/// `rocksdb_mergeoperator_create` (see `docs/c-api-gaps.md`), so no test here can configure a
-/// merge operator — every direct `merge()` call is expected to surface RocksDB's own
+/// Covers `merge()` across every write-capable type when no [MergeOperator] is configured — the
+/// default state for any [Options] that never calls `setMergeOperator`. Every direct `merge()`
+/// call is expected to surface RocksDB's own
 /// `Status::InvalidArgument("Merge requires ColumnFamilyOptions::merge_operator != nullptr")`
 /// as a [RocksDBException], confirmed against `rocksdb/db/write_batch.cc`'s
 /// `MemTableInserter::Merge`. `Transaction` and `WriteBatch` only queue a merge record and don't
 /// touch the memtable until `commit()`/`write()`, so those two throw later than the others.
+/// For the configured-operator case (merges that actually merge something), see
+/// `MergeOperatorTest`.
 class MergeTest {
 
 	// -----------------------------------------------------------------------

--- a/docs/c-api-gaps.md
+++ b/docs/c-api-gaps.md
@@ -20,7 +20,6 @@ rocksdbffm wraps `rocksdb/c.h` — the official RocksDB C API — not C++ direct
 | CompactionFilter | `rocksdb_compactionfilter_create()`, `rocksdb_compactionfilterfactory_create()` | High | Callback-based; enables custom retention/deletion policies during compaction |
 | EventListener | `rocksdb_eventlistener_create()` (~12 callbacks) | High | Flush, compaction, file creation/deletion events; needed for monitoring |
 | Custom Comparator | `rocksdb_comparator_create()`, `rocksdb_comparator_with_ts_create()` | High | Custom key ordering; note: key shortening not exposed in C API |
-| Custom MergeOperator | `rocksdb_mergeoperator_create()` | Medium | C API exists; no Java side yet. The `merge()` write op itself is implemented (see [reference.md#feature-status](reference.md#feature-status)), but every call fails with `RocksDBException` until a merge operator can be configured — that requires wrapping `full_merge`/`partial_merge`/`delete_value`/`name` FFM upcalls, same class of work as `CompactionFilter`/`EventListener` |
 | JemallocNodumpAllocator | `rocksdb_jemalloc_nodump_allocator_create()` | Medium | Jemalloc allocator for caches; avoids coredump leaking sensitive data |
 | CuckooTable options | `rocksdb_cuckoo_table_options_t` + setters | Medium | Hash-based SST format; efficient for fixed-size keys |
 | Advanced memtable config | Various `rocksdb_options_set_*` memtable setters | Low | SkipList tuning, hash-memtable variants |

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -14,6 +14,7 @@ Every snippet omits imports; all types live in `io.github.dfa1.rocksdbffm`.
 - [Read a consistent point-in-time view](#read-a-consistent-point-in-time-view)
 - [Scan a key range](#scan-a-key-range)
 - [Delete a range of keys](#delete-a-range-of-keys)
+- [Merge values without a read-modify-write](#merge-values-without-a-read-modify-write)
 - [Run a pessimistic transaction](#run-a-pessimistic-transaction)
 - [Run an optimistic transaction](#run-an-optimistic-transaction)
 - [Expire keys automatically](#expire-keys-automatically)
@@ -217,6 +218,71 @@ try (var batch = WriteBatch.create()) {
 	db.write(batch);
 }
 ```
+
+## Merge values without a read-modify-write
+
+`merge(key, operand)` queues an operand for `key` instead of overwriting it. RocksDB folds the
+base value and all queued operands together — lazily, whenever the merged value is actually
+needed (`get()`, flush, compaction) — using a `MergeOperator` you attach via
+`Options.setMergeOperator`. Without one attached, every `merge()` call fails with
+`RocksDBException`.
+
+For counters, use the built-in operator: it sums 8-byte little-endian `uint64` operands, entirely
+on the native side.
+
+```java
+try (var opts = Options.newOptions().setCreateIfMissing(true)
+            .setMergeOperator(MergeOperator.uint64Add());
+     var db = RocksDB.openReadWrite(opts, dbPath)) {
+
+	db.merge("page-views".getBytes(), encodeUint64(1));
+	db.merge("page-views".getBytes(), encodeUint64(1));
+	db.merge("page-views".getBytes(), encodeUint64(3));
+
+	long total = decodeUint64(db.get("page-views".getBytes()));   // 5, no read-modify-write
+}
+```
+
+```java
+static byte[] encodeUint64(long value) {
+	return ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(value).array();
+}
+
+static long decodeUint64(byte[] bytes) {
+	return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getLong();
+}
+```
+
+For anything else, `MergeOperator.custom(name, fn)` wires a Java `FullMergeFn` through RocksDB's
+callback-based merge operator. `fn` may run on RocksDB's own background threads (flush,
+compaction), so it must be thread-safe and must not throw:
+
+```java
+MergeOperator.FullMergeFn keepMax = (key, existingValue, operands) -> {
+	byte[] max = existingValue;
+	for (byte[] operand : operands) {
+		if (max == null || Arrays.compare(operand, max) > 0) {
+			max = operand;
+		}
+	}
+	return max;
+};
+
+try (var opts = Options.newOptions().setCreateIfMissing(true)
+            .setMergeOperator(MergeOperator.custom("string-max", keepMax));
+     var db = RocksDB.openReadWrite(opts, dbPath)) {
+
+	db.merge("high-score".getBytes(), "17".getBytes());
+	db.merge("high-score".getBytes(), "42".getBytes());
+	db.merge("high-score".getBytes(), "9".getBytes());
+
+	byte[] best = db.get("high-score".getBytes());   // "42"
+}
+```
+
+A `MergeOperator` is attached once per column family at `Options`-configuration time — every
+`merge()` on that column family shares the same interpretation of what merging means, so keep
+different kinds of merge semantics (a counter vs. a max-tracker) in separate column families.
 
 ## Run a pessimistic transaction
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -380,8 +380,8 @@ Parity tracking against `rocksdbjni`. ✅ implemented · 🚧 partial · ❌ not
 | Perf context               |   ✅    | `PerfContext`, `PerfLevel`, `PerfMetric`                                                    |
 | Background jobs            |   🚧    | `cancelAllBackgroundWork`, manual-compaction toggles, `waitForCompact`; Options-level tuning (FIFO/Universal) pending |
 | MultiGet                   |   ❌    | `rocksdb_multi_get()` exists in the C API; no Java wrapper yet                              |
-| Merge                      |   🚧    | `merge()` write op on all 7 write-capable types (byte[]/ByteBuffer/MemorySegment, CF variants), see [#8](https://github.com/dfa1/rocksdbffm/issues/8); no merge operator can be configured yet, so calls fail with `RocksDBException` until custom `MergeOperator` support lands |
-| MergeOperator               |   ❌    | `rocksdb_mergeoperator_create()` (custom `full_merge`/`partial_merge` callbacks) not wrapped; see [c-api-gaps.md](c-api-gaps.md) |
+| Merge                      |   ✅    | `merge()` write op on all 7 write-capable types (byte[]/ByteBuffer/MemorySegment, CF variants), see [#8](https://github.com/dfa1/rocksdbffm/issues/8); requires a `MergeOperator` configured via `Options.setMergeOperator`, else calls fail with `RocksDBException` |
+| MergeOperator               |   ✅    | `MergeOperator.uint64Add()` (built-in `rocksdb_options_set_uint64add_merge_operator`) and `MergeOperator.custom(String, FullMergeFn)` (`rocksdb_mergeoperator_create()` — `full_merge` implemented in Java, `partial_merge` always declines) |
 | CompactionFilter           |   ❌    | Callback-based custom compaction logic                                                      |
 | Custom comparators         |   ❌    | `rocksdb_comparator_create()` exists in the C API                                           |
 | Advanced column family     |   ❌    | Per-CF compaction style, level multipliers                                                  |


### PR DESCRIPTION
## Summary

Stacked on #92 — configures a merge operator so `merge()` actually merges instead of always throwing `RocksDBException`.

- `MergeOperator.uint64Add()` wraps `rocksdb_options_set_uint64add_merge_operator`: a single native call, no callback involved, sums 8-byte little-endian `uint64` operands.
- `MergeOperator.custom(name, FullMergeFn)` wraps the general `rocksdb_mergeoperator_create` callback path: `full_merge` runs a Java-supplied function (potentially from RocksDB's background threads), `partial_merge` always declines so RocksDB keeps accumulating operands and calls `full_merge` later, and the returned buffer is `malloc`'d from Java and freed by RocksDB's own `free()` (`delete_value` left `NULL`).
- `Options` gains a single `setMergeOperator(MergeOperator)` method that pattern-matches the sealed type — all native handles and upcall plumbing live in `MergeOperator.java` instead of accumulating a setter per operator variant on `Options`.
- Ownership: `rocksdb_options_set_merge_operator` immediately wraps the raw pointer in a `shared_ptr`, so `Custom.applyTo` calls `transferOwnership()` right after, matching the `FilterPolicy → BlockBasedTableOptions` pattern. The registry entry unregisters from the native `destructor` callback rather than Java `close()`, since the `shared_ptr` can outlive the Java wrapper.
- Docs: `c-api-gaps.md` drops the now-closed Custom MergeOperator gap, `reference.md` flips Merge/MergeOperator to done, `how-to.md` gets a new "Merge values without a read-modify-write" section with both examples (compiled against `core` to verify).

## Test plan

- [x] `./mvnw test -pl core -am` — full suite passes, including the malloc/free-across-the-JVM-boundary path and the exception-safety test (`FullMergeFn` throwing surfaces as `RocksDBException`, not a JVM crash)
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] Both new `how-to.md` snippets compile against `core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)