### PR TITLE
fix: use dedicated AssertJ assertions (Sonar java:S5838)

### DIFF
--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BlobDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BlobDBTest.java
@@ -421,8 +421,7 @@ class BlobDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("v".getBytes());
+			assertThat(result).contains("v".getBytes());
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyTest.java
@@ -153,7 +153,7 @@ class ColumnFamilyTest {
 			int id = handles.get(0).getId();
 
 			// Then
-			assertThat(id).isEqualTo(0);
+			assertThat(id).isZero();
 			handles.forEach(ColumnFamilyHandle::close);
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/MemorySizeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/MemorySizeTest.java
@@ -82,17 +82,17 @@ class MemorySizeTest {
 	void compareTo_ordersCorrectly() {
 		assertThat(MemorySize.ofKB(1)).isLessThan(MemorySize.ofMB(1));
 		assertThat(MemorySize.ofGB(1)).isGreaterThan(MemorySize.ofMB(1));
-		assertThat(MemorySize.ofMB(1).compareTo(MemorySize.ofKB(1024))).isZero();
+		assertThat(MemorySize.ofMB(1)).isEqualByComparingTo(MemorySize.ofKB(1024));
 	}
 
 	@Test
 	void toString_showsLargestEvenUnit() {
-		assertThat(MemorySize.ofGB(1).toString()).isEqualTo("1 GB");
-		assertThat(MemorySize.ofMB(64).toString()).isEqualTo("64 MB");
-		assertThat(MemorySize.ofKB(16).toString()).isEqualTo("16 KB");
-		assertThat(MemorySize.ofBytes(100).toString()).isEqualTo("100 B");
-		assertThat(MemorySize.ZERO.toString()).isEqualTo("0 B");
+		assertThat(MemorySize.ofGB(1)).hasToString("1 GB");
+		assertThat(MemorySize.ofMB(64)).hasToString("64 MB");
+		assertThat(MemorySize.ofKB(16)).hasToString("16 KB");
+		assertThat(MemorySize.ofBytes(100)).hasToString("100 B");
+		assertThat(MemorySize.ZERO).hasToString("0 B");
 		// 1536 = 1.5 KB — not evenly divisible by KB
-		assertThat(MemorySize.ofBytes(1536).toString()).isEqualTo("1536 B");
+		assertThat(MemorySize.ofBytes(1536)).hasToString("1536 B");
 	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
@@ -775,8 +775,7 @@ class OptimisticTransactionDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("v".getBytes());
+			assertThat(result).contains("v".getBytes());
 		}
 	}
 
@@ -810,8 +809,7 @@ class OptimisticTransactionDBTest {
 			var result = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("v".getBytes());
+			assertThat(result).contains("v".getBytes());
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PinnedGetTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PinnedGetTest.java
@@ -33,8 +33,7 @@ class PinnedGetTest {
 				var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then
-				assertThat(result).isPresent();
-				assertThat(result.get()).isEqualTo("v".getBytes());
+				assertThat(result).contains("v".getBytes());
 			}
 		}
 	}
@@ -173,8 +172,7 @@ class PinnedGetTest {
 				// And a later, independent call still succeeds — proving the handle and
 				// arena from the failed call were destroyed/closed rather than leaked
 				var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
-				assertThat(result).isPresent();
-				assertThat(result.get()).isEqualTo("v".getBytes());
+				assertThat(result).contains("v".getBytes());
 			}
 		}
 	}
@@ -220,8 +218,7 @@ class PinnedGetTest {
 				var result = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then
-				assertThat(result).isPresent();
-				assertThat(result.get()).isEqualTo("v".getBytes());
+				assertThat(result).contains("v".getBytes());
 			}
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
@@ -183,8 +183,7 @@ class ReadOnlyDBTest {
 			var result = ro.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("value".getBytes());
+			assertThat(result).contains("value".getBytes());
 		}
 	}
 
@@ -227,8 +226,7 @@ class ReadOnlyDBTest {
 			var result = ro.get(cf1, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("value".getBytes());
+			assertThat(result).contains("value".getBytes());
 
 			handles.forEach(ColumnFamilyHandle::close);
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
@@ -302,8 +302,7 @@ class SecondaryDBTest {
 			var result = secondary.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("v".getBytes());
+			assertThat(result).contains("v".getBytes());
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
@@ -118,8 +118,7 @@ class TransactionDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("v".getBytes());
+			assertThat(result).contains("v".getBytes());
 		}
 	}
 
@@ -153,8 +152,7 @@ class TransactionDBTest {
 			var result = txn.get(ro, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("v".getBytes());
+			assertThat(result).contains("v".getBytes());
 			txn.commit();
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
@@ -1118,8 +1118,7 @@ class TtlDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isPresent();
-			assertThat(result.get()).isEqualTo("v".getBytes());
+			assertThat(result).contains("v".getBytes());
 		}
 	}
 

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/BlobDBIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/BlobDBIntegrationTest.java
@@ -88,7 +88,7 @@ class BlobDBIntegrationTest {
 			assertThat(enableBlobGc).isTrue();
 			assertThat(blobGcAgeCutoff).isEqualTo(Ratio.of(0.25));
 			assertThat(blobGcForceThreshold).isEqualTo(Ratio.of(0.8));
-			assertThat(blobFileStartingLevel).isEqualTo(0);
+			assertThat(blobFileStartingLevel).isZero();
 
 			try (var db = RocksDB.openBlob(opts, dir)) {
 				db.put("k".getBytes(), VALUE_64KB);

--- a/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyIntegrationTest.java
+++ b/integration-tests/src/test/java/io/github/dfa1/rocksdbffm/ColumnFamilyIntegrationTest.java
@@ -254,7 +254,7 @@ class ColumnFamilyIntegrationTest {
 			// Then — memtable should be empty (or reduced) after flush
 			var entries = db.getLongProperty(cf, Property.NUM_ENTRIES_ACTIVE_MEM_TABLE);
 			assertThat(entries).isPresent();
-			assertThat(entries.getAsLong()).isEqualTo(0L);
+			assertThat(entries.getAsLong()).isZero();
 		}
 	}
 


### PR DESCRIPTION
## Summary
- 22 SonarCloud `java:S5838` findings — assertions that manually re-derive what a dedicated AssertJ method already expresses, losing readable failure messages (and, for the Optional case, correctness) in the process:
  - `assertThat(optional).isPresent(); assertThat(optional.get()).isEqualTo(x);` → `assertThat(optional).contains(x)`. Calling `.get()` in the follow-up assertion defeats the purpose of `Optional` — if the value goes missing, the test now throws `NoSuchElementException` instead of failing with a clear assertion message.
  - `assertThat(x).isEqualTo(0)` on a numeric type → `assertThat(x).isZero()`.
  - `assertThat(x.toString()).isEqualTo(s)` → `assertThat(x).hasToString(s)`; `assertThat(a.compareTo(b)).isZero()` → `assertThat(a).isEqualByComparingTo(b)`. Both let AssertJ report the actual object in the failure message instead of just the extracted string/int.

## Test plan
- [x] `./mvnw test` passes clean across all modules (core, integration-tests)