### PR TITLE
fix: guard base-DB pointer against use-after-close in Transaction(Optimistic)DB

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObjectWithBaseDb.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObjectWithBaseDb.java
@@ -1,0 +1,66 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.MemorySegment;
+
+/// Base class for native wrappers that additionally hold a second native pointer: the
+/// `rocksdb_t*` "base DB" obtained via `rocksdb_transactiondb_get_base_db` /
+/// `rocksdb_optimistictransactiondb_get_base_db`, used directly by some operations instead of
+/// the primary handle [NativeObject] manages.
+///
+/// Per `rocksdb/db/c.cc`, each `get_base_db` call heap-allocates a small `rocksdb_t` wrapper
+/// struct (`{ DB* rep; }`) around the already-owned database object — a distinct allocation
+/// from the database itself. [#tryCloseBaseDb(MemorySegment)] frees only that wrapper,
+/// best-effort (a failure there does not prevent the primary pointer from still being closed);
+/// it neither destroys nor can destroy the real database object, which the primary handle's own
+/// close ([#tryClosePrimary(MemorySegment)], run afterward) already owns and destroys.
+///
+/// The base DB pointer is private to this class — subclasses have no name for it, so they
+/// cannot accidentally read it unchecked. The only access is [#dbPtr()], which calls [#ptr()]
+/// first and therefore throws [IllegalStateException] once this object is closed, the same way
+/// every other native call on this object already does.
+abstract class NativeObjectWithBaseDb extends NativeObject {
+
+	private final MemorySegment baseDb;
+
+	protected NativeObjectWithBaseDb(MemorySegment ptr, MemorySegment baseDb) {
+		super(ptr);
+		this.baseDb = baseDb;
+	}
+
+	/// Returns the base `rocksdb_t*` pointer, after checking (via [#ptr()]) that this object
+	/// has not been closed.
+	///
+	/// @return the base DB pointer
+	/// @throws IllegalStateException if this object has been closed
+	protected final MemorySegment dbPtr() {
+		ptr();
+		return baseDb;
+	}
+
+	@Override
+	protected final void tryClose(MemorySegment ptr) throws Throwable {
+		try {
+			tryCloseBaseDb(baseDb);
+		} catch (Throwable t) {
+			// best-effort: still attempt to close the primary pointer below
+		}
+		tryClosePrimary(ptr);
+	}
+
+	/// Frees the small `rocksdb_t` wrapper struct that [#dbPtr()] returns, for subclasses whose
+	/// C API exposes a matching close call (e.g. `rocksdb_optimistictransactiondb_close_base_db`).
+	/// This does not touch the underlying database object itself — only
+	/// [#tryClosePrimary(MemorySegment)] does that, via its own teardown. Default: no-op.
+	///
+	/// @param baseDb the base DB pointer to release
+	/// @throws Throwable if the native destroy call fails
+	protected void tryCloseBaseDb(MemorySegment baseDb) throws Throwable {
+		// no separate close needed by default
+	}
+
+	/// Closes the primary native pointer. Same contract as [NativeObject#tryClose(MemorySegment)].
+	///
+	/// @param ptr the non-NULL primary native pointer to release
+	/// @throws Throwable if the native destroy call fails
+	protected abstract void tryClosePrimary(MemorySegment ptr) throws Throwable;
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDB.java
@@ -27,7 +27,7 @@ import java.util.OptionalLong;
 ///     }
 /// }
 /// ```
-public final class OptimisticTransactionDB extends NativeObject {
+public final class OptimisticTransactionDB extends NativeObjectWithBaseDb {
 
 	// -----------------------------------------------------------------------
 	// Method handles unique to OptimisticTransactionDB
@@ -57,13 +57,11 @@ public final class OptimisticTransactionDB extends NativeObject {
 	// Instance state
 	// -----------------------------------------------------------------------
 
-	private final MemorySegment baseDb;    // rocksdb_t* — for direct ops via shared helpers
 	private final WriteOptions writeOpts;
 	private final ReadOptions readOpts;
 
 	OptimisticTransactionDB(MemorySegment ptr, MemorySegment baseDb) {
-		super(ptr);
-		this.baseDb = baseDb;
+		super(ptr, baseDb);
 		this.writeOpts = RocksDB.DEFAULT_WRITE_OPTIONS;
 		this.readOpts = RocksDB.DEFAULT_READ_OPTIONS;
 	}
@@ -108,7 +106,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   key bytes
 	/// @param value value bytes
 	public void put(byte[] key, byte[] value) {
-		RocksDB.putBytes(baseDb, writeOpts.ptr(), key, value);
+		RocksDB.putBytes(dbPtr(), writeOpts.ptr(), key, value);
 	}
 
 	/// Zero-copy put: wraps the direct buffers' native memory without heap→native copy.
@@ -116,7 +114,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the value
 	public void put(ByteBuffer key, ByteBuffer value) {
-		RocksDB.putSegment(baseDb, writeOpts.ptr(),
+		RocksDB.putSegment(dbPtr(), writeOpts.ptr(),
 				MemorySegment.ofBuffer(key), key.remaining(),
 				MemorySegment.ofBuffer(value), value.remaining());
 	}
@@ -126,7 +124,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	public void put(MemorySegment key, MemorySegment value) {
-		RocksDB.putSegment(baseDb, writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
+		RocksDB.putSegment(dbPtr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -139,7 +137,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   the key to merge into
 	/// @param value the merge operand
 	public void merge(byte[] key, byte[] value) {
-		RocksDB.mergeBytes(baseDb, writeOpts.ptr(), key, value);
+		RocksDB.mergeBytes(dbPtr(), writeOpts.ptr(), key, value);
 	}
 
 	/// Zero-copy merge: wraps the direct buffers' native memory without heap→native copy.
@@ -147,7 +145,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the merge operand
 	public void merge(ByteBuffer key, ByteBuffer value) {
-		RocksDB.mergeSegment(baseDb, writeOpts.ptr(),
+		RocksDB.mergeSegment(dbPtr(), writeOpts.ptr(),
 				MemorySegment.ofBuffer(key), key.remaining(),
 				MemorySegment.ofBuffer(value), value.remaining());
 	}
@@ -157,7 +155,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	public void merge(MemorySegment key, MemorySegment value) {
-		RocksDB.mergeSegment(baseDb, writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
+		RocksDB.mergeSegment(dbPtr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -170,7 +168,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key key bytes to look up
 	/// @return value bytes, or `null` if the key does not exist
 	public byte[] get(byte[] key) {
-		return RocksDB.getBytes(baseDb, readOpts.ptr(), key);
+		return RocksDB.getBytes(dbPtr(), readOpts.ptr(), key);
 	}
 
 	/// Direct get with explicit [ReadOptions], e.g. for snapshot-pinned reads. Returns `null` if not found.
@@ -179,7 +177,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key         key bytes to look up
 	/// @return value bytes, or `null` if the key does not exist
 	public byte[] get(ReadOptions readOptions, byte[] key) {
-		return RocksDB.getBytes(baseDb, readOptions.ptr(), key);
+		return RocksDB.getBytes(dbPtr(), readOptions.ptr(), key);
 	}
 
 	/// Single-copy get via `rocksdb_get_into_buffer` + direct output [ByteBuffer].
@@ -190,7 +188,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	public CopyResult get(ByteBuffer key, ByteBuffer value) {
-		return RocksDB.getIntoBuffer(baseDb, readOpts.ptr(),
+		return RocksDB.getIntoBuffer(dbPtr(), readOpts.ptr(),
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
@@ -202,7 +200,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	public CopyResult get(MemorySegment key, MemorySegment value) {
-		return RocksDB.getIntoSegment(baseDb, readOpts.ptr(), key, key.byteSize(), value);
+		return RocksDB.getIntoSegment(dbPtr(), readOpts.ptr(), key, key.byteSize(), value);
 	}
 
 	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
@@ -219,7 +217,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @throws NullPointerException if `fn` returns `null`
 	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
 	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
-		return RocksDB.withPinned(baseDb, readOpts.ptr(), key, fn);
+		return RocksDB.withPinned(dbPtr(), readOpts.ptr(), key, fn);
 	}
 
 	// -----------------------------------------------------------------------
@@ -230,21 +228,21 @@ public final class OptimisticTransactionDB extends NativeObject {
 	///
 	/// @param key key bytes to delete
 	public void delete(byte[] key) {
-		RocksDB.deleteBytes(baseDb, writeOpts.ptr(), key);
+		RocksDB.deleteBytes(dbPtr(), writeOpts.ptr(), key);
 	}
 
 	/// Zero-copy for direct [ByteBuffer]s.
 	///
 	/// @param key direct [ByteBuffer] containing the key to delete
 	public void delete(ByteBuffer key) {
-		RocksDB.deleteSegment(baseDb, writeOpts.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+		RocksDB.deleteSegment(dbPtr(), writeOpts.ptr(), MemorySegment.ofBuffer(key), key.remaining());
 	}
 
 	/// Zero-copy native-first path.
 	///
 	/// @param key native segment containing the key to delete
 	public void delete(MemorySegment key) {
-		RocksDB.deleteSegment(baseDb, writeOpts.ptr(), key, key.byteSize());
+		RocksDB.deleteSegment(dbPtr(), writeOpts.ptr(), key, key.byteSize());
 	}
 
 	/// Direct range delete [`startKey`, `endKey`), bypassing any active transaction. Slow path.
@@ -252,7 +250,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param startKey inclusive start of the deleted range
 	/// @param endKey   exclusive end of the deleted range
 	public void deleteRange(byte[] startKey, byte[] endKey) {
-		RocksDB.deleteRangeCfBytes(baseDb, writeOpts.ptr(), startKey, endKey);
+		RocksDB.deleteRangeCfBytes(dbPtr(), writeOpts.ptr(), startKey, endKey);
 	}
 
 	/// Zero-copy deleteRange for direct [ByteBuffer]s.
@@ -260,7 +258,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param startKey direct [ByteBuffer] with the inclusive start key
 	/// @param endKey   direct [ByteBuffer] with the exclusive end key
 	public void deleteRange(ByteBuffer startKey, ByteBuffer endKey) {
-		RocksDB.deleteRangeCfBuffer(baseDb, writeOpts.ptr(), startKey, endKey);
+		RocksDB.deleteRangeCfBuffer(dbPtr(), writeOpts.ptr(), startKey, endKey);
 	}
 
 	/// Zero-copy deleteRange for [MemorySegment]s.
@@ -268,7 +266,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param startKey native segment with the inclusive start key
 	/// @param endKey   native segment with the exclusive end key
 	public void deleteRange(MemorySegment startKey, MemorySegment endKey) {
-		RocksDB.deleteRangeCfSegment(baseDb, writeOpts.ptr(), startKey, endKey);
+		RocksDB.deleteRangeCfSegment(dbPtr(), writeOpts.ptr(), startKey, endKey);
 	}
 
 	// -----------------------------------------------------------------------
@@ -280,14 +278,14 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param descriptor name and options for the new column family
 	/// @return a [ColumnFamilyHandle] for the new column family; caller must close it
 	public ColumnFamilyHandle createColumnFamily(ColumnFamilyDescriptor descriptor) {
-		return RocksDB.createCf(baseDb, descriptor);
+		return RocksDB.createCf(dbPtr(), descriptor);
 	}
 
 	/// Drops the column family identified by `handle`.
 	///
 	/// @param handle handle of the column family to drop
 	public void dropColumnFamily(ColumnFamilyHandle handle) {
-		RocksDB.dropCf(baseDb, handle);
+		RocksDB.dropCf(dbPtr(), handle);
 	}
 
 	// -----------------------------------------------------------------------
@@ -300,7 +298,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   key bytes
 	/// @param value value bytes
 	public void put(ColumnFamilyHandle cf, byte[] key, byte[] value) {
-		RocksDB.putCfBytes(baseDb, writeOpts.ptr(), cf, key, value);
+		RocksDB.putCfBytes(dbPtr(), writeOpts.ptr(), cf, key, value);
 	}
 
 	/// Zero-copy put into `cf` for direct [ByteBuffer]s.
@@ -309,7 +307,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the value
 	public void put(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
-		RocksDB.putCfSegment(baseDb, writeOpts.ptr(), cf,
+		RocksDB.putCfSegment(dbPtr(), writeOpts.ptr(), cf,
 				MemorySegment.ofBuffer(key), key.remaining(),
 				MemorySegment.ofBuffer(value), value.remaining());
 	}
@@ -320,7 +318,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	public void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		RocksDB.putCfSegment(baseDb, writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
+		RocksDB.putCfSegment(dbPtr(), writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -333,7 +331,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   the key to merge into
 	/// @param value the merge operand
 	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
-		RocksDB.mergeCfBytes(baseDb, writeOpts.ptr(), cf, key, value);
+		RocksDB.mergeCfBytes(dbPtr(), writeOpts.ptr(), cf, key, value);
 	}
 
 	/// Zero-copy merge into `cf` for direct [ByteBuffer]s.
@@ -342,7 +340,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the merge operand
 	public void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
-		RocksDB.mergeCfSegment(baseDb, writeOpts.ptr(), cf,
+		RocksDB.mergeCfSegment(dbPtr(), writeOpts.ptr(), cf,
 				MemorySegment.ofBuffer(key), key.remaining(),
 				MemorySegment.ofBuffer(value), value.remaining());
 	}
@@ -353,7 +351,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		RocksDB.mergeCfSegment(baseDb, writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
+		RocksDB.mergeCfSegment(dbPtr(), writeOpts.ptr(), cf, key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -366,7 +364,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key key bytes to look up
 	/// @return value bytes, or `null` if the key does not exist
 	public byte[] get(ColumnFamilyHandle cf, byte[] key) {
-		return RocksDB.getCfBytes(baseDb, readOpts.ptr(), cf, key);
+		return RocksDB.getCfBytes(dbPtr(), readOpts.ptr(), cf, key);
 	}
 
 	/// Get from `cf` with explicit [ReadOptions]. Returns `null` if not found.
@@ -376,7 +374,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param key         key bytes to look up
 	/// @return value bytes, or `null` if the key does not exist
 	public byte[] get(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
-		return RocksDB.getCfBytes(baseDb, readOptions.ptr(), cf, key);
+		return RocksDB.getCfBytes(dbPtr(), readOptions.ptr(), cf, key);
 	}
 
 	/// Single-copy get from `cf` via `rocksdb_get_into_buffer_cf` + direct output [ByteBuffer].
@@ -388,7 +386,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	public CopyResult get(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
-		return RocksDB.getCfIntoBuffer(baseDb, readOpts.ptr(), cf,
+		return RocksDB.getCfIntoBuffer(dbPtr(), readOpts.ptr(), cf,
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
@@ -401,7 +399,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	public CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		return RocksDB.getCfIntoSegment(baseDb, readOpts.ptr(), cf, key, key.byteSize(), value);
+		return RocksDB.getCfIntoSegment(dbPtr(), readOpts.ptr(), cf, key, key.byteSize(), value);
 	}
 
 	/// Scoped zero-copy get from `cf`. See [#get(MemorySegment, Mapper)] for
@@ -414,7 +412,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @throws NullPointerException if `fn` returns `null`
 	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
 	public <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
-		return RocksDB.withPinnedCf(baseDb, readOpts.ptr(), cf, key, fn);
+		return RocksDB.withPinnedCf(dbPtr(), readOpts.ptr(), cf, key, fn);
 	}
 
 	// -----------------------------------------------------------------------
@@ -426,7 +424,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param cf  column family to delete from
 	/// @param key key bytes to delete
 	public void delete(ColumnFamilyHandle cf, byte[] key) {
-		RocksDB.deleteCfBytes(baseDb, writeOpts.ptr(), cf, key);
+		RocksDB.deleteCfBytes(dbPtr(), writeOpts.ptr(), cf, key);
 	}
 
 	/// Zero-copy delete from `cf` for direct [ByteBuffer]s.
@@ -434,7 +432,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param cf  column family to delete from
 	/// @param key direct [ByteBuffer] containing the key to delete
 	public void delete(ColumnFamilyHandle cf, ByteBuffer key) {
-		RocksDB.deleteCfSegment(baseDb, writeOpts.ptr(), cf, MemorySegment.ofBuffer(key), key.remaining());
+		RocksDB.deleteCfSegment(dbPtr(), writeOpts.ptr(), cf, MemorySegment.ofBuffer(key), key.remaining());
 	}
 
 	/// Zero-copy delete from `cf` for [MemorySegment]s.
@@ -442,7 +440,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param cf  column family to delete from
 	/// @param key native segment containing the key to delete
 	public void delete(ColumnFamilyHandle cf, MemorySegment key) {
-		RocksDB.deleteCfSegment(baseDb, writeOpts.ptr(), cf, key, key.byteSize());
+		RocksDB.deleteCfSegment(dbPtr(), writeOpts.ptr(), cf, key, key.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -455,7 +453,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param startKey start of the range (inclusive)
 	/// @param endKey   end of the range (exclusive)
 	public void deleteRange(ColumnFamilyHandle cf, byte[] startKey, byte[] endKey) {
-		RocksDB.deleteRangeCfBytesExplicit(baseDb, writeOpts.ptr(), cf, startKey, endKey);
+		RocksDB.deleteRangeCfBytesExplicit(dbPtr(), writeOpts.ptr(), cf, startKey, endKey);
 	}
 
 	/// Zero-copy deleteRange for direct [ByteBuffer]s.
@@ -464,7 +462,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param startKey direct [ByteBuffer] for the start of the range (inclusive)
 	/// @param endKey   direct [ByteBuffer] for the end of the range (exclusive)
 	public void deleteRange(ColumnFamilyHandle cf, ByteBuffer startKey, ByteBuffer endKey) {
-		RocksDB.deleteRangeCfBufferExplicit(baseDb, writeOpts.ptr(), cf, startKey, endKey);
+		RocksDB.deleteRangeCfBufferExplicit(dbPtr(), writeOpts.ptr(), cf, startKey, endKey);
 	}
 
 	/// Zero-copy deleteRange for [MemorySegment]s.
@@ -473,7 +471,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param startKey native segment for the start of the range (inclusive)
 	/// @param endKey   native segment for the end of the range (exclusive)
 	public void deleteRange(ColumnFamilyHandle cf, MemorySegment startKey, MemorySegment endKey) {
-		RocksDB.deleteRangeCfSegmentExplicit(baseDb, writeOpts.ptr(), cf, startKey, endKey);
+		RocksDB.deleteRangeCfSegmentExplicit(dbPtr(), writeOpts.ptr(), cf, startKey, endKey);
 	}
 
 	// -----------------------------------------------------------------------
@@ -484,7 +482,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	///
 	/// @return a new [RocksIterator]; caller must close it
 	public RocksIterator newIterator() {
-		return RocksIterator.create(baseDb, readOpts.ptr());
+		return RocksIterator.create(dbPtr(), readOpts.ptr());
 	}
 
 	/// Returns a new iterator using the supplied [ReadOptions].
@@ -492,7 +490,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param readOptions read options, e.g. containing a snapshot
 	/// @return a new [RocksIterator]; caller must close it
 	public RocksIterator newIterator(ReadOptions readOptions) {
-		return RocksIterator.create(baseDb, readOptions.ptr());
+		return RocksIterator.create(dbPtr(), readOptions.ptr());
 	}
 
 	/// Returns a new iterator scoped to `cf` using the default read options.
@@ -500,7 +498,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param cf column family to iterate over
 	/// @return a new [RocksIterator]; caller must close it
 	public RocksIterator newIterator(ColumnFamilyHandle cf) {
-		return RocksDB.createIteratorCf(baseDb, readOpts.ptr(), cf);
+		return RocksDB.createIteratorCf(dbPtr(), readOpts.ptr(), cf);
 	}
 
 	/// Returns a new iterator scoped to `cf` with explicit [ReadOptions].
@@ -509,7 +507,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param readOptions read options, e.g. containing a snapshot
 	/// @return a new [RocksIterator]; caller must close it
 	public RocksIterator newIterator(ColumnFamilyHandle cf, ReadOptions readOptions) {
-		return RocksDB.createIteratorCf(baseDb, readOptions.ptr(), cf);
+		return RocksDB.createIteratorCf(dbPtr(), readOptions.ptr(), cf);
 	}
 
 	// -----------------------------------------------------------------------
@@ -521,7 +519,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	///
 	/// @return a new [Snapshot]; caller must close it
 	public Snapshot getSnapshot() {
-		return RocksDB.createSnapshot(baseDb);
+		return RocksDB.createSnapshot(dbPtr());
 	}
 
 	// -----------------------------------------------------------------------
@@ -532,14 +530,14 @@ public final class OptimisticTransactionDB extends NativeObject {
 	///
 	/// @param flushOptions controls whether the flush blocks until complete
 	public void flush(FlushOptions flushOptions) {
-		RocksDB.flush(baseDb, flushOptions);
+		RocksDB.flush(dbPtr(), flushOptions);
 	}
 
 	/// Flushes the WAL (write-ahead log) to disk.
 	///
 	/// @param sync if `true`, performs an `fsync` after writing
 	public void flushWal(boolean sync) {
-		RocksDB.flushWal(baseDb, sync);
+		RocksDB.flushWal(dbPtr(), sync);
 	}
 
 	// -----------------------------------------------------------------------
@@ -551,7 +549,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param cf           column family to flush
 	/// @param flushOptions controls whether the flush blocks until complete
 	public void flush(ColumnFamilyHandle cf, FlushOptions flushOptions) {
-		RocksDB.flushCf(baseDb, flushOptions, cf);
+		RocksDB.flushCf(dbPtr(), flushOptions, cf);
 	}
 
 	// -----------------------------------------------------------------------
@@ -563,7 +561,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param property the property to query
 	/// @return the property value, or [Optional#empty()] if not supported
 	public Optional<String> getProperty(Property property) {
-		return RocksDB.getProperty(baseDb, property);
+		return RocksDB.getProperty(dbPtr(), property);
 	}
 
 	/// Returns the value of a numeric DB property, or [OptionalLong#empty()] if not supported.
@@ -571,7 +569,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param property the property to query
 	/// @return the numeric property value, or [OptionalLong#empty()] if not supported
 	public OptionalLong getLongProperty(Property property) {
-		return RocksDB.getLongProperty(baseDb, property);
+		return RocksDB.getLongProperty(dbPtr(), property);
 	}
 
 	/// Returns the value of a property scoped to `cf`, or [Optional#empty()] if not supported.
@@ -580,7 +578,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param property the property to query
 	/// @return the property value, or [Optional#empty()] if not supported
 	public Optional<String> getProperty(ColumnFamilyHandle cf, Property property) {
-		return RocksDB.getPropertyCf(baseDb, cf, property);
+		return RocksDB.getPropertyCf(dbPtr(), cf, property);
 	}
 
 	/// Returns the value of a numeric property scoped to `cf`, or [OptionalLong#empty()] if not supported.
@@ -589,7 +587,7 @@ public final class OptimisticTransactionDB extends NativeObject {
 	/// @param property the property to query
 	/// @return the numeric property value, or [OptionalLong#empty()] if not supported
 	public OptionalLong getLongProperty(ColumnFamilyHandle cf, Property property) {
-		return RocksDB.getLongPropertyCf(baseDb, cf, property);
+		return RocksDB.getLongPropertyCf(dbPtr(), cf, property);
 	}
 
 	// -----------------------------------------------------------------------
@@ -597,8 +595,12 @@ public final class OptimisticTransactionDB extends NativeObject {
 	// -----------------------------------------------------------------------
 
 	@Override
-	protected void tryClose(MemorySegment ptr) throws Throwable {
-		RocksDB.closeQuietly(MH_CLOSE_BASE_DB, baseDb);
+	protected void tryCloseBaseDb(MemorySegment baseDb) throws Throwable {
+		MH_CLOSE_BASE_DB.invokeExact(baseDb);
+	}
+
+	@Override
+	protected void tryClosePrimary(MemorySegment ptr) throws Throwable {
 		MH_CLOSE.invokeExact(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1937,22 +1937,6 @@ public final class RocksDB {
 		throw new AssertionError(message, t);
 	}
 
-	/// Invokes a void-returning, single-`MemorySegment`-argument destroy handle, swallowing
-	/// any failure. Deliberate exception to the "never pass a `MethodHandle` as a parameter"
-	/// rule: close() is not a hot path, so losing `invokeExact`'s constant-folding here doesn't
-	/// matter, and the alternative — nested try/finally at every multi-resource `tryClose` — is
-	/// worse for a destructor that must attempt every release regardless of earlier failures.
-	///
-	/// @param destroy single-`MemorySegment`-argument native destroy handle
-	/// @param ptr     the native pointer to release
-	static void closeQuietly(MethodHandle destroy, MemorySegment ptr) {
-		try {
-			destroy.invokeExact(ptr);
-		} catch (Throwable t) {
-			// ignored — best-effort cleanup, matches NativeObject#close()
-		}
-	}
-
 	/// Copies `len` bytes out of a length-prefixed, non-owned native pointer (e.g. a `const
 	/// char*` + separate `size_t*` out-param) into a new Java array. Unlike [#toJavaString],
 	/// this does not free `ptr` -- use it for borrowed views the C API still owns, such as a

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -24,7 +24,7 @@ import java.util.OptionalLong;
 ///     }
 /// }
 /// ```
-public final class TransactionDB extends NativeObject {
+public final class TransactionDB extends NativeObjectWithBaseDb {
 
 	// -----------------------------------------------------------------------
 	// Method handles
@@ -32,6 +32,8 @@ public final class TransactionDB extends NativeObject {
 
 	/// `void rocksdb_transactiondb_close(rocksdb_transactiondb_t* txn_db);`
 	private static final MethodHandle MH_CLOSE;
+	/// `void rocksdb_transactiondb_close_base_db(rocksdb_t* base_db);`
+	private static final MethodHandle MH_CLOSE_BASE_DB;
 	/// `rocksdb_transaction_t* rocksdb_transaction_begin(rocksdb_transactiondb_t* txn_db, const rocksdb_writeoptions_t* write_options, const rocksdb_transaction_options_t* txn_options, rocksdb_transaction_t* old_txn);`
 	private static final MethodHandle MH_BEGIN;
 	/// `const rocksdb_snapshot_t* rocksdb_transactiondb_create_snapshot(rocksdb_transactiondb_t* txn_db);`
@@ -74,6 +76,9 @@ public final class TransactionDB extends NativeObject {
 
 	static {
 		MH_CLOSE = NativeLibrary.lookup("rocksdb_transactiondb_close",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+		MH_CLOSE_BASE_DB = NativeLibrary.lookup("rocksdb_transactiondb_close_base_db",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 
 		MH_BEGIN = NativeLibrary.lookup("rocksdb_transaction_begin",
@@ -167,13 +172,11 @@ public final class TransactionDB extends NativeObject {
 	// Instance state
 	// -----------------------------------------------------------------------
 
-	private final MemorySegment baseDb;  // rocksdb_t* — for CF management and CF property queries
 	private final WriteOptions writeOpts; // default write options for direct ops
 	private final ReadOptions readOpts;  // default read options for direct ops
 
 	TransactionDB(MemorySegment ptr, MemorySegment baseDb) {
-		super(ptr);
-		this.baseDb = baseDb;
+		super(ptr, baseDb);
 		this.writeOpts = RocksDB.DEFAULT_WRITE_OPTIONS;
 		this.readOpts = RocksDB.DEFAULT_READ_OPTIONS;
 	}
@@ -592,7 +595,7 @@ public final class TransactionDB extends NativeObject {
 	///
 	/// @param handle handle of the column family to drop
 	public void dropColumnFamily(ColumnFamilyHandle handle) {
-		RocksDB.dropCf(baseDb, handle);
+		RocksDB.dropCf(dbPtr(), handle);
 	}
 
 	// -----------------------------------------------------------------------
@@ -923,7 +926,7 @@ public final class TransactionDB extends NativeObject {
 	/// @param property the property to query
 	/// @return the property value, or empty if not supported
 	public Optional<String> getProperty(ColumnFamilyHandle cf, Property property) {
-		return RocksDB.getPropertyCf(baseDb, cf, property);
+		return RocksDB.getPropertyCf(dbPtr(), cf, property);
 	}
 
 	/// Returns the value of a numeric property for `cf`, or [OptionalLong#empty()] if not supported.
@@ -932,7 +935,7 @@ public final class TransactionDB extends NativeObject {
 	/// @param property the property to query
 	/// @return the numeric property value, or empty if not supported
 	public OptionalLong getLongProperty(ColumnFamilyHandle cf, Property property) {
-		return RocksDB.getLongPropertyCf(baseDb, cf, property);
+		return RocksDB.getLongPropertyCf(dbPtr(), cf, property);
 	}
 
 	// -----------------------------------------------------------------------
@@ -940,7 +943,12 @@ public final class TransactionDB extends NativeObject {
 	// -----------------------------------------------------------------------
 
 	@Override
-	protected void tryClose(MemorySegment ptr) throws Throwable {
+	protected void tryCloseBaseDb(MemorySegment baseDb) throws Throwable {
+		MH_CLOSE_BASE_DB.invokeExact(baseDb);
+	}
+
+	@Override
+	protected void tryClosePrimary(MemorySegment ptr) throws Throwable {
 		MH_CLOSE.invokeExact(ptr);
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
@@ -832,4 +832,87 @@ class OptimisticTransactionDBTest {
 			assertThat(result).isPresent();
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// Calling methods after close() must throw, not crash the JVM
+	// -----------------------------------------------------------------------
+	// Direct ops go through a second native pointer (the "base DB") that RocksDB frees
+	// separately when this OptimisticTransactionDB closes; verify it's guarded.
+
+	@Test
+	void put_afterClose_throwsInsteadOfCrashing(@TempDir Path dir) {
+		// Given
+		var opts = Options.newOptions().setCreateIfMissing(true);
+		var db = RocksDB.openOptimistic(opts, dir);
+		db.close();
+		opts.close();
+
+		// When
+		ThrowingCallable callable = () -> db.put("k".getBytes(), "v".getBytes());
+
+		// Then
+		assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void get_afterClose_throwsInsteadOfCrashing(@TempDir Path dir) {
+		// Given
+		var opts = Options.newOptions().setCreateIfMissing(true);
+		var db = RocksDB.openOptimistic(opts, dir);
+		db.put("k".getBytes(), "v".getBytes());
+		db.close();
+		opts.close();
+
+		// When
+		ThrowingCallable callable = () -> db.get("k".getBytes());
+
+		// Then
+		assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void getProperty_afterClose_throwsInsteadOfCrashing(@TempDir Path dir) {
+		// Given
+		var opts = Options.newOptions().setCreateIfMissing(true);
+		var db = RocksDB.openOptimistic(opts, dir);
+		db.close();
+		opts.close();
+
+		// When
+		ThrowingCallable callable = () -> db.getProperty(Property.STATS);
+
+		// Then
+		assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void newIterator_afterClose_throwsInsteadOfCrashing(@TempDir Path dir) {
+		// Given
+		var opts = Options.newOptions().setCreateIfMissing(true);
+		var db = RocksDB.openOptimistic(opts, dir);
+		db.close();
+		opts.close();
+
+		// When
+		ThrowingCallable callable = db::newIterator;
+
+		// Then
+		assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void close_isIdempotent(@TempDir Path dir) {
+		// Given — an already-closed OptimisticTransactionDB; close() must have released both
+		// the primary pointer and the base DB pointer (NativeObjectWithBaseDb#tryCloseBaseDb)
+		var opts = Options.newOptions().setCreateIfMissing(true);
+		var db = RocksDB.openOptimistic(opts, dir);
+		db.close();
+		opts.close();
+
+		// When
+		ThrowingCallable secondClose = db::close;
+
+		// Then — normally a double-free would crash the JVM
+		assertThatCode(secondClose).doesNotThrowAnyException();
+	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TransactionDBTest {
 
@@ -838,6 +839,69 @@ class TransactionDBTest {
 			// Then
 			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
 		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Calling methods after close() must throw, not crash the JVM
+	// -----------------------------------------------------------------------
+	// dropColumnFamily/getProperty(ColumnFamilyHandle,...)/getLongProperty(ColumnFamilyHandle,...)
+	// operate on a second native pointer (the "base DB", see NativeObjectWithBaseDb) that would
+	// otherwise bypass NativeObject's own closed-check — verify each is guarded.
+
+	@Test
+	void dropColumnFamily_afterClose_throwsInsteadOfCrashing(@TempDir Path dir) {
+		// Given
+		var db = openDb(dir);
+		ColumnFamilyHandle cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		db.close();
+
+		// When
+		ThrowingCallable callable = () -> db.dropColumnFamily(cf);
+
+		// Then
+		assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void getProperty_columnFamily_afterClose_throwsInsteadOfCrashing(@TempDir Path dir) {
+		// Given
+		var db = openDb(dir);
+		ColumnFamilyHandle cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		db.close();
+
+		// When
+		ThrowingCallable callable = () -> db.getProperty(cf, Property.STATS);
+
+		// Then
+		assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void getLongProperty_columnFamily_afterClose_throwsInsteadOfCrashing(@TempDir Path dir) {
+		// Given
+		var db = openDb(dir);
+		ColumnFamilyHandle cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		db.close();
+
+		// When
+		ThrowingCallable callable = () -> db.getLongProperty(cf, Property.ESTIMATE_NUM_KEYS);
+
+		// Then
+		assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void close_isIdempotent(@TempDir Path dir) {
+		// Given — an already-closed TransactionDB; close() must have released both the
+		// primary pointer and the base DB pointer (NativeObjectWithBaseDb#tryCloseBaseDb)
+		var db = openDb(dir);
+		db.close();
+
+		// When
+		ThrowingCallable secondClose = db::close;
+
+		// Then — normally a double-free would crash the JVM
+		assertThatCode(secondClose).doesNotThrowAnyException();
 	}
 
 	// -----------------------------------------------------------------------

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -97,6 +97,20 @@ consumed which pointer. Determining *which* calls transfer ownership is not gues
 off `db/c.cc` (does `rocksdb_block_based_options_destroy` delete the filter policy?), the C API
 docs, or how `rocksdbjni` handles the same object.
 
+The third hazard is a *second owned pointer on the same object*. `TransactionDB` and
+`OptimisticTransactionDB` each hold a `rocksdb_t*` "base DB" handle (from
+`rocksdb_transactiondb_get_base_db` / `rocksdb_optimistictransactiondb_get_base_db`) that most of
+their data-plane methods use directly instead of their own primary handle. A private field read
+directly from within the class bypasses `NativeObject`'s closed-check entirely — nothing stops a
+method from touching a dangling pointer after `close()`, no matter what the field is named, since a
+private field is visible to every method in its own class. Renaming it doesn't help: the fix has to
+put the pointer somewhere the subclass genuinely cannot see it. `NativeObjectWithBaseDb` is that
+place — a `NativeObject` subclass holding the base DB pointer as a private field of *its own*, with
+the only access being `dbPtr()`, which calls `ptr()` first and therefore throws
+`IllegalStateException` once the object is closed, exactly like every other native call already
+does. A future class with the same "second owned pointer" shape should extend it rather than
+re-inventing a guard.
+
 ## Only valid operations
 
 Each way of opening a database gets its own Java type, exposing only the operations that are

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -317,6 +317,7 @@ Reopening requires listing every existing column family, `default` included — 
 | `CopyResult`      | Sealed: `Copied()`, `NotEnoughCapacity(long required)`, `NotFound()`                         |
 | `RocksDBException`| Unchecked; thrown for a genuine RocksDB-reported error (see [explanation.md#errors-are-always-loud](explanation.md#errors-are-always-loud)) |
 | `NativeObject`    | Base class of every native wrapper; `ptr()`, `close()` (idempotent), abstract `tryClose`      |
+| `NativeObjectWithBaseDb` | `NativeObject` subclass for wrappers with a second owned pointer (`TransactionDB`/`OptimisticTransactionDB`'s `rocksdb_t*` "base DB"); guarded `dbPtr()`, hooks `tryCloseBaseDb`/`tryClosePrimary` — see [explanation.md](explanation.md#lifecycle-and-ownership) |
 
 `Path` is used for every filesystem argument; there is no `String` path overload anywhere.
 


### PR DESCRIPTION
## Summary
- `TransactionDB`/`OptimisticTransactionDB` each hold a second native pointer (the `rocksdb_t*` "base DB") that most data-plane methods used directly, bypassing `NativeObject`'s own closed-check (`ptr()`) entirely. `OptimisticTransactionDB.close()` explicitly frees the base DB (`rocksdb_optimistictransactiondb_close_base_db`) before closing itself — calling any of ~30 affected methods afterward operated on a dangling pointer. Reproduced directly: `db.put(...)` after `close()` segfaults the JVM on the very first `rocksdb_put` call.
- Fixed by extracting `NativeObjectWithBaseDb`, a `NativeObject` subclass that holds the base DB pointer as a genuinely private field — subclasses have no name that resolves to the raw pointer, so there's no way to bypass the guard by accident. The only access is `dbPtr()`, which calls `ptr()` first. Close ordering is centralized via two hooks: `tryCloseBaseDb()` (default no-op) and the abstract `tryClosePrimary()`.
  - An earlier version used a private per-class accessor instead of a shared base class — it looked compiler-enforced but wasn't: a private field is visible to every method in its own class, so nothing stopped a new method from reading it directly under whatever name it currently had. Real enforcement requires the pointer to live in a class the subclass can't see into.
- Centralizing the close sequence surfaced a second, separate bug: `TransactionDB` called `rocksdb_transactiondb_get_base_db` (which mallocs a small wrapper struct per call) but never called the matching `rocksdb_transactiondb_close_base_db` — a native memory leak on every instance. Fixed alongside this, since both classes now go through the same base class.
- `RocksDB.closeQuietly` is now dead code and removed — it was itself a `MethodHandle` passed as a parameter, against the project's own no-shared-call-site convention.
- Follow-up filed as #102: `OptimisticTransactionDB`'s direct ops already share the same native calls as `ReadWriteDB`/`TtlDB`/`BlobDB` (no bespoke `MethodHandle`s), so it could implement the shared `RocksDBReadOperations`/`RocksDBWriteOperations` interfaces instead of hand-duplicating ~30 methods — kept out of scope here.

## Test plan
- [x] `./mvnw test` — 845 tests pass
- [x] `./mvnw javadoc:javadoc -pl core` — 0 checkstyle violations, 0 javadoc errors
- [x] Regression tests in `TransactionDBTest`/`OptimisticTransactionDBTest` confirm `IllegalStateException` (not a crash) when calling affected methods after `close()`, plus double-close idempotency for both classes
- [x] Reproduced the original crash with a throwaway test before fixing, confirmed it's gone after

🤖 Generated with [Claude Code](https://claude.com/claude-code)