### PR TITLE
Type write-side RocksDB helpers on objects, not raw pointers

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -832,12 +832,12 @@ public final class RocksDB {
 	}
 
 	/// byte[] put — slow path, allocates native memory.
-	static void putBytes(MemorySegment db, MemorySegment writeOpts, byte[] key, byte[] value) {
+	static void putBytes(RocksDBWriteOperations db, WriteOptions writeOpts, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment k = toNative(arena, key);
 			MemorySegment v = toNative(arena, value);
-			MH_PUT.invokeExact(db, writeOpts, k, (long) key.length, v, (long) value.length, err);
+			MH_PUT.invokeExact(db.dbPtr(), writeOpts.ptr(), k, (long) key.length, v, (long) value.length, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -845,12 +845,12 @@ public final class RocksDB {
 	}
 
 	/// byte[] put using the caller's arena.
-	static void putBytes(Arena arena, MemorySegment db, MemorySegment writeOpts, byte[] key, byte[] value) {
+	static void putBytes(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts, byte[] key, byte[] value) {
 		try {
 			MemorySegment err = errHolder(arena);
 			MemorySegment k = toNative(arena, key);
 			MemorySegment v = toNative(arena, value);
-			MH_PUT.invokeExact(db, writeOpts, k, (long) key.length, v, (long) value.length, err);
+			MH_PUT.invokeExact(db.dbPtr(), writeOpts.ptr(), k, (long) key.length, v, (long) value.length, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -858,11 +858,11 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment put — zero-copy, caller supplies pre-allocated native segments.
-	static void putSegment(MemorySegment db, MemorySegment writeOpts,
+	static void putSegment(RocksDBWriteOperations db, WriteOptions writeOpts,
 	                       MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_PUT.invokeExact(db, writeOpts, key, keyLen, val, valLen, err);
+			MH_PUT.invokeExact(db.dbPtr(), writeOpts.ptr(), key, keyLen, val, valLen, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -870,11 +870,11 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment put using the caller's arena.
-	static void putSegment(Arena arena, MemorySegment db, MemorySegment writeOpts,
+	static void putSegment(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts,
 	                       MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try {
 			MemorySegment err = errHolder(arena);
-			MH_PUT.invokeExact(db, writeOpts, key, keyLen, val, valLen, err);
+			MH_PUT.invokeExact(db.dbPtr(), writeOpts.ptr(), key, keyLen, val, valLen, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -882,21 +882,21 @@ public final class RocksDB {
 	}
 
 	/// byte[] merge — slow path, allocates native memory.
-	static void mergeBytes(MemorySegment db, MemorySegment writeOpts, byte[] key, byte[] value) {
+	static void mergeBytes(RocksDBWriteOperations db, WriteOptions writeOpts, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
 			mergeBytes(arena, db, writeOpts, key, value);
 		}
 	}
 
 	/// byte[] merge using the caller's arena.
-	static void mergeBytes(Arena arena, MemorySegment db, MemorySegment writeOpts, byte[] key, byte[] value) {
+	static void mergeBytes(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts, byte[] key, byte[] value) {
 		MemorySegment k = toNative(arena, key);
 		MemorySegment v = toNative(arena, value);
 		mergeSegment(arena, db, writeOpts, k, key.length, v, value.length);
 	}
 
 	/// MemorySegment merge — zero-copy, caller supplies pre-allocated native segments.
-	static void mergeSegment(MemorySegment db, MemorySegment writeOpts,
+	static void mergeSegment(RocksDBWriteOperations db, WriteOptions writeOpts,
 	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try (Arena arena = Arena.ofConfined()) {
 			mergeSegment(arena, db, writeOpts, key, keyLen, val, valLen);
@@ -904,11 +904,11 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment merge using the caller's arena.
-	static void mergeSegment(Arena arena, MemorySegment db, MemorySegment writeOpts,
+	static void mergeSegment(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts,
 	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try {
 			MemorySegment err = errHolder(arena);
-			MH_MERGE.invokeExact(db, writeOpts, key, keyLen, val, valLen, err);
+			MH_MERGE.invokeExact(db.dbPtr(), writeOpts.ptr(), key, keyLen, val, valLen, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("merge failed", t);
@@ -916,11 +916,11 @@ public final class RocksDB {
 	}
 
 	/// byte[] delete — slow path.
-	static void deleteBytes(MemorySegment db, MemorySegment writeOpts, byte[] key) {
+	static void deleteBytes(RocksDBWriteOperations db, WriteOptions writeOpts, byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment k = toNative(arena, key);
-			MH_DELETE.invokeExact(db, writeOpts, k, (long) key.length, err);
+			MH_DELETE.invokeExact(db.dbPtr(), writeOpts.ptr(), k, (long) key.length, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("delete failed", t);
@@ -928,74 +928,74 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment delete — zero-copy.
-	static void deleteSegment(MemorySegment db, MemorySegment writeOpts, MemorySegment key, long keyLen) {
+	static void deleteSegment(RocksDBWriteOperations db, WriteOptions writeOpts, MemorySegment key, long keyLen) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DELETE.invokeExact(db, writeOpts, key, keyLen, err);
+			MH_DELETE.invokeExact(db.dbPtr(), writeOpts.ptr(), key, keyLen, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("delete failed", t);
 		}
 	}
 
-	static void flush(MemorySegment db, FlushOptions flushOptions) {
+	static void flush(RocksDBWriteOperations db, FlushOptions flushOptions) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_FLUSH.invokeExact(db, flushOptions.ptr(), err);
+			MH_FLUSH.invokeExact(db.dbPtr(), flushOptions.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("flush failed", t);
 		}
 	}
 
-	static void cancelAllBackgroundWork(MemorySegment db, boolean wait) {
+	static void cancelAllBackgroundWork(RocksDBWriteOperations db, boolean wait) {
 		try {
-			MH_CANCEL_ALL_BACKGROUND_WORK.invokeExact(db, toByte(wait));
+			MH_CANCEL_ALL_BACKGROUND_WORK.invokeExact(db.dbPtr(), toByte(wait));
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("cancelAllBackgroundWork failed", t);
 		}
 	}
 
-	static void disableManualCompaction(MemorySegment db) {
+	static void disableManualCompaction(RocksDBWriteOperations db) {
 		try {
-			MH_DISABLE_MANUAL_COMPACTION.invokeExact(db);
+			MH_DISABLE_MANUAL_COMPACTION.invokeExact(db.dbPtr());
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("disableManualCompaction failed", t);
 		}
 	}
 
-	static void enableManualCompaction(MemorySegment db) {
+	static void enableManualCompaction(RocksDBWriteOperations db) {
 		try {
-			MH_ENABLE_MANUAL_COMPACTION.invokeExact(db);
+			MH_ENABLE_MANUAL_COMPACTION.invokeExact(db.dbPtr());
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("enableManualCompaction failed", t);
 		}
 	}
 
-	static void waitForCompact(MemorySegment db, WaitForCompactOptions options) {
+	static void waitForCompact(RocksDBWriteOperations db, WaitForCompactOptions options) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_WAIT_FOR_COMPACT.invokeExact(db, options.ptr(), err);
+			MH_WAIT_FOR_COMPACT.invokeExact(db.dbPtr(), options.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("waitForCompact failed", t);
 		}
 	}
 
-	static SequenceNumber getLatestSequenceNumber(MemorySegment db) {
+	static SequenceNumber getLatestSequenceNumber(RocksDBWriteOperations db) {
 		try {
-			long seq = (long) MH_GET_LATEST_SEQUENCE_NUMBER.invokeExact(db);
+			long seq = (long) MH_GET_LATEST_SEQUENCE_NUMBER.invokeExact(db.dbPtr());
 			return SequenceNumber.of(seq);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("getLatestSequenceNumber failed", t);
 		}
 	}
 
-	static WalIterator getUpdatesSince(MemorySegment db, SequenceNumber sequenceNumber) {
+	static WalIterator getUpdatesSince(RocksDBWriteOperations db, SequenceNumber sequenceNumber) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment iterPtr = (MemorySegment) MH_GET_UPDATES_SINCE.invokeExact(
-					db, sequenceNumber.toLong(), MemorySegment.NULL, err);
+					db.dbPtr(), sequenceNumber.toLong(), MemorySegment.NULL, err);
 			checkError(err);
 			return WalIterator.wrap(iterPtr);
 		} catch (Throwable t) {
@@ -1003,10 +1003,10 @@ public final class RocksDB {
 		}
 	}
 
-	static void flushWal(MemorySegment db, boolean sync) {
+	static void flushWal(RocksDBWriteOperations db, boolean sync) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_FLUSH_WAL.invokeExact(db, toByte(sync), err);
+			MH_FLUSH_WAL.invokeExact(db.dbPtr(), toByte(sync), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("flushWal failed", t);
@@ -1050,11 +1050,11 @@ public final class RocksDB {
 		MH_CLOSE.invokeExact(db);
 	}
 
-	static void deleteRangeCfBytes(MemorySegment db, MemorySegment writeOpts, byte[] startKey, byte[] endKey) {
+	static void deleteRangeCfBytes(RocksDBWriteOperations db, WriteOptions writeOpts, byte[] startKey, byte[] endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment cf = (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db);
-			MH_DELETE_RANGE_CF.invokeExact(db, writeOpts, cf,
+			MemorySegment cf = (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db.dbPtr());
+			MH_DELETE_RANGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf,
 					toNative(arena, startKey), (long) startKey.length,
 					toNative(arena, endKey), (long) endKey.length, err);
 			checkError(err);
@@ -1063,12 +1063,12 @@ public final class RocksDB {
 		}
 	}
 
-	static void deleteRangeCfBuffer(MemorySegment db, MemorySegment writeOpts,
+	static void deleteRangeCfBuffer(RocksDBWriteOperations db, WriteOptions writeOpts,
 	                                ByteBuffer startKey, ByteBuffer endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment cf = (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db);
-			MH_DELETE_RANGE_CF.invokeExact(db, writeOpts, cf,
+			MemorySegment cf = (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db.dbPtr());
+			MH_DELETE_RANGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf,
 					MemorySegment.ofBuffer(startKey), (long) startKey.remaining(),
 					MemorySegment.ofBuffer(endKey), (long) endKey.remaining(), err);
 			checkError(err);
@@ -1077,12 +1077,12 @@ public final class RocksDB {
 		}
 	}
 
-	static void deleteRangeCfSegment(MemorySegment db, MemorySegment writeOpts,
+	static void deleteRangeCfSegment(RocksDBWriteOperations db, WriteOptions writeOpts,
 	                                 MemorySegment startKey, MemorySegment endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MemorySegment cf = (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db);
-			MH_DELETE_RANGE_CF.invokeExact(db, writeOpts, cf,
+			MemorySegment cf = (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db.dbPtr());
+			MH_DELETE_RANGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf,
 					startKey, startKey.byteSize(), endKey, endKey.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
@@ -1090,20 +1090,20 @@ public final class RocksDB {
 		}
 	}
 
-	static void writeBatch(MemorySegment db, MemorySegment writeOpts, WriteBatch batch) {
+	static void writeBatch(RocksDBWriteOperations db, WriteOptions writeOpts, WriteBatch batch) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_WRITE.invokeExact(db, writeOpts, batch.ptr(), err);
+			MH_WRITE.invokeExact(db.dbPtr(), writeOpts.ptr(), batch.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("write failed", t);
 		}
 	}
 
-	static void writeBatch(Arena arena, MemorySegment db, MemorySegment writeOpts, WriteBatch batch) {
+	static void writeBatch(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts, WriteBatch batch) {
 		try {
 			MemorySegment err = errHolder(arena);
-			MH_WRITE.invokeExact(db, writeOpts, batch.ptr(), err);
+			MH_WRITE.invokeExact(db.dbPtr(), writeOpts.ptr(), batch.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("write failed", t);
@@ -1129,11 +1129,11 @@ public final class RocksDB {
 		}
 	}
 
-	static void compactRangeBytes(MemorySegment db, byte[] startKey, byte[] endKey) {
+	static void compactRangeBytes(RocksDBWriteOperations db, byte[] startKey, byte[] endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment s = startKey == null ? MemorySegment.NULL : toNative(arena, startKey);
 			MemorySegment e = endKey == null ? MemorySegment.NULL : toNative(arena, endKey);
-			MH_COMPACT_RANGE.invokeExact(db,
+			MH_COMPACT_RANGE.invokeExact(db.dbPtr(),
 					s, startKey == null ? 0L : (long) startKey.length,
 					e, endKey == null ? 0L : (long) endKey.length);
 		} catch (Throwable t) {
@@ -1141,11 +1141,11 @@ public final class RocksDB {
 		}
 	}
 
-	static void compactRangeBuffer(MemorySegment db, ByteBuffer startKey, ByteBuffer endKey) {
+	static void compactRangeBuffer(RocksDBWriteOperations db, ByteBuffer startKey, ByteBuffer endKey) {
 		try {
 			MemorySegment s = startKey == null ? MemorySegment.NULL : MemorySegment.ofBuffer(startKey);
 			MemorySegment e = endKey == null ? MemorySegment.NULL : MemorySegment.ofBuffer(endKey);
-			MH_COMPACT_RANGE.invokeExact(db,
+			MH_COMPACT_RANGE.invokeExact(db.dbPtr(),
 					s, startKey == null ? 0L : (long) startKey.remaining(),
 					e, endKey == null ? 0L : (long) endKey.remaining());
 		} catch (Throwable t) {
@@ -1153,11 +1153,11 @@ public final class RocksDB {
 		}
 	}
 
-	static void compactRangeSegment(MemorySegment db, MemorySegment startKey, MemorySegment endKey) {
+	static void compactRangeSegment(RocksDBWriteOperations db, MemorySegment startKey, MemorySegment endKey) {
 		try {
 			MemorySegment s = startKey == null ? MemorySegment.NULL : startKey;
 			MemorySegment e = endKey == null ? MemorySegment.NULL : endKey;
-			MH_COMPACT_RANGE.invokeExact(db,
+			MH_COMPACT_RANGE.invokeExact(db.dbPtr(),
 					s, s == MemorySegment.NULL ? 0L : s.byteSize(),
 					e, e == MemorySegment.NULL ? 0L : e.byteSize());
 		} catch (Throwable t) {
@@ -1165,11 +1165,11 @@ public final class RocksDB {
 		}
 	}
 
-	static void compactRangeOptBytes(MemorySegment db, CompactOptions opts, byte[] startKey, byte[] endKey) {
+	static void compactRangeOptBytes(RocksDBWriteOperations db, CompactOptions opts, byte[] startKey, byte[] endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment s = startKey == null ? MemorySegment.NULL : toNative(arena, startKey);
 			MemorySegment e = endKey == null ? MemorySegment.NULL : toNative(arena, endKey);
-			MH_COMPACT_RANGE_OPT.invokeExact(db, opts.ptr(),
+			MH_COMPACT_RANGE_OPT.invokeExact(db.dbPtr(), opts.ptr(),
 					s, startKey == null ? 0L : (long) startKey.length,
 					e, endKey == null ? 0L : (long) endKey.length);
 		} catch (Throwable t) {
@@ -1177,12 +1177,12 @@ public final class RocksDB {
 		}
 	}
 
-	static void suggestCompactRangeBytes(MemorySegment db, byte[] startKey, byte[] endKey) {
+	static void suggestCompactRangeBytes(RocksDBWriteOperations db, byte[] startKey, byte[] endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment s = startKey == null ? MemorySegment.NULL : toNative(arena, startKey);
 			MemorySegment e = endKey == null ? MemorySegment.NULL : toNative(arena, endKey);
-			MH_SUGGEST_COMPACT_RANGE.invokeExact(db,
+			MH_SUGGEST_COMPACT_RANGE.invokeExact(db.dbPtr(),
 					s, startKey == null ? 0L : (long) startKey.length,
 					e, endKey == null ? 0L : (long) endKey.length, err);
 			checkError(err);
@@ -1191,27 +1191,27 @@ public final class RocksDB {
 		}
 	}
 
-	static void disableFileDeletions(MemorySegment db) {
+	static void disableFileDeletions(RocksDBWriteOperations db) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DISABLE_FILE_DELETIONS.invokeExact(db, err);
+			MH_DISABLE_FILE_DELETIONS.invokeExact(db.dbPtr(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("disableFileDeletions failed", t);
 		}
 	}
 
-	static void enableFileDeletions(MemorySegment db) {
+	static void enableFileDeletions(RocksDBWriteOperations db) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_ENABLE_FILE_DELETIONS.invokeExact(db, err);
+			MH_ENABLE_FILE_DELETIONS.invokeExact(db.dbPtr(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("enableFileDeletions failed", t);
 		}
 	}
 
-	static void ingestExternalFile(MemorySegment db, List<Path> files, IngestExternalFileOptions options) {
+	static void ingestExternalFile(RocksDBWriteOperations db, List<Path> files, IngestExternalFileOptions options) {
 		if (files.isEmpty()) {
 			return;
 		}
@@ -1221,14 +1221,14 @@ public final class RocksDB {
 			for (int i = 0; i < files.size(); i++) {
 				fileArray.setAtIndex(ValueLayout.ADDRESS, i, arena.allocateFrom(files.get(i).toString()));
 			}
-			MH_INGEST_EXTERNAL_FILE.invokeExact(db, fileArray, (long) files.size(), options.ptr(), err);
+			MH_INGEST_EXTERNAL_FILE.invokeExact(db.dbPtr(), fileArray, (long) files.size(), options.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("ingestExternalFile failed", t);
 		}
 	}
 
-	static void ingestExternalFileWithDefaults(MemorySegment db, List<Path> files) {
+	static void ingestExternalFileWithDefaults(RocksDBWriteOperations db, List<Path> files) {
 		try (IngestExternalFileOptions opts = IngestExternalFileOptions.newIngestExternalFileOptions()) {
 			ingestExternalFile(db, files, opts);
 		}
@@ -1552,7 +1552,7 @@ public final class RocksDB {
 		}
 	}
 
-	static ColumnFamilyHandle createCf(MemorySegment db, ColumnFamilyDescriptor descriptor) {
+	static ColumnFamilyHandle createCf(RocksDBWriteOperations db, ColumnFamilyDescriptor descriptor) {
 		List<Options> tempOptions = new ArrayList<>(1);
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
@@ -1564,7 +1564,7 @@ public final class RocksDB {
 			MemorySegment nameSeg = arena.allocateFrom(
 					new String(descriptor.name(), StandardCharsets.UTF_8));
 			MemorySegment handle = (MemorySegment) MH_CREATE_CF.invokeExact(
-					db, cfOpts.ptr(), nameSeg, err);
+					db.dbPtr(), cfOpts.ptr(), nameSeg, err);
 			checkError(err);
 			return ColumnFamilyHandle.wrap(handle);
 		} catch (Throwable t) {
@@ -1587,11 +1587,11 @@ public final class RocksDB {
 	}
 
 	/// byte[] put with explicit column family — slow path.
-	static void putCfBytes(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	static void putCfBytes(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
 	                       byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_PUT_CF.invokeExact(db, writeOpts, cf.ptr(),
+			MH_PUT_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(),
 					toNative(arena, key), (long) key.length,
 					toNative(arena, value), (long) value.length, err);
 			checkError(err);
@@ -1601,11 +1601,11 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment put with explicit column family — zero-copy.
-	static void putCfSegment(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	static void putCfSegment(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
 	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_PUT_CF.invokeExact(db, writeOpts, cf.ptr(), key, keyLen, val, valLen, err);
+			MH_PUT_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, keyLen, val, valLen, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -1613,7 +1613,7 @@ public final class RocksDB {
 	}
 
 	/// byte[] merge with explicit column family — slow path.
-	static void mergeCfBytes(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	static void mergeCfBytes(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
 	                         byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
 			mergeCfBytes(arena, db, writeOpts, cf, key, value);
@@ -1621,7 +1621,7 @@ public final class RocksDB {
 	}
 
 	/// byte[] merge with explicit column family using the caller's arena.
-	static void mergeCfBytes(Arena arena, MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	static void mergeCfBytes(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
 	                         byte[] key, byte[] value) {
 		MemorySegment k = toNative(arena, key);
 		MemorySegment v = toNative(arena, value);
@@ -1629,7 +1629,7 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment merge with explicit column family — zero-copy.
-	static void mergeCfSegment(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	static void mergeCfSegment(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
 	                           MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try (Arena arena = Arena.ofConfined()) {
 			mergeCfSegment(arena, db, writeOpts, cf, key, keyLen, val, valLen);
@@ -1637,11 +1637,11 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment merge with explicit column family using the caller's arena.
-	static void mergeCfSegment(Arena arena, MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	static void mergeCfSegment(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
 	                           MemorySegment key, long keyLen, MemorySegment val, long valLen) {
 		try {
 			MemorySegment err = errHolder(arena);
-			MH_MERGE_CF.invokeExact(db, writeOpts, cf.ptr(), key, keyLen, val, valLen, err);
+			MH_MERGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, keyLen, val, valLen, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("merge failed", t);
@@ -1721,11 +1721,11 @@ public final class RocksDB {
 	}
 
 	/// byte[] delete with explicit column family — slow path.
-	static void deleteCfBytes(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	static void deleteCfBytes(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
 	                          byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DELETE_CF.invokeExact(db, writeOpts, cf.ptr(),
+			MH_DELETE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(),
 					toNative(arena, key), (long) key.length, err);
 			checkError(err);
 		} catch (Throwable t) {
@@ -1734,11 +1734,11 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment delete with explicit column family — zero-copy.
-	static void deleteCfSegment(MemorySegment db, MemorySegment writeOpts, ColumnFamilyHandle cf,
+	static void deleteCfSegment(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
 	                            MemorySegment key, long keyLen) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DELETE_CF.invokeExact(db, writeOpts, cf.ptr(), key, keyLen, err);
+			MH_DELETE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, keyLen, err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("delete failed", t);
@@ -1746,12 +1746,12 @@ public final class RocksDB {
 	}
 
 	/// deleteRange with explicit column family — slow path.
-	static void deleteRangeCfBytesExplicit(MemorySegment db, MemorySegment writeOpts,
+	static void deleteRangeCfBytesExplicit(RocksDBWriteOperations db, WriteOptions writeOpts,
 	                                       ColumnFamilyHandle cf,
 	                                       byte[] startKey, byte[] endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DELETE_RANGE_CF.invokeExact(db, writeOpts, cf.ptr(),
+			MH_DELETE_RANGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(),
 					toNative(arena, startKey), (long) startKey.length,
 					toNative(arena, endKey), (long) endKey.length, err);
 			checkError(err);
@@ -1761,12 +1761,12 @@ public final class RocksDB {
 	}
 
 	/// deleteRange with explicit column family — zero-copy for direct ByteBuffers.
-	static void deleteRangeCfBufferExplicit(MemorySegment db, MemorySegment writeOpts,
+	static void deleteRangeCfBufferExplicit(RocksDBWriteOperations db, WriteOptions writeOpts,
 	                                        ColumnFamilyHandle cf,
 	                                        ByteBuffer startKey, ByteBuffer endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DELETE_RANGE_CF.invokeExact(db, writeOpts, cf.ptr(),
+			MH_DELETE_RANGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(),
 					MemorySegment.ofBuffer(startKey), (long) startKey.remaining(),
 					MemorySegment.ofBuffer(endKey), (long) endKey.remaining(), err);
 			checkError(err);
@@ -1776,12 +1776,12 @@ public final class RocksDB {
 	}
 
 	/// deleteRange with explicit column family — zero-copy for MemorySegments.
-	static void deleteRangeCfSegmentExplicit(MemorySegment db, MemorySegment writeOpts,
+	static void deleteRangeCfSegmentExplicit(RocksDBWriteOperations db, WriteOptions writeOpts,
 	                                         ColumnFamilyHandle cf,
 	                                         MemorySegment startKey, MemorySegment endKey) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DELETE_RANGE_CF.invokeExact(db, writeOpts, cf.ptr(),
+			MH_DELETE_RANGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(),
 					startKey, startKey.byteSize(), endKey, endKey.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
@@ -1821,10 +1821,10 @@ public final class RocksDB {
 		}
 	}
 
-	static void flushCf(MemorySegment db, FlushOptions flushOptions, ColumnFamilyHandle cf) {
+	static void flushCf(RocksDBWriteOperations db, FlushOptions flushOptions, ColumnFamilyHandle cf) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_FLUSH_CF.invokeExact(db, flushOptions.ptr(), cf.ptr(), err);
+			MH_FLUSH_CF.invokeExact(db.dbPtr(), flushOptions.ptr(), cf.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("flush failed", t);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBWriteOperations.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBWriteOperations.java
@@ -41,7 +41,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   the key to store
 	/// @param value the value to associate with the key
 	default void put(byte[] key, byte[] value) {
-		RocksDB.putBytes(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, value);
+		RocksDB.putBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
 	/// Stores `value` under `key` using the caller's [Arena] for native allocation.
@@ -50,7 +50,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   the key to store
 	/// @param value the value to associate with the key
 	default void put(Arena arena, byte[] key, byte[] value) {
-		RocksDB.putBytes(arena, dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, value);
+		RocksDB.putBytes(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
 	/// Zero-copy put: wraps the direct buffers' native memory without heap→native copy.
@@ -58,7 +58,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the value
 	default void put(ByteBuffer key, ByteBuffer value) {
-		RocksDB.putSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(),
+		RocksDB.putSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS,
 				MemorySegment.ofBuffer(key), key.remaining(),
 				MemorySegment.ofBuffer(value), value.remaining());
 	}
@@ -68,7 +68,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	default void put(MemorySegment key, MemorySegment value) {
-		RocksDB.putSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, key.byteSize(), value, value.byteSize());
+		RocksDB.putSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize(), value, value.byteSize());
 	}
 
 	/// Zero-copy put using the caller's [Arena].
@@ -77,7 +77,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	default void put(Arena arena, MemorySegment key, MemorySegment value) {
-		RocksDB.putSegment(arena, dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, key.byteSize(), value, value.byteSize());
+		RocksDB.putSegment(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize(), value, value.byteSize());
 	}
 
 	/// Stores `value` under `key` in `cf`. Slow path: copies key/value into native memory.
@@ -86,7 +86,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   the key to store
 	/// @param value the value to associate with the key
 	default void put(ColumnFamilyHandle cf, byte[] key, byte[] value) {
-		RocksDB.putCfBytes(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, key, value);
+		RocksDB.putCfBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, value);
 	}
 
 	/// Zero-copy put into `cf`: wraps the direct buffers' native memory without heap→native copy.
@@ -95,7 +95,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the value
 	default void put(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
-		RocksDB.putCfSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf,
+		RocksDB.putCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf,
 				MemorySegment.ofBuffer(key), key.remaining(),
 				MemorySegment.ofBuffer(value), value.remaining());
 	}
@@ -106,7 +106,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	default void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		RocksDB.putCfSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, key, key.byteSize(), value, value.byteSize());
+		RocksDB.putCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -119,7 +119,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   the key to merge into
 	/// @param value the merge operand
 	default void merge(byte[] key, byte[] value) {
-		RocksDB.mergeBytes(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, value);
+		RocksDB.mergeBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
 	/// Merges `value` into `key` using the caller's [Arena] for native allocation.
@@ -128,7 +128,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   the key to merge into
 	/// @param value the merge operand
 	default void merge(Arena arena, byte[] key, byte[] value) {
-		RocksDB.mergeBytes(arena, dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, value);
+		RocksDB.mergeBytes(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
 	/// Zero-copy merge: wraps the direct buffers' native memory without heap→native copy.
@@ -136,7 +136,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the merge operand
 	default void merge(ByteBuffer key, ByteBuffer value) {
-		RocksDB.mergeSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(),
+		RocksDB.mergeSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS,
 				MemorySegment.ofBuffer(key), key.remaining(),
 				MemorySegment.ofBuffer(value), value.remaining());
 	}
@@ -146,7 +146,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	default void merge(MemorySegment key, MemorySegment value) {
-		RocksDB.mergeSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, key.byteSize(), value, value.byteSize());
+		RocksDB.mergeSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize(), value, value.byteSize());
 	}
 
 	/// Zero-copy merge using the caller's [Arena].
@@ -155,7 +155,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	default void merge(Arena arena, MemorySegment key, MemorySegment value) {
-		RocksDB.mergeSegment(arena, dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, key.byteSize(), value, value.byteSize());
+		RocksDB.mergeSegment(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize(), value, value.byteSize());
 	}
 
 	/// Merges `value` into `key` in `cf`. Slow path: copies key/value into native memory.
@@ -164,7 +164,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   the key to merge into
 	/// @param value the merge operand
 	default void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
-		RocksDB.mergeCfBytes(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, key, value);
+		RocksDB.mergeCfBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, value);
 	}
 
 	/// Zero-copy merge into `cf`: wraps the direct buffers' native memory without heap→native copy.
@@ -173,7 +173,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   direct [ByteBuffer] containing the key
 	/// @param value direct [ByteBuffer] containing the merge operand
 	default void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
-		RocksDB.mergeCfSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf,
+		RocksDB.mergeCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf,
 				MemorySegment.ofBuffer(key), key.remaining(),
 				MemorySegment.ofBuffer(value), value.remaining());
 	}
@@ -184,7 +184,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	default void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		RocksDB.mergeCfSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, key, key.byteSize(), value, value.byteSize());
+		RocksDB.mergeCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, key.byteSize(), value, value.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -195,21 +195,21 @@ public interface RocksDBWriteOperations {
 	///
 	/// @param key the key to remove
 	default void delete(byte[] key) {
-		RocksDB.deleteBytes(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key);
+		RocksDB.deleteBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, key);
 	}
 
 	/// Zero-copy for direct [ByteBuffer]s.
 	///
 	/// @param key direct [ByteBuffer] containing the key to remove
 	default void delete(ByteBuffer key) {
-		RocksDB.deleteSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), MemorySegment.ofBuffer(key), key.remaining());
+		RocksDB.deleteSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, MemorySegment.ofBuffer(key), key.remaining());
 	}
 
 	/// Zero-copy native-first path.
 	///
 	/// @param key native segment containing the key to remove
 	default void delete(MemorySegment key) {
-		RocksDB.deleteSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), key, key.byteSize());
+		RocksDB.deleteSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize());
 	}
 
 	/// Removes `key` from `cf`. Slow path: copies the key into native memory.
@@ -217,7 +217,7 @@ public interface RocksDBWriteOperations {
 	/// @param cf  target column family
 	/// @param key the key to remove
 	default void delete(ColumnFamilyHandle cf, byte[] key) {
-		RocksDB.deleteCfBytes(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, key);
+		RocksDB.deleteCfBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key);
 	}
 
 	/// Zero-copy delete from `cf` for direct [ByteBuffer]s.
@@ -225,7 +225,7 @@ public interface RocksDBWriteOperations {
 	/// @param cf  target column family
 	/// @param key direct [ByteBuffer] containing the key to remove
 	default void delete(ColumnFamilyHandle cf, ByteBuffer key) {
-		RocksDB.deleteCfSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf,
+		RocksDB.deleteCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf,
 				MemorySegment.ofBuffer(key), key.remaining());
 	}
 
@@ -234,7 +234,7 @@ public interface RocksDBWriteOperations {
 	/// @param cf  target column family
 	/// @param key native segment containing the key to remove
 	default void delete(ColumnFamilyHandle cf, MemorySegment key) {
-		RocksDB.deleteCfSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, key, key.byteSize());
+		RocksDB.deleteCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, key.byteSize());
 	}
 
 	// -----------------------------------------------------------------------
@@ -247,7 +247,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey inclusive lower bound
 	/// @param endKey   exclusive upper bound
 	default void deleteRange(byte[] startKey, byte[] endKey) {
-		RocksDB.deleteRangeCfBytes(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), startKey, endKey);
+		RocksDB.deleteRangeCfBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, startKey, endKey);
 	}
 
 	/// Zero-copy for direct [ByteBuffer]s.
@@ -255,7 +255,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey direct [ByteBuffer] with inclusive lower bound
 	/// @param endKey   direct [ByteBuffer] with exclusive upper bound
 	default void deleteRange(ByteBuffer startKey, ByteBuffer endKey) {
-		RocksDB.deleteRangeCfBuffer(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), startKey, endKey);
+		RocksDB.deleteRangeCfBuffer(this, RocksDB.DEFAULT_WRITE_OPTIONS, startKey, endKey);
 	}
 
 	/// Zero-copy native-first path.
@@ -263,7 +263,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey native segment with inclusive lower bound
 	/// @param endKey   native segment with exclusive upper bound
 	default void deleteRange(MemorySegment startKey, MemorySegment endKey) {
-		RocksDB.deleteRangeCfSegment(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), startKey, endKey);
+		RocksDB.deleteRangeCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, startKey, endKey);
 	}
 
 	/// Deletes all keys in the half-open range [`startKey`, `endKey`) from `cf`. Slow path.
@@ -272,7 +272,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey inclusive lower bound
 	/// @param endKey   exclusive upper bound
 	default void deleteRange(ColumnFamilyHandle cf, byte[] startKey, byte[] endKey) {
-		RocksDB.deleteRangeCfBytesExplicit(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, startKey, endKey);
+		RocksDB.deleteRangeCfBytesExplicit(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, startKey, endKey);
 	}
 
 	/// Zero-copy deleteRange from `cf` for direct [ByteBuffer]s.
@@ -281,7 +281,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey direct [ByteBuffer] with inclusive lower bound
 	/// @param endKey   direct [ByteBuffer] with exclusive upper bound
 	default void deleteRange(ColumnFamilyHandle cf, ByteBuffer startKey, ByteBuffer endKey) {
-		RocksDB.deleteRangeCfBufferExplicit(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, startKey, endKey);
+		RocksDB.deleteRangeCfBufferExplicit(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, startKey, endKey);
 	}
 
 	/// Zero-copy deleteRange from `cf` for [MemorySegment]s.
@@ -290,7 +290,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey native segment with inclusive lower bound
 	/// @param endKey   native segment with exclusive upper bound
 	default void deleteRange(ColumnFamilyHandle cf, MemorySegment startKey, MemorySegment endKey) {
-		RocksDB.deleteRangeCfSegmentExplicit(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), cf, startKey, endKey);
+		RocksDB.deleteRangeCfSegmentExplicit(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, startKey, endKey);
 	}
 
 	// -----------------------------------------------------------------------
@@ -301,7 +301,7 @@ public interface RocksDBWriteOperations {
 	///
 	/// @param batch the write batch to apply
 	default void write(WriteBatch batch) {
-		RocksDB.writeBatch(dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), batch);
+		RocksDB.writeBatch(this, RocksDB.DEFAULT_WRITE_OPTIONS, batch);
 	}
 
 	/// Applies all mutations in `batch` atomically, using the caller's [Arena] for native allocation.
@@ -309,7 +309,7 @@ public interface RocksDBWriteOperations {
 	/// @param arena arena used for temporary native allocations
 	/// @param batch the write batch to apply
 	default void write(Arena arena, WriteBatch batch) {
-		RocksDB.writeBatch(arena, dbPtr(), RocksDB.DEFAULT_WRITE_OPTIONS.ptr(), batch);
+		RocksDB.writeBatch(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, batch);
 	}
 
 	// -----------------------------------------------------------------------
@@ -320,19 +320,19 @@ public interface RocksDBWriteOperations {
 	///
 	/// @param wait if `true`, blocks until all running jobs have finished
 	default void cancelAllBackgroundWork(boolean wait) {
-		RocksDB.cancelAllBackgroundWork(dbPtr(), wait);
+		RocksDB.cancelAllBackgroundWork(this, wait);
 	}
 
 	/// Prevents new manual compactions from starting.
 	/// In-progress manual compactions are not affected.
 	/// Call [#enableManualCompaction()] to reverse.
 	default void disableManualCompaction() {
-		RocksDB.disableManualCompaction(dbPtr());
+		RocksDB.disableManualCompaction(this);
 	}
 
 	/// Re-enables manual compactions after [#disableManualCompaction()].
 	default void enableManualCompaction() {
-		RocksDB.enableManualCompaction(dbPtr());
+		RocksDB.enableManualCompaction(this);
 	}
 
 	/// Blocks until all current compactions finish, subject to the given [WaitForCompactOptions].
@@ -341,7 +341,7 @@ public interface RocksDBWriteOperations {
 	/// @throws RocksDBException on I/O error or if [WaitForCompactOptions#isAbortOnPause()] is
 	///                          `true` and background work is paused
 	default void waitForCompact(WaitForCompactOptions options) {
-		RocksDB.waitForCompact(dbPtr(), options);
+		RocksDB.waitForCompact(this, options);
 	}
 
 	// -----------------------------------------------------------------------
@@ -352,7 +352,7 @@ public interface RocksDBWriteOperations {
 	///
 	/// @return current sequence number
 	default SequenceNumber getLatestSequenceNumber() {
-		return RocksDB.getLatestSequenceNumber(dbPtr());
+		return RocksDB.getLatestSequenceNumber(this);
 	}
 
 	/// Returns a [WalIterator] positioned at the first [WriteBatch] with a sequence number
@@ -363,7 +363,7 @@ public interface RocksDBWriteOperations {
 	/// @param sequenceNumber starting sequence number (inclusive)
 	/// @return a new [WalIterator]; caller must close it
 	default WalIterator getUpdatesSince(SequenceNumber sequenceNumber) {
-		return RocksDB.getUpdatesSince(dbPtr(), sequenceNumber);
+		return RocksDB.getUpdatesSince(this, sequenceNumber);
 	}
 
 	// -----------------------------------------------------------------------
@@ -374,14 +374,14 @@ public interface RocksDBWriteOperations {
 	///
 	/// @param flushOptions options controlling flush behavior
 	default void flush(FlushOptions flushOptions) {
-		RocksDB.flush(dbPtr(), flushOptions);
+		RocksDB.flush(this, flushOptions);
 	}
 
 	/// Flushes the WAL to disk.
 	///
 	/// @param sync if `true`, performs an `fsync` after writing
 	default void flushWal(boolean sync) {
-		RocksDB.flushWal(dbPtr(), sync);
+		RocksDB.flushWal(this, sync);
 	}
 
 	/// Flushes the memtable for `cf` to SST files.
@@ -389,7 +389,7 @@ public interface RocksDBWriteOperations {
 	/// @param cf           target column family
 	/// @param flushOptions options controlling flush behavior
 	default void flush(ColumnFamilyHandle cf, FlushOptions flushOptions) {
-		RocksDB.flushCf(dbPtr(), flushOptions, cf);
+		RocksDB.flushCf(this, flushOptions, cf);
 	}
 
 	// -----------------------------------------------------------------------
@@ -398,7 +398,7 @@ public interface RocksDBWriteOperations {
 
 	/// Manually triggers compaction over the entire key space.
 	default void compactRange() {
-		RocksDB.compactRangeBytes(dbPtr(), null, null);
+		RocksDB.compactRangeBytes(this, null, null);
 	}
 
 	/// Manually triggers compaction over `[startKey, endKey]`.
@@ -407,7 +407,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey inclusive lower bound, or `null` for the start of the key space
 	/// @param endKey   inclusive upper bound, or `null` for the end of the key space
 	default void compactRange(byte[] startKey, byte[] endKey) {
-		RocksDB.compactRangeBytes(dbPtr(), startKey, endKey);
+		RocksDB.compactRangeBytes(this, startKey, endKey);
 	}
 
 	/// [ByteBuffer] overload of [#compactRange(byte\[\], byte\[\])].
@@ -415,7 +415,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey direct [ByteBuffer] with inclusive lower bound
 	/// @param endKey   direct [ByteBuffer] with inclusive upper bound
 	default void compactRange(ByteBuffer startKey, ByteBuffer endKey) {
-		RocksDB.compactRangeBuffer(dbPtr(), startKey, endKey);
+		RocksDB.compactRangeBuffer(this, startKey, endKey);
 	}
 
 	/// [MemorySegment] overload of [#compactRange(byte\[\], byte\[\])].
@@ -423,7 +423,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey native segment with inclusive lower bound
 	/// @param endKey   native segment with inclusive upper bound
 	default void compactRange(MemorySegment startKey, MemorySegment endKey) {
-		RocksDB.compactRangeSegment(dbPtr(), startKey, endKey);
+		RocksDB.compactRangeSegment(this, startKey, endKey);
 	}
 
 	/// Compaction with explicit options.
@@ -432,7 +432,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey inclusive lower bound, or `null` for the start of the key space
 	/// @param endKey   inclusive upper bound, or `null` for the end of the key space
 	default void compactRange(CompactOptions opts, byte[] startKey, byte[] endKey) {
-		RocksDB.compactRangeOptBytes(dbPtr(), opts, startKey, endKey);
+		RocksDB.compactRangeOptBytes(this, opts, startKey, endKey);
 	}
 
 	/// Hints that `[startKey, endKey]` may benefit from compaction, but does not block.
@@ -440,7 +440,7 @@ public interface RocksDBWriteOperations {
 	/// @param startKey inclusive lower bound
 	/// @param endKey   inclusive upper bound
 	default void suggestCompactRange(byte[] startKey, byte[] endKey) {
-		RocksDB.suggestCompactRangeBytes(dbPtr(), startKey, endKey);
+		RocksDB.suggestCompactRangeBytes(this, startKey, endKey);
 	}
 
 	// -----------------------------------------------------------------------
@@ -449,12 +449,12 @@ public interface RocksDBWriteOperations {
 
 	/// Prevents new SST files from being deleted. Must be paired with [#enableFileDeletions()].
 	default void disableFileDeletions() {
-		RocksDB.disableFileDeletions(dbPtr());
+		RocksDB.disableFileDeletions(this);
 	}
 
 	/// Re-enables SST file deletions after [#disableFileDeletions()].
 	default void enableFileDeletions() {
-		RocksDB.enableFileDeletions(dbPtr());
+		RocksDB.enableFileDeletions(this);
 	}
 
 	// -----------------------------------------------------------------------
@@ -466,14 +466,14 @@ public interface RocksDBWriteOperations {
 	/// @param files   list of SST file paths to ingest
 	/// @param options ingest options controlling move vs copy, error handling, etc.
 	default void ingestExternalFile(List<Path> files, IngestExternalFileOptions options) {
-		RocksDB.ingestExternalFile(dbPtr(), files, options);
+		RocksDB.ingestExternalFile(this, files, options);
 	}
 
 	/// Ingests `files` using default [IngestExternalFileOptions].
 	///
 	/// @param files list of SST file paths to ingest
 	default void ingestExternalFile(List<Path> files) {
-		RocksDB.ingestExternalFileWithDefaults(dbPtr(), files);
+		RocksDB.ingestExternalFileWithDefaults(this, files);
 	}
 
 	/// Convenience overload for ingesting a single file with explicit options.
@@ -501,7 +501,7 @@ public interface RocksDBWriteOperations {
 	/// @param descriptor name and options for the new column family
 	/// @return handle to the newly created column family; caller must close it
 	default ColumnFamilyHandle createColumnFamily(ColumnFamilyDescriptor descriptor) {
-		return RocksDB.createCf(dbPtr(), descriptor);
+		return RocksDB.createCf(this, descriptor);
 	}
 
 	/// Drops the column family identified by `handle`.


### PR DESCRIPTION
## Summary

Companion to #110, same treatment applied to the write side.

- `RocksDB.java`'s put/merge/delete/deleteRange/write/flush/compaction/file-deletion/ingest/`createCf` helpers backing `RocksDBWriteOperations` retype their `db` and `writeOpts` parameters from `MemorySegment` to `RocksDBWriteOperations` and `WriteOptions`, extracting `.dbPtr()`/`.ptr()` inside the helper instead of at each of the ~35 call sites in `RocksDBWriteOperations.java`.
- Verified every retyped method is called *exclusively* from `RocksDBWriteOperations.java` before touching it. `dropCf` is also called from `TransactionDB.java` (which does not implement `RocksDBWriteOperations`) and keeps its `MemorySegment db` parameter unchanged.

Pure refactor, no behavior change, no new tests needed.

## Test plan

- [x] `./mvnw -pl core -am clean test` — full core suite passes
- [x] `./mvnw -pl core javadoc:javadoc` — zero output
- [x] `./mvnw -pl integration-tests -am verify` — full integration suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)