### PR TITLE
fix: Snapshot crashed the JVM if its owning DB closed first

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
@@ -23,7 +23,7 @@ import java.lang.foreign.MemorySegment;
 ///
 /// Blob-specific statistics are available via [Property#BLOB_STATS],
 /// [Property#NUM_BLOB_FILES], [Property#TOTAL_BLOB_FILE_SIZE], etc.
-public final class BlobDB extends NativeObject implements RocksDBReadOperations, RocksDBWriteOperations {
+public final class BlobDB extends NativeObjectWithChildren implements RocksDBReadOperations, RocksDBWriteOperations {
 
 	BlobDB(MemorySegment ptr) {
 		super(ptr);
@@ -39,7 +39,7 @@ public final class BlobDB extends NativeObject implements RocksDBReadOperations,
 	// -----------------------------------------------------------------------
 
 	@Override
-	protected void tryClose(MemorySegment ptr) throws Throwable {
+	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
 		RocksDB.close(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObject.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObject.java
@@ -9,6 +9,14 @@ import java.util.concurrent.atomic.AtomicReference;
 /// the reference is atomically swapped to [MemorySegment#NULL], ensuring
 /// [#tryClose(MemorySegment)] is called exactly once even under
 /// concurrent or repeated close() calls.
+///
+/// That guarantee is narrower than it might read: it covers concurrent or repeated calls to
+/// [#close()] itself, not `close()` racing a concurrent call to any *other* method. Nothing
+/// synchronizes `close()` against a live call to, say, a `get`/`put` method on another thread —
+/// one thread's [#ptr()] succeeding does not stop a second thread's `close()` from freeing that
+/// same memory immediately afterward, before the native call that read `ptr()` actually runs.
+/// Do not call `close()` on one thread while another thread might still be calling any method on
+/// the same object; synchronize externally if your usage can't rule that out.
 public abstract class NativeObject implements AutoCloseable {
 
 	private final AtomicReference<MemorySegment> owningPointer;

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObjectWithBaseDb.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObjectWithBaseDb.java
@@ -18,7 +18,7 @@ import java.lang.foreign.MemorySegment;
 /// cannot accidentally read it unchecked. The only access is [#dbPtr()], which calls [#ptr()]
 /// first and therefore throws [IllegalStateException] once this object is closed, the same way
 /// every other native call on this object already does.
-abstract class NativeObjectWithBaseDb extends NativeObject {
+abstract class NativeObjectWithBaseDb extends NativeObjectWithChildren {
 
 	private final MemorySegment baseDb;
 
@@ -44,7 +44,7 @@ abstract class NativeObjectWithBaseDb extends NativeObject {
 	}
 
 	@Override
-	protected final void tryClose(MemorySegment ptr) throws Throwable {
+	protected final void tryCloseResource(MemorySegment ptr) throws Throwable {
 		try {
 			tryCloseBaseDb(baseDb);
 		} catch (Throwable t) {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObjectWithChildren.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/NativeObjectWithChildren.java
@@ -1,0 +1,66 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/// Base class for native wrappers that can produce child resources borrowing this object's
+/// native pointer for their own release call (e.g. [Snapshot]'s `rocksdb_release_snapshot`
+/// needs its owning DB's pointer) — and would otherwise dangle if this object closed first.
+///
+/// A child registers itself via [#registerChild(NativeObject)] (typically from its own
+/// constructor) and unregisters via [#unregisterChild(NativeObject)] once released on its own,
+/// so a long-lived parent doesn't accumulate strong references to every child it ever produced.
+/// [#tryClose(MemorySegment)] closes every still-registered child, synchronously, while `ptr`
+/// is still valid — before delegating to [#tryCloseResource(MemorySegment)] for this object's
+/// own native destroy call — so a child's release call never runs against memory this object
+/// has already freed, whichever side closes first.
+abstract class NativeObjectWithChildren extends NativeObject {
+
+	/// Effectively free (a [ConcurrentHashMap]-backed set allocates no backing table until
+	/// first written) for any instance that never actually registers a child.
+	private final Set<NativeObject> children = ConcurrentHashMap.newKeySet();
+
+	protected NativeObjectWithChildren(MemorySegment ptr) {
+		super(ptr);
+	}
+
+	/// Registers `child` to be closed automatically before this object's own native resource is
+	/// destroyed, if `child` is not already closed by then.
+	///
+	/// @param child the child resource to close alongside (and before) this object
+	final void registerChild(NativeObject child) {
+		children.add(child);
+	}
+
+	/// Removes a previously-[#registerChild(NativeObject) registered] child, e.g. because it
+	/// was closed on its own rather than by this object's [#close()]. A no-op if `child` was
+	/// never registered, or already removed (including by a concurrent sweep in
+	/// [#tryClose(MemorySegment)]).
+	///
+	/// @param child the child resource to stop tracking
+	final void unregisterChild(NativeObject child) {
+		children.remove(child);
+	}
+
+	@Override
+	protected final void tryClose(MemorySegment ptr) throws Throwable {
+		// child.close() is safe to call whether or not the child was already closed by its own
+		// caller (NativeObject's close() is idempotent), and children is a ConcurrentHashMap-
+		// backed set, so a child unregistering itself mid-iteration does not throw
+		// ConcurrentModificationException.
+		for (NativeObject child : children) {
+			child.close();
+		}
+		children.clear();
+		tryCloseResource(ptr);
+	}
+
+	/// Closes this object's own native resource. Same contract as
+	/// [NativeObject#tryClose(MemorySegment)] — renamed only because `tryClose` itself is
+	/// final here, to guarantee children are always closed first.
+	///
+	/// @param ptr the non-NULL primary native pointer to release
+	/// @throws Throwable if the native destroy call fails
+	protected abstract void tryCloseResource(MemorySegment ptr) throws Throwable;
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
@@ -11,7 +11,7 @@ import java.lang.foreign.MemorySegment;
 ///     byte[] value = db.get("key".getBytes());
 /// }
 /// ```
-public final class ReadOnlyDB extends NativeObject implements RocksDBReadOperations {
+public final class ReadOnlyDB extends NativeObjectWithChildren implements RocksDBReadOperations {
 
 	ReadOnlyDB(MemorySegment ptr) {
 		super(ptr);
@@ -27,7 +27,7 @@ public final class ReadOnlyDB extends NativeObject implements RocksDBReadOperati
 	// -----------------------------------------------------------------------
 
 	@Override
-	protected void tryClose(MemorySegment ptr) throws Throwable {
+	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
 		RocksDB.close(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -12,7 +12,7 @@ import java.lang.foreign.MemorySegment;
 ///     byte[] value = db.get("key".getBytes());
 /// }
 /// ```
-public final class ReadWriteDB extends NativeObject implements RocksDBReadOperations, RocksDBWriteOperations {
+public final class ReadWriteDB extends NativeObjectWithChildren implements RocksDBReadOperations, RocksDBWriteOperations {
 
 	ReadWriteDB(MemorySegment ptr) {
 		super(ptr);
@@ -28,7 +28,7 @@ public final class ReadWriteDB extends NativeObject implements RocksDBReadOperat
 	// -----------------------------------------------------------------------
 
 	@Override
-	protected void tryClose(MemorySegment ptr) throws Throwable {
+	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
 		RocksDB.close(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1013,7 +1013,7 @@ public final class RocksDB {
 		}
 	}
 
-	static Snapshot createSnapshot(NativeObject owningDb, MemorySegment db) {
+	static Snapshot createSnapshot(NativeObjectWithChildren owningDb, MemorySegment db) {
 		try {
 			MemorySegment snapPtr = (MemorySegment) MH_CREATE_SNAPSHOT.invokeExact(db);
 			return new Snapshot(owningDb, db, snapPtr);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1013,10 +1013,10 @@ public final class RocksDB {
 		}
 	}
 
-	static Snapshot createSnapshot(MemorySegment db) {
+	static Snapshot createSnapshot(NativeObject owningDb, MemorySegment db) {
 		try {
 			MemorySegment snapPtr = (MemorySegment) MH_CREATE_SNAPSHOT.invokeExact(db);
-			return new Snapshot(db, snapPtr);
+			return new Snapshot(owningDb, db, snapPtr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("getSnapshot failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
@@ -277,10 +277,10 @@ public interface RocksDBReadOperations {
 	///
 	/// @return a new [Snapshot]; caller must close it
 	default Snapshot getSnapshot() {
-		// Every implementor is a NativeObject (see #dbPtr()); passed through so the returned
-		// Snapshot can detect this DB being closed before the snapshot is, rather than
-		// releasing against a dangling pointer.
-		return RocksDB.createSnapshot((NativeObject) this, dbPtr());
+		// Every implementor extends NativeObjectWithChildren (see #dbPtr()); passed through so
+		// the returned Snapshot registers itself and is released automatically if this DB
+		// closes first, rather than dangling.
+		return RocksDB.createSnapshot((NativeObjectWithChildren) this, dbPtr());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
@@ -277,7 +277,10 @@ public interface RocksDBReadOperations {
 	///
 	/// @return a new [Snapshot]; caller must close it
 	default Snapshot getSnapshot() {
-		return RocksDB.createSnapshot(dbPtr());
+		// Every implementor is a NativeObject (see #dbPtr()); passed through so the returned
+		// Snapshot can detect this DB being closed before the snapshot is, rather than
+		// releasing against a dangling pointer.
+		return RocksDB.createSnapshot((NativeObject) this, dbPtr());
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
@@ -26,7 +26,7 @@ import java.lang.invoke.MethodHandle;
 ///     byte[] value = secondary.get("key".getBytes());
 /// }
 /// ```
-public final class SecondaryDB extends NativeObject implements RocksDBReadOperations {
+public final class SecondaryDB extends NativeObjectWithChildren implements RocksDBReadOperations {
 
 	// -----------------------------------------------------------------------
 	// Method handles unique to SecondaryDB
@@ -73,7 +73,7 @@ public final class SecondaryDB extends NativeObject implements RocksDBReadOperat
 	// -----------------------------------------------------------------------
 
 	@Override
-	protected void tryClose(MemorySegment ptr) throws Throwable {
+	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
 		RocksDB.close(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Snapshot.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Snapshot.java
@@ -11,9 +11,13 @@ import java.lang.invoke.MethodHandle;
 /// Reads performed with a snapshot set on [ReadOptions] see only data
 /// that was committed before the snapshot was taken.
 ///
-/// Obtain via [TransactionDB#getSnapshot()],
-/// or [Transaction#getSnapshot()]. Always close after use to release the
-/// underlying native snapshot.
+/// Obtain via [RocksDBReadOperations#getSnapshot()] (implemented by [ReadWriteDB], [TtlDB],
+/// [BlobDB], and [OptimisticTransactionDB]), [TransactionDB#getSnapshot()], or
+/// [Transaction#getSnapshot()]. Always close after use to release the underlying native
+/// snapshot — and close it before closing the DB (or transaction) that produced it; closing
+/// out of order is not an error (the release is silently skipped, since the DB's own teardown
+/// already destroyed the snapshot internally), but the snapshot's data is only guaranteed
+/// valid while the DB itself is still open.
 ///
 /// ```
 /// try (Snapshot snap = db.getSnapshot();
@@ -43,9 +47,26 @@ public final class Snapshot extends NativeObject {
 	/// should be used instead (transaction snapshot ownership model).
 	private final MemorySegment dbPtr;
 
+	/// The DB object that produced this snapshot, used only as a liveness check in
+	/// [#tryClose(MemorySegment)] — NULL for transaction-owned snapshots, which have no such
+	/// hazard (`rocksdb_free` doesn't touch the DB at all).
+	///
+	/// If that DB is closed before this snapshot is, `dbPtr` becomes a dangling pointer: the
+	/// DB's own teardown already destroyed every snapshot it owned internally, and calling
+	/// `rocksdb_release_snapshot` again would be a use-after-free. Checking `owningDb.ptr()`
+	/// first turns that into a clean skip instead: it throws `IllegalStateException`, which
+	/// propagates out of `tryClose` and is caught by `NativeObject#close()`'s catch-all, so the
+	/// (already-unnecessary) release call is simply never made.
+	private final NativeObject owningDb;
+
 	/// Creates a snapshot owned by a RocksDB or TransactionDB instance.
-	Snapshot(MemorySegment dbPtr, MemorySegment ptr) {
+	///
+	/// @param owningDb the DB object `dbPtr` belongs to, checked for liveness before release
+	/// @param dbPtr    native pointer passed to `rocksdb_release_snapshot`
+	/// @param ptr      the native snapshot pointer
+	Snapshot(NativeObject owningDb, MemorySegment dbPtr, MemorySegment ptr) {
 		super(ptr);
+		this.owningDb = owningDb;
 		this.dbPtr = dbPtr;
 	}
 
@@ -53,6 +74,7 @@ public final class Snapshot extends NativeObject {
 	/// Released via `rocksdb_free` rather than `rocksdb_release_snapshot`.
 	Snapshot(MemorySegment ptr) {
 		super(ptr);
+		this.owningDb = null;
 		this.dbPtr = MemorySegment.NULL;
 	}
 
@@ -70,11 +92,12 @@ public final class Snapshot extends NativeObject {
 
 	@Override
 	protected void tryClose(MemorySegment ptr) throws Throwable {
-		if (MemorySegment.NULL.equals(dbPtr)) {
+		if (owningDb == null) {
 			RocksDB.free(ptr);
-		} else {
-			MH_RELEASE.invokeExact(dbPtr, ptr);
+			return;
 		}
+		owningDb.ptr(); // liveness check: throws if the owning DB is already closed
+		MH_RELEASE.invokeExact(dbPtr, ptr);
 	}
 
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Snapshot.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Snapshot.java
@@ -11,13 +11,14 @@ import java.lang.invoke.MethodHandle;
 /// Reads performed with a snapshot set on [ReadOptions] see only data
 /// that was committed before the snapshot was taken.
 ///
-/// Obtain via [RocksDBReadOperations#getSnapshot()] (implemented by [ReadWriteDB], [TtlDB],
-/// [BlobDB], and [OptimisticTransactionDB]), [TransactionDB#getSnapshot()], or
-/// [Transaction#getSnapshot()]. Always close after use to release the underlying native
-/// snapshot — and close it before closing the DB (or transaction) that produced it; closing
-/// out of order is not an error (the release is silently skipped, since the DB's own teardown
-/// already destroyed the snapshot internally), but the snapshot's data is only guaranteed
-/// valid while the DB itself is still open.
+/// Obtain via [RocksDBReadOperations#getSnapshot()] (implemented by [ReadWriteDB],
+/// [ReadOnlyDB], [TtlDB], [BlobDB], [SecondaryDB], and [OptimisticTransactionDB]),
+/// [TransactionDB#getSnapshot()], or [Transaction#getSnapshot()]. Always close after use to
+/// release the underlying native snapshot. Closing the owning DB (or transaction) first is
+/// safe — the DB registers every snapshot it produces as a [NativeObjectWithChildren] child and
+/// releases any still-outstanding ones itself, synchronously, before destroying its own native
+/// handle — so a snapshot never outlives the pointer its release call needs, whichever side
+/// closes first.
 ///
 /// ```
 /// try (Snapshot snap = db.getSnapshot();
@@ -47,27 +48,26 @@ public final class Snapshot extends NativeObject {
 	/// should be used instead (transaction snapshot ownership model).
 	private final MemorySegment dbPtr;
 
-	/// The DB object that produced this snapshot, used only as a liveness check in
-	/// [#tryClose(MemorySegment)] — NULL for transaction-owned snapshots, which have no such
-	/// hazard (`rocksdb_free` doesn't touch the DB at all).
-	///
-	/// If that DB is closed before this snapshot is, `dbPtr` becomes a dangling pointer: the
-	/// DB's own teardown already destroyed every snapshot it owned internally, and calling
-	/// `rocksdb_release_snapshot` again would be a use-after-free. Checking `owningDb.ptr()`
-	/// first turns that into a clean skip instead: it throws `IllegalStateException`, which
-	/// propagates out of `tryClose` and is caught by `NativeObject#close()`'s catch-all, so the
-	/// (already-unnecessary) release call is simply never made.
-	private final NativeObject owningDb;
+	/// The DB object that produced this snapshot — NULL for transaction-owned snapshots, which
+	/// register with nothing (`rocksdb_free` doesn't touch the DB at all, so there is no
+	/// ordering hazard to guard against). Used in [#tryClose(MemorySegment)] only to
+	/// unregister this snapshot from the DB's child set once released on its own, so a
+	/// long-lived DB doesn't accumulate strong references to every snapshot it ever produced —
+	/// registration itself happens in the constructor below, via
+	/// [NativeObjectWithChildren#registerChild(NativeObject)].
+	private final NativeObjectWithChildren owningDb;
 
-	/// Creates a snapshot owned by a RocksDB or TransactionDB instance.
+	/// Creates a snapshot owned by a RocksDB or TransactionDB instance, and registers it with
+	/// `owningDb` so it is released automatically if `owningDb` closes first.
 	///
-	/// @param owningDb the DB object `dbPtr` belongs to, checked for liveness before release
+	/// @param owningDb the DB object `dbPtr` belongs to
 	/// @param dbPtr    native pointer passed to `rocksdb_release_snapshot`
 	/// @param ptr      the native snapshot pointer
-	Snapshot(NativeObject owningDb, MemorySegment dbPtr, MemorySegment ptr) {
+	Snapshot(NativeObjectWithChildren owningDb, MemorySegment dbPtr, MemorySegment ptr) {
 		super(ptr);
 		this.owningDb = owningDb;
 		this.dbPtr = dbPtr;
+		owningDb.registerChild(this);
 	}
 
 	/// Creates a snapshot owned by a Transaction instance.
@@ -96,7 +96,11 @@ public final class Snapshot extends NativeObject {
 			RocksDB.free(ptr);
 			return;
 		}
-		owningDb.ptr(); // liveness check: throws if the owning DB is already closed
+		// Unregister first: if this runs because owningDb's own close() is sweeping its
+		// children (owningDb closed first), dbPtr is still valid — owningDb captures its raw
+		// pointer before nulling its own AtomicReference and only then closes children — so
+		// this release call is always safe, whichever side closed first.
+		owningDb.unregisterChild(this);
 		MH_RELEASE.invokeExact(dbPtr, ptr);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -223,7 +223,7 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	public Snapshot getSnapshot() {
 		try {
 			MemorySegment snapPtr = (MemorySegment) MH_CREATE_SNAPSHOT.invokeExact(ptr());
-			return new Snapshot(ptr(), snapPtr);
+			return new Snapshot(this, ptr(), snapPtr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("getSnapshot failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
@@ -16,7 +16,7 @@ import java.time.Duration;
 ///     byte[] value = db.get("key".getBytes());
 /// }
 /// ```
-public final class TtlDB extends NativeObject implements RocksDBReadOperations, RocksDBWriteOperations {
+public final class TtlDB extends NativeObjectWithChildren implements RocksDBReadOperations, RocksDBWriteOperations {
 
 	private final Duration ttl;
 
@@ -43,7 +43,7 @@ public final class TtlDB extends NativeObject implements RocksDBReadOperations, 
 	// -----------------------------------------------------------------------
 
 	@Override
-	protected void tryClose(MemorySegment ptr) throws Throwable {
+	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
 		RocksDB.close(ptr);
 	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SnapshotTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SnapshotTest.java
@@ -186,16 +186,20 @@ class SnapshotTest {
 
 	@Test
 	void snapshot_closedAfterOwningDb_doesNotCrash(@TempDir Path dir) {
-		// Given — the owning DB is closed before the snapshot it produced
+		// Given — a snapshot that is never explicitly closed by the caller
 		var db = RocksDB.openReadWrite(dir);
 		Snapshot snap = db.getSnapshot();
+
+		// When — closing the DB must release the still-outstanding snapshot itself
+		// (synchronously, before its own native handle is destroyed) rather than leaving a
+		// dangling pointer for a later snap.close() to crash on
 		db.close();
 
-		// When — releasing against the DB's now-dangling pointer would otherwise be a
-		// use-after-free; normally this would trigger a JVM crash
-		ThrowingCallable closeAfterDb = snap::close;
+		// Then — the snapshot is already closed as a side effect of db.close()
+		assertThatThrownBy(snap::ptr).isInstanceOf(IllegalStateException.class);
 
-		// Then
+		// And closing it again explicitly is still a safe no-op
+		ThrowingCallable closeAfterDb = snap::close;
 		assertThatCode(closeAfterDb).doesNotThrowAnyException();
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SnapshotTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SnapshotTest.java
@@ -184,6 +184,21 @@ class SnapshotTest {
 		}
 	}
 
+	@Test
+	void snapshot_closedAfterOwningDb_doesNotCrash(@TempDir Path dir) {
+		// Given — the owning DB is closed before the snapshot it produced
+		var db = RocksDB.openReadWrite(dir);
+		Snapshot snap = db.getSnapshot();
+		db.close();
+
+		// When — releasing against the DB's now-dangling pointer would otherwise be a
+		// use-after-free; normally this would trigger a JVM crash
+		ThrowingCallable closeAfterDb = snap::close;
+
+		// Then
+		assertThatCode(closeAfterDb).doesNotThrowAnyException();
+	}
+
 	// -----------------------------------------------------------------------
 	// Transaction snapshot — dbPtr-less variant, released via rocksdb_free
 	// -----------------------------------------------------------------------

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -111,6 +111,24 @@ the only access being `dbPtr()`, which calls `ptr()` first and therefore throws
 does. A future class with the same "second owned pointer" shape should extend it rather than
 re-inventing a guard.
 
+The fourth hazard is a *borrowed pointer from a different object*. `Snapshot` needs its owning
+DB's pointer to call `rocksdb_release_snapshot`, but doesn't own that pointer or control its
+lifetime — closing the DB before the snapshot leaves `Snapshot` holding a dangling reference to
+memory it never owned in the first place. This is not the same shape as the third hazard: there
+the second pointer belongs to the *same* object, so `NativeObjectWithBaseDb`'s guard (check
+`ptr()` before returning it) is enough. Here the pointer's owner is a *different* object whose
+lifetime `Snapshot` can't observe from the outside.
+
+`NativeObjectWithChildren` solves this the other direction: instead of the child defensively
+checking whether its parent is still alive, the parent tracks every child it has handed a
+borrowed pointer to and closes them itself — synchronously, while its own pointer is still
+valid — before running its own real `tryClose`. A `Snapshot` registers with its owning DB at
+construction and unregisters when closed on its own; if the DB closes first, the still-registered
+snapshot is released as part of that same `close()` call, using the DB's pointer before it's
+freed, not after. This removes the ordering hazard by construction rather than by runtime detection: `Snapshot`'s
+own release code never has to ask "is my pointer still good?" because the design guarantees it
+always is by the time that code runs.
+
 ## Only valid operations
 
 Each way of opening a database gets its own Java type, exposing only the operations that are

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -77,6 +77,19 @@ Java-level stack trace and no exception to catch. `NativeObject` holds the point
 exactly once no matter how many times or from how many threads `close()` is called. Using the
 pointer afterwards throws `IllegalStateException` instead of dereferencing freed memory.
 
+That guarantee is narrower than it might read: it covers concurrent or repeated calls to
+`close()` itself, not `close()` racing a concurrent call to any *other* method. There is no lock
+between `close()` and, say, `get()`/`put()` running on another thread — one thread's `ptr()`
+succeeding does not stop a second thread's `close()` from freeing that same memory immediately
+afterward, before the native call that read `ptr()` actually runs. Every method on every
+`NativeObject` has this same narrow window; it is a property of the base class, not something
+specific to any one wrapper. Closing it fully would mean a lock around every native call site in
+the codebase (e.g. a read/write lock — every method takes a read lock, `close()` takes a write
+lock), at a real cost to a library whose design otherwise leans on zero-copy, lock-free FFM
+calls. Until that trade is made deliberately: do not call `close()` on one thread while another
+thread might still be calling any method on the same object — synchronize externally if your
+usage can't rule that out.
+
 The second hazard is *ownership transfer*. Several C API calls hand a pointer's ownership to another
 native object: `rocksdb_block_based_options_set_filter_policy` makes the table options responsible
 for destroying the filter policy. Closing the Java wrapper afterwards would be a double free. The

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -317,7 +317,8 @@ Reopening requires listing every existing column family, `default` included — 
 | `CopyResult`      | Sealed: `Copied()`, `NotEnoughCapacity(long required)`, `NotFound()`                         |
 | `RocksDBException`| Unchecked; thrown for a genuine RocksDB-reported error (see [explanation.md#errors-are-always-loud](explanation.md#errors-are-always-loud)) |
 | `NativeObject`    | Base class of every native wrapper; `ptr()`, `close()` (idempotent), abstract `tryClose`      |
-| `NativeObjectWithBaseDb` | `NativeObject` subclass for wrappers with a second owned pointer (`TransactionDB`/`OptimisticTransactionDB`'s `rocksdb_t*` "base DB"); guarded `dbPtr()`, hooks `tryCloseBaseDb`/`tryClosePrimary` — see [explanation.md](explanation.md#lifecycle-and-ownership) |
+| `NativeObjectWithChildren` | `NativeObject` subclass for wrappers that can produce children borrowing their pointer (every DB type producing `Snapshot`); `registerChild`/`unregisterChild`, closes children before `tryCloseResource` — see [explanation.md](explanation.md#lifecycle-and-ownership) |
+| `NativeObjectWithBaseDb` | `NativeObjectWithChildren` subclass for wrappers with a second owned pointer (`TransactionDB`/`OptimisticTransactionDB`'s `rocksdb_t*` "base DB"); guarded `dbPtr()`, hooks `tryCloseBaseDb`/`tryClosePrimary` — see [explanation.md](explanation.md#lifecycle-and-ownership) |
 
 `Path` is used for every filesystem argument; there is no `String` path overload anywhere.
 


### PR DESCRIPTION
## Summary
- `Snapshot` held a raw `dbPtr` (the owning DB's native pointer), read unguarded in `tryClose()` to call `rocksdb_release_snapshot`. If the DB was closed before the snapshot (`db.close(); snap.close();`), `dbPtr` was already dangling — the release call operated on freed memory. Reproduced directly before fixing: crashed the JVM (VM crash, exit 134).
- First pass had `Snapshot` check `owningDb.ptr()` (a liveness check) before releasing. Review caught that this only traded the crash for two lesser problems: a **native memory leak** when the DB closes first (verified against `rocksdb/db/db_impl/db_impl.cc`/`snapshot_impl.h` — `~DBImpl()` never frees outstanding ordinary snapshots, only `ReleaseSnapshot` does, so skipping the release call leaks the `SnapshotImpl` and its C-API wrapper), and a **TOCTOU race** if the DB closes concurrently between the check and the release call.
- Fixed properly: the owning DB now tracks its outstanding snapshots and releases them itself, synchronously, before destroying its own native handle — instead of `Snapshot` defensively checking whether its parent is still alive. Extracted as `NativeObjectWithChildren` (`registerChild`/`unregisterChild`, closes children before delegating to `tryCloseResource`) rather than adding a `children` field to every `NativeObject` — only the DB types that can produce snapshots need it (`ReadWriteDB`, `ReadOnlyDB`, `TtlDB`, `BlobDB`, `SecondaryDB` directly; `TransactionDB`/`OptimisticTransactionDB` via `NativeObjectWithBaseDb`, which now extends it).
- `Snapshot` registers with its owning DB at construction and unregisters on its own close; if the DB closes first, the still-registered snapshot is released as part of that same `close()` call, using the DB's pointer before it's freed. This removes the ordering hazard by construction — `Snapshot`'s release code no longer needs to ask "is my pointer still good," the design guarantees it.
- Docs updated: `docs/explanation.md` gets a fourth "lifecycle and ownership" hazard section, `docs/reference.md`'s type table gets `NativeObjectWithChildren`.

Closes #104.

## Test plan
- [x] `./mvnw test` — 857 tests pass
- [x] `./mvnw javadoc:javadoc -pl core` — 0 checkstyle violations, 0 javadoc errors
- [x] Reproduced the original crash with a throwaway test before fixing, confirmed it's gone after
- [x] Regression test asserts the auto-release actually ran (`snap.ptr()` throws `IllegalStateException` immediately after `db.close()`, before `snap.close()` is ever called), not just that nothing crashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)