### PR TITLE
refactor: merge()'s byte[]/ByteBuffer tiers delegate to MemorySegment

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -838,15 +838,9 @@ public final class RocksDB {
 
 	/// byte[] merge using the caller's arena.
 	static void mergeBytes(Arena arena, MemorySegment db, MemorySegment writeOpts, byte[] key, byte[] value) {
-		try {
-			MemorySegment err = errHolder(arena);
-			MemorySegment k = toNative(arena, key);
-			MemorySegment v = toNative(arena, value);
-			MH_MERGE.invokeExact(db, writeOpts, k, (long) key.length, v, (long) value.length, err);
-			checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("merge failed", t);
-		}
+		MemorySegment k = toNative(arena, key);
+		MemorySegment v = toNative(arena, value);
+		mergeSegment(arena, db, writeOpts, k, (long) key.length, v, (long) value.length);
 	}
 
 	/// MemorySegment merge — zero-copy, caller supplies pre-allocated native segments.
@@ -1573,15 +1567,9 @@ public final class RocksDB {
 	/// byte[] merge with explicit column family using the caller's arena.
 	static void mergeCfBytes(Arena arena, MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
 	                         byte[] key, byte[] value) {
-		try {
-			MemorySegment err = errHolder(arena);
-			MH_MERGE_CF.invokeExact(db, writeOpts, cf.ptr(),
-					toNative(arena, key), (long) key.length,
-					toNative(arena, value), (long) value.length, err);
-			checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("merge failed", t);
-		}
+		MemorySegment k = toNative(arena, key);
+		MemorySegment v = toNative(arena, value);
+		mergeCfSegment(arena, db, writeOpts, cf, k, (long) key.length, v, (long) value.length);
 	}
 
 	/// MemorySegment merge with explicit column family — zero-copy.

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -247,13 +247,7 @@ public final class Transaction extends NativeObject {
 	/// @param value the merge operand
 	public void merge(byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = RocksDB.errHolder(arena);
-			MemorySegment k = RocksDB.toNative(arena, key);
-			MemorySegment v = RocksDB.toNative(arena, value);
-			MH_MERGE.invokeExact(ptr(), k, (long) key.length, v, (long) value.length, err);
-			RocksDB.checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+			merge(arena, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
 		}
 	}
 
@@ -263,13 +257,7 @@ public final class Transaction extends NativeObject {
 	/// @param value direct [ByteBuffer] containing the merge operand
 	public void merge(ByteBuffer key, ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = RocksDB.errHolder(arena);
-			MH_MERGE.invokeExact(ptr(),
-					MemorySegment.ofBuffer(key), (long) key.remaining(),
-					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
-			RocksDB.checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+			merge(arena, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
 		}
 	}
 
@@ -279,6 +267,13 @@ public final class Transaction extends NativeObject {
 	/// @param value native segment containing the merge operand
 	public void merge(MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, key, value);
+		}
+	}
+
+	/// Merge core using the caller's arena — every tier above builds its segments then delegates here.
+	private void merge(Arena arena, MemorySegment key, MemorySegment value) {
+		try {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MH_MERGE.invokeExact(ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
@@ -588,13 +583,7 @@ public final class Transaction extends NativeObject {
 	/// @param value the merge operand
 	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = RocksDB.errHolder(arena);
-			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
-					RocksDB.toNative(arena, key), (long) key.length,
-					RocksDB.toNative(arena, value), (long) value.length, err);
-			RocksDB.checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+			merge(arena, cf, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
 		}
 	}
 
@@ -605,13 +594,7 @@ public final class Transaction extends NativeObject {
 	/// @param value direct [ByteBuffer] containing the merge operand
 	public void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = RocksDB.errHolder(arena);
-			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
-					MemorySegment.ofBuffer(key), (long) key.remaining(),
-					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
-			RocksDB.checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("Native call failed", t);
+			merge(arena, cf, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
 		}
 	}
 
@@ -622,6 +605,13 @@ public final class Transaction extends NativeObject {
 	/// @param value native segment containing the merge operand
 	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, cf, key, value);
+		}
+	}
+
+	/// Merge-into-cf core using the caller's arena — every tier above delegates here.
+	private void merge(Arena arena, ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		try {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -313,13 +313,7 @@ public final class TransactionDB extends NativeObject {
 	/// @param value the merge operand
 	public void merge(byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = RocksDB.errHolder(arena);
-			MemorySegment k = RocksDB.toNative(arena, key);
-			MemorySegment v = RocksDB.toNative(arena, value);
-			MH_MERGE.invokeExact(ptr(), writeOpts.ptr(), k, (long) key.length, v, (long) value.length, err);
-			RocksDB.checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("merge failed", t);
+			merge(arena, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
 		}
 	}
 
@@ -329,14 +323,7 @@ public final class TransactionDB extends NativeObject {
 	/// @param value direct [java.nio.ByteBuffer] containing the merge operand
 	public void merge(java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = RocksDB.errHolder(arena);
-			MH_MERGE.invokeExact(ptr(), writeOpts.ptr(),
-					MemorySegment.ofBuffer(key), (long) key.remaining(),
-					MemorySegment.ofBuffer(value), (long) value.remaining(),
-					err);
-			RocksDB.checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("merge failed", t);
+			merge(arena, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
 		}
 	}
 
@@ -346,6 +333,13 @@ public final class TransactionDB extends NativeObject {
 	/// @param value native segment containing the merge operand
 	public void merge(MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, key, value);
+		}
+	}
+
+	/// Merge core using the caller's arena — every tier above builds its segments then delegates here.
+	private void merge(Arena arena, MemorySegment key, MemorySegment value) {
+		try {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MH_MERGE.invokeExact(ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
@@ -666,13 +660,7 @@ public final class TransactionDB extends NativeObject {
 	/// @param value the merge operand
 	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = RocksDB.errHolder(arena);
-			MH_MERGE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
-					RocksDB.toNative(arena, key), (long) key.length,
-					RocksDB.toNative(arena, value), (long) value.length, err);
-			RocksDB.checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("merge failed", t);
+			merge(arena, cf, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
 		}
 	}
 
@@ -683,13 +671,7 @@ public final class TransactionDB extends NativeObject {
 	/// @param value direct [java.nio.ByteBuffer] containing the merge operand
 	public void merge(ColumnFamilyHandle cf, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment err = RocksDB.errHolder(arena);
-			MH_MERGE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
-					MemorySegment.ofBuffer(key), (long) key.remaining(),
-					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
-			RocksDB.checkError(err);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("merge failed", t);
+			merge(arena, cf, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
 		}
 	}
 
@@ -700,6 +682,13 @@ public final class TransactionDB extends NativeObject {
 	/// @param value native segment containing the merge operand
 	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, cf, key, value);
+		}
+	}
+
+	/// Merge-into-cf core using the caller's arena — every tier above delegates here.
+	private void merge(Arena arena, ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		try {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MH_MERGE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
 					key, key.byteSize(), value, value.byteSize(), err);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WriteBatch.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WriteBatch.java
@@ -182,13 +182,7 @@ public final class WriteBatch extends NativeObject {
 	/// @param key   the key to merge into
 	/// @param value the merge operand
 	public void merge(Arena arena, byte[] key, byte[] value) {
-		try {
-			MemorySegment k = RocksDB.toNative(arena, key);
-			MemorySegment v = RocksDB.toNative(arena, value);
-			MH_MERGE.invokeExact(ptr(), k, (long) key.length, v, (long) value.length);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("writebatch merge failed", t);
-		}
+		merge(RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
 	}
 
 	/// Queues a merge operand. Slow path: copies key/value into native memory.
@@ -197,11 +191,7 @@ public final class WriteBatch extends NativeObject {
 	/// @param value the merge operand
 	public void merge(byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MemorySegment k = RocksDB.toNative(arena, key);
-			MemorySegment v = RocksDB.toNative(arena, value);
-			MH_MERGE.invokeExact(ptr(), k, (long) key.length, v, (long) value.length);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("writebatch merge failed", t);
+			merge(arena, key, value);
 		}
 	}
 
@@ -210,13 +200,7 @@ public final class WriteBatch extends NativeObject {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the merge operand
 	public void merge(ByteBuffer key, ByteBuffer value) {
-		try {
-			MH_MERGE.invokeExact(ptr(),
-					MemorySegment.ofBuffer(key), (long) key.remaining(),
-					MemorySegment.ofBuffer(value), (long) value.remaining());
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("writebatch merge failed", t);
-		}
+		merge(MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
 	}
 
 	/// Queues a merge operand. Zero-copy for [MemorySegment]s.
@@ -362,11 +346,7 @@ public final class WriteBatch extends NativeObject {
 	/// @param value the merge operand
 	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
-					RocksDB.toNative(arena, key), (long) key.length,
-					RocksDB.toNative(arena, value), (long) value.length);
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("writebatch merge_cf failed", t);
+			merge(cf, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
 		}
 	}
 
@@ -376,13 +356,7 @@ public final class WriteBatch extends NativeObject {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the merge operand
 	public void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
-		try {
-			MH_MERGE_CF.invokeExact(ptr(), cf.ptr(),
-					MemorySegment.ofBuffer(key), (long) key.remaining(),
-					MemorySegment.ofBuffer(value), (long) value.remaining());
-		} catch (Throwable t) {
-			throw RocksDB.wrapInvokeFailure("writebatch merge_cf failed", t);
-		}
+		merge(cf, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
 	}
 
 	/// Queues a merge operand into `cf`. Zero-copy for [MemorySegment]s.


### PR DESCRIPTION
## Summary

Closes the merge()-shaped slice of #71: every byte[]/ByteBuffer merge tier duplicated the MemorySegment tier's `invokeExact`/`checkError` logic instead of building a segment and calling it. Pure internal delegation, no public API or behavior change.

- `RocksDB.mergeBytes`/`mergeCfBytes` (Arena-taking cores) now build segments and call `mergeSegment`/`mergeCfSegment` instead of duplicating the native call.
- `WriteBatch.merge` (byte[]/ByteBuffer, plus CF variants) has no `errHolder`/`checkError` at all, so these just build/wrap a segment and call the existing `MemorySegment` overload directly.
- `TransactionDB`/`Transaction` had no `Arena`-taking core to delegate to (unlike `ReadWriteDB`/`TtlDB`/`BlobDB`, which already got one for merge). Added a package-private `merge(Arena, ...)` core to each (plus CF); the public byte[]/ByteBuffer/MemorySegment tiers all delegate to it. Exactly one `Arena.ofConfined()` per top-level call either way, same as before.

The broader put/delete/get scope of #71 (including the `CopyResult` breaking change for `get`/`getForUpdate`) is **not** in this PR — #71 itself was closed rather than narrowed; reopen/refile if that work is picked up later.

## Test plan

- [x] \`./mvnw test -pl core -am\` — full suite green, no test assertions needed changing (behavior-preserving)
- [x] \`./mvnw javadoc:javadoc -pl core\` — zero output

🤖 Generated with [Claude Code](https://claude.com/claude-code)