### PR TITLE
Type read-side RocksDB helpers on objects, not raw pointers

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -722,14 +722,14 @@ public final class RocksDB {
 	/// [PinnableSlice].
 	///
 	/// Returns `null` if not found.
-	static byte[] getBytes(MemorySegment db, MemorySegment readOpts, byte[] key) {
+	static byte[] getBytes(RocksDBReadOperations db, ReadOptions readOpts, byte[] key) {
 		// Single arena: it already needs one to marshal `key`, and withPinned would open
 		// its own, paying for two Arena.ofConfined() per get instead of one.
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment k = toNative(arena, key);
 			MemorySegment handle = (MemorySegment) MH_GET_PINNED_V2.invokeExact(
-					db, readOpts, k, (long) key.length, err);
+					db.dbPtr(), readOpts.ptr(), k, (long) key.length, err);
 			checkError(err);
 			if (MemorySegment.NULL.equals(handle)) {
 				return null;
@@ -744,12 +744,12 @@ public final class RocksDB {
 
 	/// ByteBuffer get via `rocksdb_get_into_buffer` — copies directly into the caller's buffer,
 	/// with no intermediate PinnableSlice. Copies nothing when the buffer is too small.
-	static CopyResult getIntoBuffer(MemorySegment db, MemorySegment readOpts, MemorySegment key, long keyLen, ByteBuffer value) {
+	static CopyResult getIntoBuffer(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, long keyLen, ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
-			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db, readOpts, key, keyLen,
+			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db.dbPtr(), readOpts.ptr(), key, keyLen,
 					MemorySegment.ofBuffer(value), (long) value.remaining(), valLenSeg, foundSeg, err);
 			checkError(err);
 			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
@@ -768,12 +768,12 @@ public final class RocksDB {
 
 	/// MemorySegment get via `rocksdb_get_into_buffer` — copies directly into the caller's
 	/// segment, with no intermediate PinnableSlice. Copies nothing when `value` is too small.
-	static CopyResult getIntoSegment(MemorySegment db, MemorySegment readOpts, MemorySegment key, long keyLen, MemorySegment value) {
+	static CopyResult getIntoSegment(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, long keyLen, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
-			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db, readOpts, key, keyLen,
+			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db.dbPtr(), readOpts.ptr(), key, keyLen,
 					value, value.byteSize(), valLenSeg, foundSeg, err);
 			checkError(err);
 			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
@@ -795,10 +795,10 @@ public final class RocksDB {
 
 	/// Scoped zero-copy get via `rocksdb_get_pinned_v2`. [PinnableHandle] owns the pinned
 	/// value's lifetime and every way it gets consumed.
-	static <R> Optional<R> withPinned(MemorySegment db, MemorySegment readOpts, MemorySegment key, Mapper<R> fn) {
+	static <R> Optional<R> withPinned(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment handle = (MemorySegment) MH_GET_PINNED_V2.invokeExact(db, readOpts, key, key.byteSize(), err);
+			MemorySegment handle = (MemorySegment) MH_GET_PINNED_V2.invokeExact(db.dbPtr(), readOpts.ptr(), key, key.byteSize(), err);
 			checkError(err);
 			if (MemorySegment.NULL.equals(handle)) {
 				return Optional.empty();
@@ -813,12 +813,12 @@ public final class RocksDB {
 
 	/// Scoped zero-copy get from `cf` via `rocksdb_get_pinned_cf_v2`. See [#withPinned]
 	/// for the lifetime contract.
-	static <R> Optional<R> withPinnedCf(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
+	static <R> Optional<R> withPinnedCf(RocksDBReadOperations db, ReadOptions readOpts, ColumnFamilyHandle cf,
 	                                     MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment handle = (MemorySegment) MH_GET_PINNED_CF_V2.invokeExact(
-					db, readOpts, cf.ptr(), key, key.byteSize(), err);
+					db.dbPtr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			checkError(err);
 			if (MemorySegment.NULL.equals(handle)) {
 				return Optional.empty();
@@ -1022,21 +1022,21 @@ public final class RocksDB {
 		}
 	}
 
-	static Optional<String> getProperty(MemorySegment db, Property property) {
+	static Optional<String> getProperty(RocksDBReadOperations db, Property property) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment propSeg = arena.allocateFrom(property.propertyName());
-			MemorySegment result = (MemorySegment) MH_PROPERTY_VALUE.invokeExact(db, propSeg);
+			MemorySegment result = (MemorySegment) MH_PROPERTY_VALUE.invokeExact(db.dbPtr(), propSeg);
 			return toOptionalString(result);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("getProperty failed", t);
 		}
 	}
 
-	static OptionalLong getLongProperty(MemorySegment db, Property property) {
+	static OptionalLong getLongProperty(RocksDBReadOperations db, Property property) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment propSeg = arena.allocateFrom(property.propertyName());
 			MemorySegment out = arena.allocate(ValueLayout.JAVA_LONG);
-			int rc = (int) MH_PROPERTY_INT.invokeExact(db, propSeg, out);
+			int rc = (int) MH_PROPERTY_INT.invokeExact(db.dbPtr(), propSeg, out);
 			if (rc != 0) {
 				return OptionalLong.empty();
 			}
@@ -1110,10 +1110,10 @@ public final class RocksDB {
 		}
 	}
 
-	static boolean keyMayExistSegment(MemorySegment db, MemorySegment roOpts,
+	static boolean keyMayExistSegment(RocksDBReadOperations db, ReadOptions roOpts,
 	                                  MemorySegment key, long keyLen) {
 		try {
-			return fromByte((byte) MH_KEY_MAY_EXIST.invokeExact(db, roOpts, key, keyLen,
+			return fromByte((byte) MH_KEY_MAY_EXIST.invokeExact(db.dbPtr(), roOpts.ptr(), key, keyLen,
 					MemorySegment.NULL, MemorySegment.NULL,
 					MemorySegment.NULL, 0L, MemorySegment.NULL));
 		} catch (Throwable t) {
@@ -1123,7 +1123,7 @@ public final class RocksDB {
 
 	/// [#keyMayExistSegment] for a `byte[]` key: marshals `key` into a scratch [Arena]
 	/// before delegating.
-	static boolean keyMayExistBytes(MemorySegment db, MemorySegment roOpts, byte[] key) {
+	static boolean keyMayExistBytes(RocksDBReadOperations db, ReadOptions roOpts, byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
 			return keyMayExistSegment(db, roOpts, toNative(arena, key), key.length);
 		}
@@ -1651,14 +1651,14 @@ public final class RocksDB {
 	/// Single-copy byte[] get from `cf` via `rocksdb_get_pinned_cf_v2`. See [#getBytes] for
 	/// why this pins rather than calling `rocksdb_get`, and why it uses the `_v2` handle.
 	/// Returns `null` if not found.
-	static byte[] getCfBytes(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
+	static byte[] getCfBytes(RocksDBReadOperations db, ReadOptions readOpts, ColumnFamilyHandle cf,
 	                         byte[] key) {
 		// Single arena, same reasoning as getBytes above.
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment k = toNative(arena, key);
 			MemorySegment handle = (MemorySegment) MH_GET_PINNED_CF_V2.invokeExact(
-					db, readOpts, cf.ptr(), k, (long) key.length, err);
+					db.dbPtr(), readOpts.ptr(), cf.ptr(), k, (long) key.length, err);
 			checkError(err);
 			if (MemorySegment.NULL.equals(handle)) {
 				return null;
@@ -1673,13 +1673,13 @@ public final class RocksDB {
 
 	/// ByteBuffer get with explicit column family via `rocksdb_get_into_buffer_cf`.
 	/// Copies nothing when the buffer is too small.
-	static CopyResult getCfIntoBuffer(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
+	static CopyResult getCfIntoBuffer(RocksDBReadOperations db, ReadOptions readOpts, ColumnFamilyHandle cf,
 	                                  MemorySegment key, long keyLen, ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
-			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db, readOpts, cf.ptr(), key, keyLen,
+			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db.dbPtr(), readOpts.ptr(), cf.ptr(), key, keyLen,
 					MemorySegment.ofBuffer(value), (long) value.remaining(), valLenSeg, foundSeg, err);
 			checkError(err);
 			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
@@ -1698,13 +1698,13 @@ public final class RocksDB {
 
 	/// MemorySegment get with explicit column family via `rocksdb_get_into_buffer_cf` —
 	/// copies directly into the caller's segment. Copies nothing when `value` is too small.
-	static CopyResult getCfIntoSegment(MemorySegment db, MemorySegment readOpts, ColumnFamilyHandle cf,
+	static CopyResult getCfIntoSegment(RocksDBReadOperations db, ReadOptions readOpts, ColumnFamilyHandle cf,
 	                                   MemorySegment key, long keyLen, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
-			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db, readOpts, cf.ptr(), key, keyLen,
+			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db.dbPtr(), readOpts.ptr(), cf.ptr(), key, keyLen,
 					value, value.byteSize(), valLenSeg, foundSeg, err);
 			checkError(err);
 			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
@@ -1789,11 +1789,11 @@ public final class RocksDB {
 		}
 	}
 
-	static boolean keyMayExistCfSegment(MemorySegment db, MemorySegment roOpts,
+	static boolean keyMayExistCfSegment(RocksDBReadOperations db, ReadOptions roOpts,
 	                                    ColumnFamilyHandle cf,
 	                                    MemorySegment key, long keyLen) {
 		try {
-			return fromByte((byte) MH_KEY_MAY_EXIST_CF.invokeExact(db, roOpts, cf.ptr(), key, keyLen,
+			return fromByte((byte) MH_KEY_MAY_EXIST_CF.invokeExact(db.dbPtr(), roOpts.ptr(), cf.ptr(), key, keyLen,
 					MemorySegment.NULL, MemorySegment.NULL,
 					MemorySegment.NULL, 0L, MemorySegment.NULL));
 		} catch (Throwable t) {
@@ -1803,18 +1803,18 @@ public final class RocksDB {
 
 	/// [#keyMayExistCfSegment] for a `byte[]` key: marshals `key` into a scratch [Arena]
 	/// before delegating.
-	static boolean keyMayExistCfBytes(MemorySegment db, MemorySegment roOpts,
+	static boolean keyMayExistCfBytes(RocksDBReadOperations db, ReadOptions roOpts,
 	                                  ColumnFamilyHandle cf, byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
 			return keyMayExistCfSegment(db, roOpts, cf, toNative(arena, key), key.length);
 		}
 	}
 
-	static RocksIterator createIteratorCf(MemorySegment db, MemorySegment readOpts,
+	static RocksIterator createIteratorCf(RocksDBReadOperations db, ReadOptions readOpts,
 	                                      ColumnFamilyHandle cf) {
 		try {
 			MemorySegment iterPtr = (MemorySegment) MH_CREATE_ITERATOR_CF.invokeExact(
-					db, readOpts, cf.ptr());
+					db.dbPtr(), readOpts.ptr(), cf.ptr());
 			return RocksIterator.create(iterPtr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("newIterator failed", t);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
@@ -39,7 +39,7 @@ public interface RocksDBReadOperations {
 	/// @param key key bytes to look up
 	/// @return value bytes, or `null` if the key does not exist
 	default byte[] get(byte[] key) {
-		return RocksDB.getBytes(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), key);
+		return RocksDB.getBytes(this, RocksDB.DEFAULT_READ_OPTIONS, key);
 	}
 
 	/// Get with explicit [ReadOptions], e.g. for snapshot-pinned reads. Returns `null` if not found.
@@ -48,7 +48,7 @@ public interface RocksDBReadOperations {
 	/// @param key         key bytes to look up
 	/// @return value bytes, or `null` if the key does not exist
 	default byte[] get(ReadOptions readOptions, byte[] key) {
-		return RocksDB.getBytes(dbPtr(), readOptions.ptr(), key);
+		return RocksDB.getBytes(this, readOptions, key);
 	}
 
 	/// Single-copy get via `rocksdb_get_into_buffer` + direct output [ByteBuffer].
@@ -59,7 +59,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ByteBuffer key, ByteBuffer value) {
-		return RocksDB.getIntoBuffer(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(),
+		return RocksDB.getIntoBuffer(this, RocksDB.DEFAULT_READ_OPTIONS,
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
@@ -71,7 +71,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ReadOptions readOptions, ByteBuffer key, ByteBuffer value) {
-		return RocksDB.getIntoBuffer(dbPtr(), readOptions.ptr(),
+		return RocksDB.getIntoBuffer(this, readOptions,
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
@@ -83,7 +83,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(MemorySegment key, MemorySegment value) {
-		return RocksDB.getIntoSegment(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), key, key.byteSize(), value);
+		return RocksDB.getIntoSegment(this, RocksDB.DEFAULT_READ_OPTIONS, key, key.byteSize(), value);
 	}
 
 	/// [#get(MemorySegment, MemorySegment)] with explicit [ReadOptions].
@@ -94,7 +94,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ReadOptions readOptions, MemorySegment key, MemorySegment value) {
-		return RocksDB.getIntoSegment(dbPtr(), readOptions.ptr(), key, key.byteSize(), value);
+		return RocksDB.getIntoSegment(this, readOptions, key, key.byteSize(), value);
 	}
 
 	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
@@ -111,7 +111,7 @@ public interface RocksDBReadOperations {
 	/// @throws NullPointerException if `fn` returns `null`
 	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
 	default <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
-		return RocksDB.withPinned(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), key, fn);
+		return RocksDB.withPinned(this, RocksDB.DEFAULT_READ_OPTIONS, key, fn);
 	}
 
 	/// [#get(MemorySegment, Mapper)] with explicit [ReadOptions].
@@ -123,7 +123,7 @@ public interface RocksDBReadOperations {
 	/// @throws NullPointerException if `fn` returns `null`
 	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
 	default <R> Optional<R> get(ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
-		return RocksDB.withPinned(dbPtr(), readOptions.ptr(), key, fn);
+		return RocksDB.withPinned(this, readOptions, key, fn);
 	}
 
 	/// Returns the value for `key` in `cf`, or `null` if not found.
@@ -132,7 +132,7 @@ public interface RocksDBReadOperations {
 	/// @param key key bytes to look up
 	/// @return value bytes, or `null` if the key does not exist
 	default byte[] get(ColumnFamilyHandle cf, byte[] key) {
-		return RocksDB.getCfBytes(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), cf, key);
+		return RocksDB.getCfBytes(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key);
 	}
 
 	/// Get from `cf` with explicit [ReadOptions]. Returns `null` if not found.
@@ -142,7 +142,7 @@ public interface RocksDBReadOperations {
 	/// @param key         key bytes to look up
 	/// @return value bytes, or `null` if the key does not exist
 	default byte[] get(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
-		return RocksDB.getCfBytes(dbPtr(), readOptions.ptr(), cf, key);
+		return RocksDB.getCfBytes(this, readOptions, cf, key);
 	}
 
 	/// Single-copy get from `cf` via `rocksdb_get_into_buffer_cf` + direct output [ByteBuffer].
@@ -154,7 +154,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
-		return RocksDB.getCfIntoBuffer(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), cf,
+		return RocksDB.getCfIntoBuffer(this, RocksDB.DEFAULT_READ_OPTIONS, cf,
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
@@ -167,7 +167,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ColumnFamilyHandle cf, ReadOptions readOptions, ByteBuffer key, ByteBuffer value) {
-		return RocksDB.getCfIntoBuffer(dbPtr(), readOptions.ptr(), cf,
+		return RocksDB.getCfIntoBuffer(this, readOptions, cf,
 				MemorySegment.ofBuffer(key), key.remaining(), value);
 	}
 
@@ -180,7 +180,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		return RocksDB.getCfIntoSegment(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), cf, key, key.byteSize(), value);
+		return RocksDB.getCfIntoSegment(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key, key.byteSize(), value);
 	}
 
 	/// [#get(ColumnFamilyHandle, MemorySegment, MemorySegment)] with explicit [ReadOptions].
@@ -192,7 +192,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key, MemorySegment value) {
-		return RocksDB.getCfIntoSegment(dbPtr(), readOptions.ptr(), cf, key, key.byteSize(), value);
+		return RocksDB.getCfIntoSegment(this, readOptions, cf, key, key.byteSize(), value);
 	}
 
 	/// Scoped zero-copy get from `cf`. See [#get(MemorySegment, Mapper)] for
@@ -205,7 +205,7 @@ public interface RocksDBReadOperations {
 	/// @throws NullPointerException if `fn` returns `null`
 	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
 	default <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
-		return RocksDB.withPinnedCf(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), cf, key, fn);
+		return RocksDB.withPinnedCf(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key, fn);
 	}
 
 	/// [#get(ColumnFamilyHandle, MemorySegment, Mapper)] with explicit [ReadOptions].
@@ -218,7 +218,7 @@ public interface RocksDBReadOperations {
 	/// @throws NullPointerException if `fn` returns `null`
 	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
 	default <R> Optional<R> get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
-		return RocksDB.withPinnedCf(dbPtr(), readOptions.ptr(), cf, key, fn);
+		return RocksDB.withPinnedCf(this, readOptions, cf, key, fn);
 	}
 
 	// -----------------------------------------------------------------------
@@ -231,7 +231,7 @@ public interface RocksDBReadOperations {
 	/// @param key the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(byte[] key) {
-		return RocksDB.keyMayExistBytes(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), key);
+		return RocksDB.keyMayExistBytes(this, RocksDB.DEFAULT_READ_OPTIONS, key);
 	}
 
 	/// [#keyMayExist(byte\[\])] with explicit [ReadOptions].
@@ -240,7 +240,7 @@ public interface RocksDBReadOperations {
 	/// @param key         the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ReadOptions readOptions, byte[] key) {
-		return RocksDB.keyMayExistBytes(dbPtr(), readOptions.ptr(), key);
+		return RocksDB.keyMayExistBytes(this, readOptions, key);
 	}
 
 	/// Zero-copy for direct [ByteBuffer]s.
@@ -248,7 +248,7 @@ public interface RocksDBReadOperations {
 	/// @param key direct [ByteBuffer] containing the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ByteBuffer key) {
-		return RocksDB.keyMayExistSegment(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+		return RocksDB.keyMayExistSegment(this, RocksDB.DEFAULT_READ_OPTIONS, MemorySegment.ofBuffer(key), key.remaining());
 	}
 
 	/// Zero-copy for [MemorySegment]s.
@@ -256,7 +256,7 @@ public interface RocksDBReadOperations {
 	/// @param key native segment containing the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(MemorySegment key) {
-		return RocksDB.keyMayExistSegment(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), key, key.byteSize());
+		return RocksDB.keyMayExistSegment(this, RocksDB.DEFAULT_READ_OPTIONS, key, key.byteSize());
 	}
 
 	/// Returns `false` if the key definitely does not exist in `cf`; `true` means it _may_ exist.
@@ -265,7 +265,7 @@ public interface RocksDBReadOperations {
 	/// @param key the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ColumnFamilyHandle cf, byte[] key) {
-		return RocksDB.keyMayExistCfBytes(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), cf, key);
+		return RocksDB.keyMayExistCfBytes(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key);
 	}
 
 	/// [#keyMayExist(ColumnFamilyHandle, byte\[\])] with explicit [ReadOptions].
@@ -275,7 +275,7 @@ public interface RocksDBReadOperations {
 	/// @param key         the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ColumnFamilyHandle cf, ReadOptions readOptions, byte[] key) {
-		return RocksDB.keyMayExistCfBytes(dbPtr(), readOptions.ptr(), cf, key);
+		return RocksDB.keyMayExistCfBytes(this, readOptions, cf, key);
 	}
 
 	/// Zero-copy keyMayExist in `cf` for direct [ByteBuffer]s.
@@ -284,7 +284,7 @@ public interface RocksDBReadOperations {
 	/// @param key direct [ByteBuffer] containing the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ColumnFamilyHandle cf, ByteBuffer key) {
-		return RocksDB.keyMayExistCfSegment(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), cf,
+		return RocksDB.keyMayExistCfSegment(this, RocksDB.DEFAULT_READ_OPTIONS, cf,
 				MemorySegment.ofBuffer(key), key.remaining());
 	}
 
@@ -294,7 +294,7 @@ public interface RocksDBReadOperations {
 	/// @param key native segment containing the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ColumnFamilyHandle cf, MemorySegment key) {
-		return RocksDB.keyMayExistCfSegment(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), cf, key, key.byteSize());
+		return RocksDB.keyMayExistCfSegment(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key, key.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -305,7 +305,7 @@ public interface RocksDBReadOperations {
 	///
 	/// @return a new [RocksIterator]; caller must close it
 	default RocksIterator newIterator() {
-		return RocksIterator.create(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr());
+		return RocksIterator.create(this, RocksDB.DEFAULT_READ_OPTIONS);
 	}
 
 	/// Returns a new iterator using the supplied [ReadOptions].
@@ -313,7 +313,7 @@ public interface RocksDBReadOperations {
 	/// @param readOptions read options, e.g. containing a snapshot
 	/// @return a new [RocksIterator]; caller must close it
 	default RocksIterator newIterator(ReadOptions readOptions) {
-		return RocksIterator.create(dbPtr(), readOptions.ptr());
+		return RocksIterator.create(this, readOptions);
 	}
 
 	/// Returns a new iterator scoped to `cf` using the database's default read options.
@@ -321,7 +321,7 @@ public interface RocksDBReadOperations {
 	/// @param cf target column family
 	/// @return a new [RocksIterator]; caller must close it
 	default RocksIterator newIterator(ColumnFamilyHandle cf) {
-		return RocksDB.createIteratorCf(dbPtr(), RocksDB.DEFAULT_READ_OPTIONS.ptr(), cf);
+		return RocksDB.createIteratorCf(this, RocksDB.DEFAULT_READ_OPTIONS, cf);
 	}
 
 	/// Returns a new iterator scoped to `cf` using the supplied [ReadOptions].
@@ -330,7 +330,7 @@ public interface RocksDBReadOperations {
 	/// @param readOptions read options, e.g. containing a snapshot
 	/// @return a new [RocksIterator]; caller must close it
 	default RocksIterator newIterator(ColumnFamilyHandle cf, ReadOptions readOptions) {
-		return RocksDB.createIteratorCf(dbPtr(), readOptions.ptr(), cf);
+		return RocksDB.createIteratorCf(this, readOptions, cf);
 	}
 
 	// -----------------------------------------------------------------------
@@ -356,7 +356,7 @@ public interface RocksDBReadOperations {
 	/// @param property the property to query
 	/// @return the property value, or [Optional#empty()] if not supported
 	default Optional<String> getProperty(Property property) {
-		return RocksDB.getProperty(dbPtr(), property);
+		return RocksDB.getProperty(this, property);
 	}
 
 	/// Returns the value of a numeric DB property, or [OptionalLong#empty()] if not supported.
@@ -364,7 +364,7 @@ public interface RocksDBReadOperations {
 	/// @param property the property to query
 	/// @return the numeric property value, or [OptionalLong#empty()] if not supported
 	default OptionalLong getLongProperty(Property property) {
-		return RocksDB.getLongProperty(dbPtr(), property);
+		return RocksDB.getLongProperty(this, property);
 	}
 
 	/// Returns the value of a property scoped to `cf`, or [Optional#empty()] if not supported.

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
@@ -109,9 +109,9 @@ public final class RocksIterator extends NativeObject {
 	}
 
 	/// Package-private factory called by RocksDB.
-	static RocksIterator create(MemorySegment dbPtr, MemorySegment readOptions) {
+	static RocksIterator create(RocksDBReadOperations db, ReadOptions readOptions) {
 		try {
-			MemorySegment iterPtr = (MemorySegment) MH_CREATE.invokeExact(dbPtr, readOptions);
+			MemorySegment iterPtr = (MemorySegment) MH_CREATE.invokeExact(db.dbPtr(), readOptions.ptr());
 			return new RocksIterator(iterPtr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("iterator create failed", t);


### PR DESCRIPTION
## Summary

- `RocksDB.java`'s get/keyMayExist/newIterator/getProperty helpers backing `RocksDBReadOperations` already took `ColumnFamilyHandle` as an object (extracting `.ptr()` internally) instead of a raw pointer — `db` and `readOpts`/`roOpts` were the two remaining holdouts still typed as `MemorySegment`.
- Retyped both to `RocksDBReadOperations` and `ReadOptions` respectively, extracting `.dbPtr()`/`.ptr()` inside the helper instead of at each of the ~30 call sites in `RocksDBReadOperations.java`. Same treatment for `RocksIterator.create`'s two-arg overload, the third caller of this pattern.
- Verified every retyped method is called *exclusively* from `RocksDBReadOperations.java` before touching it. `getPropertyCf`/`getLongPropertyCf` are also called from `TransactionDB.java` (which does not implement `RocksDBReadOperations`) and keep their `MemorySegment db` parameter unchanged. `createSnapshot` is left alone too — it stores the raw `db` pointer in the returned `Snapshot` rather than only using it for one `invokeExact` call, so it doesn't fit this shape.

Pure refactor, no behavior change, no new tests needed.

## Test plan

- [x] `./mvnw -pl core -am clean test` — full core suite passes
- [x] `./mvnw -pl core javadoc:javadoc` — zero output
- [x] `./mvnw -pl integration-tests -am verify` — full integration suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)