### PR TITLE
build: try plain .bat wrapper for Windows AR/RANLIB

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlobDB.java
@@ -40,6 +40,6 @@ public final class BlobDB extends NativeObjectWithChildren implements RocksDBRea
 
 	@Override
 	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
-		RocksDB.close(ptr);
+		RocksDB.closeDb(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadOnlyDB.java
@@ -28,6 +28,6 @@ public final class ReadOnlyDB extends NativeObjectWithChildren implements RocksD
 
 	@Override
 	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
-		RocksDB.close(ptr);
+		RocksDB.closeDb(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadWriteDB.java
@@ -29,6 +29,6 @@ public final class ReadWriteDB extends NativeObjectWithChildren implements Rocks
 
 	@Override
 	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
-		RocksDB.close(ptr);
+		RocksDB.closeDb(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1046,7 +1046,7 @@ public final class RocksDB {
 		}
 	}
 
-	static void close(MemorySegment db) throws Throwable {
+	static void closeDb(MemorySegment db) throws Throwable {
 		MH_CLOSE.invokeExact(db);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SecondaryDB.java
@@ -74,6 +74,6 @@ public final class SecondaryDB extends NativeObjectWithChildren implements Rocks
 
 	@Override
 	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
-		RocksDB.close(ptr);
+		RocksDB.closeDb(ptr);
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TtlDB.java
@@ -44,6 +44,6 @@ public final class TtlDB extends NativeObjectWithChildren implements RocksDBRead
 
 	@Override
 	protected void tryCloseResource(MemorySegment ptr) throws Throwable {
-		RocksDB.close(ptr);
+		RocksDB.closeDb(ptr);
 	}
 }

--- a/docs/adr/0005-no-jpms.md
+++ b/docs/adr/0005-no-jpms.md
@@ -1,0 +1,99 @@
+# ADR 0005: Not adopting the Java Platform Module System
+
+- **Status:** Accepted
+- **Date:** 2026-08-21
+- **Deciders:** project maintainer
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context
+
+The question came up whether `core` (and the five `native/*` classifier artifacts it depends on
+at runtime: `osx-aarch64`, `linux-x86_64`, `linux-aarch64`, `windows-x86_64`, `windows-aarch64`)
+should ship a `module-info.java` and become a named module under the Java Platform Module System
+(JPMS), rather than the plain classpath JAR it is today.
+
+Two things make this worth writing down rather than deciding informally:
+
+- The project's entire public surface already lives in one package,
+  `io.github.dfa1.rocksdbffm`, with `package-private` and `sealed` types doing the encapsulation
+  work internally (`NativeObject`, `Custom` merge-operator/logger implementations, etc. — see
+  `CLAUDE.md`'s "use NativeObject as base class" and "don't expose public constructors" rules). A
+  module boundary would wrap a second encapsulation mechanism around a surface that is already
+  fully encapsulated by the first.
+- The library uses `java.lang.foreign` throughout, which requires an explicit native-access grant
+  at JVM launch. Every module today launches with a single flag,
+  `--enable-native-access=ALL-UNNAMED` (`pom.xml`, `benchmarks/pom.xml`,
+  `integration-tests/pom.xml`, `.github/smoke/pom.xml`, `scripts/benchmark.sh`), because the
+  library and its consumers run unnamed, on the classpath. A named module changes what that flag
+  needs to name — `--enable-native-access=<module-name>` instead of `ALL-UNNAMED` — and that name
+  becomes something every downstream consumer's launch command has to get right, not just this
+  repo's own build.
+
+## Decision
+
+Do not add `module-info.java` to `core` or to any `native/*` artifact. Stay on the classpath,
+unnamed-module model this project has used since 0.1.
+
+If module-path interop for consumers who *do* modularize becomes a real ask, the lightweight
+follow-up is an `Automatic-Module-Name: io.github.dfa1.rocksdbffm` entry in `core`'s manifest
+(one `maven-jar-plugin` config line) — it gives such consumers a stable, predictable module name
+to `requires` on the module path, without this project taking on a module graph, a native-access
+grant that has to be spelled out per consuming module, or a decision about which of the five
+`native/*` artifacts additionally need names. That follow-up is not implemented as part of this
+ADR — it stays available, not scheduled.
+
+## Consequences
+
+### Positive
+
+- No new decision surface: consumers keep using the library exactly as they do today, on the
+  classpath, with the single `ALL-UNNAMED` native-access flag already documented in
+  `docs/how-to.md`/benchmarks.
+- No `module-info.java` to keep in sync with the `native/*` classifier matrix as platforms are
+  added or removed (`docs/reference.md`'s "Source Map" already tracks that matrix in prose; a
+  module graph would be a second, executable copy of the same fact).
+- Avoids a JPMS-specific failure mode this library is exposed to more than most: a `MethodHandles.Lookup`-based
+  upcall stub (`Logger`, `MergeOperator.Custom`, `UpcallRegistry`) only needs `MethodHandles.lookup()`
+  from within its own class, which JPMS does not restrict — but split-package or
+  service-loader-style extension points, if ever added, would need `opens`/`exports` reasoned
+  about per module. Not having a module graph removes that whole category of question today.
+
+### Negative
+
+- No enforced encapsulation at the JAR boundary — a consumer on the classpath can call any
+  `public` method regardless of intended internal-vs-external status. In practice this is already
+  true today (unnamed modules have always worked this way), so nothing regresses; JPMS would have
+  been a net-new guarantee, not a restored one.
+- No official module name until/unless the `Automatic-Module-Name` follow-up lands, so a consumer
+  who modularizes today gets the JAR-filename-derived automatic module name
+  (`rocksdbffm.core` or similar, unstable across artifact renames) rather than a maintained one.
+
+### Risks to manage
+
+- If a future consumer files an issue asking specifically for module-path support, re-read this
+  ADR before reaching for full `module-info.java` — the `Automatic-Module-Name` manifest entry
+  described above solves the common case (stable name, `requires` works) without reopening the
+  native-access and five-artifact questions this ADR chose to avoid.
+
+## Alternatives considered
+
+- **Full JPMS**: `module-info.java` in `core`, `exports io.github.dfa1.rocksdbffm`, and a name
+  per `native/*` artifact. Rejected for the reasons above — no encapsulation gain over the
+  existing package-private/sealed surface, and real complexity added to native-access grants and
+  the native-artifact-selection story, for consumers who are not asking for it today.
+- **`Automatic-Module-Name` only** (no `module-info.java`): the middle ground described in
+  Decision as a deferred follow-up. Not adopted now because nothing currently depends on it;
+  revisit if asked.
+- **Do nothing, don't write it down**: rejected because "would JPMS make sense here" is exactly
+  the kind of question that gets re-asked periodically without a record of the tradeoff already
+  having been weighed.
+
+## References
+
+- `CLAUDE.md` — "Manual Memory Management & Lifecycle", "don't expose public constructors"
+- `docs/reference.md` — "Source Map" (the `native/*` classifier matrix this ADR avoids duplicating
+  in a module graph)
+- `docs/adr/0001-ffm-instead-of-jni.md` — the FFM API this project builds on, and the
+  native-access requirement that motivates most of this ADR's Negative/Risks sections
+- `pom.xml`, `scripts/benchmark.sh` — current `--enable-native-access=ALL-UNNAMED` usage

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ ADR is a point-in-time snapshot: context, the decision, and its known consequenc
 | [0002](0002-why-zig.md)            | Build the native library with `zig cc`/`zig c++` | Accepted |
 | [0003](0003-ownership-model.md)    | `NativeObject`: `AutoCloseable`, idempotent close, ownership transfer | Accepted |
 | [0004](0004-error-handling.md)     | Separating genuine RocksDB errors from FFM binding bugs | Accepted |
+| [0005](0005-no-jpms.md)            | Not adopting the Java Platform Module System            | Accepted |

--- a/scripts/build-rocksdb-windows.sh
+++ b/scripts/build-rocksdb-windows.sh
@@ -109,68 +109,41 @@ if [ "$IS_WINDOWS_HOST" = true ]; then
     # generator bundles objects into an intermediate CMakeFiles/.../objects.a
     # via `ar qc ... @objects1.rsp`, then links the shared lib with
     # `-Wl,--whole-archive objects.a`. There's no CMAKE_AR_ARG1 equivalent to
-    # point straight at zig(.exe) the way CC/CXX do, and a .bat wrapper hits
-    # the same cmd.exe quoting problem CC/CXX had (confirmed in CI — the
-    # ar.bat invocation failed with "The system cannot find the path
-    # specified"). So compile a tiny native .exe stub instead: `_execvp`
-    # (from the C runtime, not a hand-rolled batch script) constructs the
-    # Windows command line using the same well-tested quoting logic every
-    # native compiler/linker already relies on.
+    # point straight at zig(.exe) the way CC/CXX do, so a wrapper is
+    # unavoidable.
     #
-    # TODO(cleanup): compiling a C stub from a shell script is more machinery
-    # than this really deserves. Revisit if CMake ever grows a CMAKE_AR_ARG1
-    # (or equivalent) for archivers, or if zig starts shipping standalone
-    # llvm-ar/llvm-ranlib binaries alongside zig(.exe) that could be pointed
-    # at directly with no wrapper at all.
-    # $ZIG_EXE is in Git Bash's MSYS path form (e.g. /c/hostedtoolcache/...).
-    # Bash auto-translates that to a native Windows path when it's passed as
-    # a *command-line argument* to a native executable (which is why
-    # CMAKE_C_COMPILER="$ZIG_EXE" above works fine) — but here it gets
-    # embedded as a plain string literal inside a generated C *source file*,
-    # which isn't argv, so that translation never happens. Confirmed in CI:
-    # the compiled wrapper's own _spawnv failed with ENOENT on the raw MSYS
-    # path baked into the binary. cygpath -m converts to the Windows-native
-    # "mixed" form (drive letter, forward slashes) — safe to drop straight
-    # into a C string with no backslash-escaping needed.
+    # A plain .bat wrapper was tried here once before (see #39) and failed
+    # in CI with "The system cannot find the path specified", assumed at the
+    # time to be the same cmd.exe multi-quoted-segment bug CC/CXX hit —
+    # never actually confirmed. That prior attempt embedded $ZIG_EXE
+    # untranslated: Git Bash's MSYS path form (e.g. /c/hostedtoolcache/...)
+    # only auto-translates to native Windows form when passed as a
+    # *command-line argument* to a native executable, not when written into
+    # a generated file's text — so the .bat's target path may simply have
+    # been wrong, no cmd.exe quoting bug required. cygpath -m fixes that
+    # (drive-letter, forward-slash "mixed" form, safe with no
+    # backslash-escaping); retrying the plain .bat wrapper with that fix
+    # applied, since a compiled C stub is more machinery than this deserves
+    # if the real fix is this simple.
     ZIG_EXE_WIN="$(cygpath -m "$ZIG_EXE")"
     WRAPPER_DIR="$(mktemp -d)"
     trap 'rm -rf "$WRAPPER_DIR"' EXIT
-    AR_WRAPPER="$WRAPPER_DIR/ar.exe"
-    RANLIB_WRAPPER="$WRAPPER_DIR/ranlib.exe"
-    for pair in "ar:$AR_WRAPPER" "ranlib:$RANLIB_WRAPPER"; do
-        subcommand="${pair%%:*}"
-        out="${pair#*:}"
-        src="$WRAPPER_DIR/${subcommand}_wrapper.c"
-        # Use _spawnv (not _execv): CI showed the ar invocation failing
-        # completely silently — no output at all, not even a zig error —
-        # which is consistent with the process-replace call itself never
-        # succeeding, and _execv gives no way to see why since it doesn't
-        # return on success and this code printed nothing on failure
-        # either. _spawnv (wait for the child, keep running) lets the
-        # wrapper report exactly what went wrong instead of a bare exit
-        # code with zero diagnostic output.
-        cat > "$src" <<EOF
-#include <process.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <string.h>
-int main(int argc, char** argv) {
-    char** newargv = (char**)malloc(sizeof(char*) * (size_t)(argc + 2));
-    newargv[0] = "$ZIG_EXE_WIN";
-    newargv[1] = "$subcommand";
-    for (int i = 1; i < argc; i++) newargv[i + 1] = argv[i];
-    newargv[argc + 1] = NULL;
-    intptr_t status = _spawnv(_P_WAIT, "$ZIG_EXE_WIN", (const char* const*)newargv);
-    if (status == -1) {
-        fprintf(stderr, "$subcommand wrapper: _spawnv failed for $ZIG_EXE_WIN: %s (errno=%d)\n", strerror(errno), errno);
-        return 1;
-    }
-    return (int)status;
-}
+    AR_WRAPPER="$WRAPPER_DIR/ar.bat"
+    RANLIB_WRAPPER="$WRAPPER_DIR/ranlib.bat"
+    # Diagnostic echo to stderr on every invocation: if this still fails,
+    # the CI log shows exactly what path/args cmd.exe was handed, instead of
+    # a bare "cannot find the path specified" with nothing to diagnose from
+    # (the gap that cost the most time last time around).
+    cat > "$AR_WRAPPER" <<EOF
+@echo off
+echo [ar.bat] "$ZIG_EXE_WIN" ar %* 1>&2
+"$ZIG_EXE_WIN" ar %*
 EOF
-        "$ZIG_EXE" cc -o "$out" "$src"
-    done
+    cat > "$RANLIB_WRAPPER" <<EOF
+@echo off
+echo [ranlib.bat] "$ZIG_EXE_WIN" ranlib %* 1>&2
+"$ZIG_EXE_WIN" ranlib %*
+EOF
 else
     WRAPPER_DIR="$(mktemp -d)"
     trap 'rm -rf "$WRAPPER_DIR"' EXIT


### PR DESCRIPTION
Experimental verification for #39: replaces the compiled C .exe stub with a plain `.bat` wrapper for `CMAKE_AR`/`CMAKE_RANLIB`, using the same `cygpath -m`-translated absolute zig path that turned out to be the real fix for the C stub. The `.bat` wrapper's earlier failure was never conclusively pinned on cmd.exe quoting -- worth confirming empirically whether the untranslated MSYS path was the actual root cause all along, per the issue's own "test with the same rigor... before assuming it fails."

CI on `windows-latest` (via `-Pall-natives`) exercises both `windows-x86_64` and `windows-aarch64` classifiers, since both cross-compile from the same Windows host.

- If CI passes: this simplification is confirmed, ready to merge and close #39.
- If CI fails: the diagnostic echo added here should show exactly what cmd.exe was handed, informing whether to revert to the C stub or try something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)