### PR TITLE
Drop redundant length params from *Segment helpers

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -744,12 +744,12 @@ public final class RocksDB {
 
 	/// ByteBuffer get via `rocksdb_get_into_buffer` — copies directly into the caller's buffer,
 	/// with no intermediate PinnableSlice. Copies nothing when the buffer is too small.
-	static CopyResult getIntoBuffer(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, long keyLen, ByteBuffer value) {
+	static CopyResult getIntoBuffer(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
-			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db.dbPtr(), readOpts.ptr(), key, keyLen,
+			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db.dbPtr(), readOpts.ptr(), key, key.byteSize(),
 					MemorySegment.ofBuffer(value), (long) value.remaining(), valLenSeg, foundSeg, err);
 			checkError(err);
 			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
@@ -768,12 +768,12 @@ public final class RocksDB {
 
 	/// MemorySegment get via `rocksdb_get_into_buffer` — copies directly into the caller's
 	/// segment, with no intermediate PinnableSlice. Copies nothing when `value` is too small.
-	static CopyResult getIntoSegment(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, long keyLen, MemorySegment value) {
+	static CopyResult getIntoSegment(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
-			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db.dbPtr(), readOpts.ptr(), key, keyLen,
+			byte fit = (byte) MH_GET_INTO_BUFFER.invokeExact(db.dbPtr(), readOpts.ptr(), key, key.byteSize(),
 					value, value.byteSize(), valLenSeg, foundSeg, err);
 			checkError(err);
 			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
@@ -859,10 +859,10 @@ public final class RocksDB {
 
 	/// MemorySegment put — zero-copy, caller supplies pre-allocated native segments.
 	static void putSegment(RocksDBWriteOperations db, WriteOptions writeOpts,
-	                       MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+	                       MemorySegment key, MemorySegment val) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_PUT.invokeExact(db.dbPtr(), writeOpts.ptr(), key, keyLen, val, valLen, err);
+			MH_PUT.invokeExact(db.dbPtr(), writeOpts.ptr(), key, key.byteSize(), val, val.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -871,10 +871,10 @@ public final class RocksDB {
 
 	/// MemorySegment put using the caller's arena.
 	static void putSegment(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts,
-	                       MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+	                       MemorySegment key, MemorySegment val) {
 		try {
 			MemorySegment err = errHolder(arena);
-			MH_PUT.invokeExact(db.dbPtr(), writeOpts.ptr(), key, keyLen, val, valLen, err);
+			MH_PUT.invokeExact(db.dbPtr(), writeOpts.ptr(), key, key.byteSize(), val, val.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -892,23 +892,23 @@ public final class RocksDB {
 	static void mergeBytes(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts, byte[] key, byte[] value) {
 		MemorySegment k = toNative(arena, key);
 		MemorySegment v = toNative(arena, value);
-		mergeSegment(arena, db, writeOpts, k, key.length, v, value.length);
+		mergeSegment(arena, db, writeOpts, k, v);
 	}
 
 	/// MemorySegment merge — zero-copy, caller supplies pre-allocated native segments.
 	static void mergeSegment(RocksDBWriteOperations db, WriteOptions writeOpts,
-	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+	                         MemorySegment key, MemorySegment val) {
 		try (Arena arena = Arena.ofConfined()) {
-			mergeSegment(arena, db, writeOpts, key, keyLen, val, valLen);
+			mergeSegment(arena, db, writeOpts, key, val);
 		}
 	}
 
 	/// MemorySegment merge using the caller's arena.
 	static void mergeSegment(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts,
-	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+	                         MemorySegment key, MemorySegment val) {
 		try {
 			MemorySegment err = errHolder(arena);
-			MH_MERGE.invokeExact(db.dbPtr(), writeOpts.ptr(), key, keyLen, val, valLen, err);
+			MH_MERGE.invokeExact(db.dbPtr(), writeOpts.ptr(), key, key.byteSize(), val, val.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("merge failed", t);
@@ -928,10 +928,10 @@ public final class RocksDB {
 	}
 
 	/// MemorySegment delete — zero-copy.
-	static void deleteSegment(RocksDBWriteOperations db, WriteOptions writeOpts, MemorySegment key, long keyLen) {
+	static void deleteSegment(RocksDBWriteOperations db, WriteOptions writeOpts, MemorySegment key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DELETE.invokeExact(db.dbPtr(), writeOpts.ptr(), key, keyLen, err);
+			MH_DELETE.invokeExact(db.dbPtr(), writeOpts.ptr(), key, key.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("delete failed", t);
@@ -1110,10 +1110,9 @@ public final class RocksDB {
 		}
 	}
 
-	static boolean keyMayExistSegment(RocksDBReadOperations db, ReadOptions roOpts,
-	                                  MemorySegment key, long keyLen) {
+	static boolean keyMayExistSegment(RocksDBReadOperations db, ReadOptions roOpts, MemorySegment key) {
 		try {
-			return fromByte((byte) MH_KEY_MAY_EXIST.invokeExact(db.dbPtr(), roOpts.ptr(), key, keyLen,
+			return fromByte((byte) MH_KEY_MAY_EXIST.invokeExact(db.dbPtr(), roOpts.ptr(), key, key.byteSize(),
 					MemorySegment.NULL, MemorySegment.NULL,
 					MemorySegment.NULL, 0L, MemorySegment.NULL));
 		} catch (Throwable t) {
@@ -1125,7 +1124,7 @@ public final class RocksDB {
 	/// before delegating.
 	static boolean keyMayExistBytes(RocksDBReadOperations db, ReadOptions roOpts, byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
-			return keyMayExistSegment(db, roOpts, toNative(arena, key), key.length);
+			return keyMayExistSegment(db, roOpts, toNative(arena, key));
 		}
 	}
 
@@ -1602,10 +1601,10 @@ public final class RocksDB {
 
 	/// MemorySegment put with explicit column family — zero-copy.
 	static void putCfSegment(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
-	                         MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+	                         MemorySegment key, MemorySegment val) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_PUT_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, keyLen, val, valLen, err);
+			MH_PUT_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, key.byteSize(), val, val.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -1625,23 +1624,23 @@ public final class RocksDB {
 	                         byte[] key, byte[] value) {
 		MemorySegment k = toNative(arena, key);
 		MemorySegment v = toNative(arena, value);
-		mergeCfSegment(arena, db, writeOpts, cf, k, key.length, v, value.length);
+		mergeCfSegment(arena, db, writeOpts, cf, k, v);
 	}
 
 	/// MemorySegment merge with explicit column family — zero-copy.
 	static void mergeCfSegment(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
-	                           MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+	                           MemorySegment key, MemorySegment val) {
 		try (Arena arena = Arena.ofConfined()) {
-			mergeCfSegment(arena, db, writeOpts, cf, key, keyLen, val, valLen);
+			mergeCfSegment(arena, db, writeOpts, cf, key, val);
 		}
 	}
 
 	/// MemorySegment merge with explicit column family using the caller's arena.
 	static void mergeCfSegment(Arena arena, RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
-	                           MemorySegment key, long keyLen, MemorySegment val, long valLen) {
+	                           MemorySegment key, MemorySegment val) {
 		try {
 			MemorySegment err = errHolder(arena);
-			MH_MERGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, keyLen, val, valLen, err);
+			MH_MERGE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, key.byteSize(), val, val.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("merge failed", t);
@@ -1674,12 +1673,12 @@ public final class RocksDB {
 	/// ByteBuffer get with explicit column family via `rocksdb_get_into_buffer_cf`.
 	/// Copies nothing when the buffer is too small.
 	static CopyResult getCfIntoBuffer(RocksDBReadOperations db, ReadOptions readOpts, ColumnFamilyHandle cf,
-	                                  MemorySegment key, long keyLen, ByteBuffer value) {
+	                                  MemorySegment key, ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
-			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db.dbPtr(), readOpts.ptr(), cf.ptr(), key, keyLen,
+			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db.dbPtr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(),
 					MemorySegment.ofBuffer(value), (long) value.remaining(), valLenSeg, foundSeg, err);
 			checkError(err);
 			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
@@ -1699,12 +1698,12 @@ public final class RocksDB {
 	/// MemorySegment get with explicit column family via `rocksdb_get_into_buffer_cf` —
 	/// copies directly into the caller's segment. Copies nothing when `value` is too small.
 	static CopyResult getCfIntoSegment(RocksDBReadOperations db, ReadOptions readOpts, ColumnFamilyHandle cf,
-	                                   MemorySegment key, long keyLen, MemorySegment value) {
+	                                   MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment valLenSeg = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment foundSeg = arena.allocate(ValueLayout.JAVA_BYTE);
-			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db.dbPtr(), readOpts.ptr(), cf.ptr(), key, keyLen,
+			byte fit = (byte) MH_GET_INTO_BUFFER_CF.invokeExact(db.dbPtr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(),
 					value, value.byteSize(), valLenSeg, foundSeg, err);
 			checkError(err);
 			if (foundSeg.get(ValueLayout.JAVA_BYTE, 0) == 0) {
@@ -1735,10 +1734,10 @@ public final class RocksDB {
 
 	/// MemorySegment delete with explicit column family — zero-copy.
 	static void deleteCfSegment(RocksDBWriteOperations db, WriteOptions writeOpts, ColumnFamilyHandle cf,
-	                            MemorySegment key, long keyLen) {
+	                            MemorySegment key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
-			MH_DELETE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, keyLen, err);
+			MH_DELETE_CF.invokeExact(db.dbPtr(), writeOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("delete failed", t);
@@ -1790,10 +1789,9 @@ public final class RocksDB {
 	}
 
 	static boolean keyMayExistCfSegment(RocksDBReadOperations db, ReadOptions roOpts,
-	                                    ColumnFamilyHandle cf,
-	                                    MemorySegment key, long keyLen) {
+	                                    ColumnFamilyHandle cf, MemorySegment key) {
 		try {
-			return fromByte((byte) MH_KEY_MAY_EXIST_CF.invokeExact(db.dbPtr(), roOpts.ptr(), cf.ptr(), key, keyLen,
+			return fromByte((byte) MH_KEY_MAY_EXIST_CF.invokeExact(db.dbPtr(), roOpts.ptr(), cf.ptr(), key, key.byteSize(),
 					MemorySegment.NULL, MemorySegment.NULL,
 					MemorySegment.NULL, 0L, MemorySegment.NULL));
 		} catch (Throwable t) {
@@ -1806,7 +1804,7 @@ public final class RocksDB {
 	static boolean keyMayExistCfBytes(RocksDBReadOperations db, ReadOptions roOpts,
 	                                  ColumnFamilyHandle cf, byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
-			return keyMayExistCfSegment(db, roOpts, cf, toNative(arena, key), key.length);
+			return keyMayExistCfSegment(db, roOpts, cf, toNative(arena, key));
 		}
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
@@ -60,7 +60,7 @@ public interface RocksDBReadOperations {
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ByteBuffer key, ByteBuffer value) {
 		return RocksDB.getIntoBuffer(this, RocksDB.DEFAULT_READ_OPTIONS,
-				MemorySegment.ofBuffer(key), key.remaining(), value);
+				MemorySegment.ofBuffer(key), value);
 	}
 
 	/// [#get(ByteBuffer, ByteBuffer)] with explicit [ReadOptions].
@@ -72,7 +72,7 @@ public interface RocksDBReadOperations {
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ReadOptions readOptions, ByteBuffer key, ByteBuffer value) {
 		return RocksDB.getIntoBuffer(this, readOptions,
-				MemorySegment.ofBuffer(key), key.remaining(), value);
+				MemorySegment.ofBuffer(key), value);
 	}
 
 	/// Single-copy get into a caller-supplied native segment via `rocksdb_get_into_buffer`.
@@ -83,7 +83,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(MemorySegment key, MemorySegment value) {
-		return RocksDB.getIntoSegment(this, RocksDB.DEFAULT_READ_OPTIONS, key, key.byteSize(), value);
+		return RocksDB.getIntoSegment(this, RocksDB.DEFAULT_READ_OPTIONS, key, value);
 	}
 
 	/// [#get(MemorySegment, MemorySegment)] with explicit [ReadOptions].
@@ -94,7 +94,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ReadOptions readOptions, MemorySegment key, MemorySegment value) {
-		return RocksDB.getIntoSegment(this, readOptions, key, key.byteSize(), value);
+		return RocksDB.getIntoSegment(this, readOptions, key, value);
 	}
 
 	/// Scoped zero-copy get: reads `key` via a `rocksdb_pinnable_handle_t` and passes a
@@ -155,7 +155,7 @@ public interface RocksDBReadOperations {
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
 		return RocksDB.getCfIntoBuffer(this, RocksDB.DEFAULT_READ_OPTIONS, cf,
-				MemorySegment.ofBuffer(key), key.remaining(), value);
+				MemorySegment.ofBuffer(key), value);
 	}
 
 	/// [#get(ColumnFamilyHandle, ByteBuffer, ByteBuffer)] with explicit [ReadOptions].
@@ -168,7 +168,7 @@ public interface RocksDBReadOperations {
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ColumnFamilyHandle cf, ReadOptions readOptions, ByteBuffer key, ByteBuffer value) {
 		return RocksDB.getCfIntoBuffer(this, readOptions, cf,
-				MemorySegment.ofBuffer(key), key.remaining(), value);
+				MemorySegment.ofBuffer(key), value);
 	}
 
 	/// Single-copy get from `cf` into a caller-supplied native segment via
@@ -180,7 +180,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		return RocksDB.getCfIntoSegment(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key, key.byteSize(), value);
+		return RocksDB.getCfIntoSegment(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key, value);
 	}
 
 	/// [#get(ColumnFamilyHandle, MemorySegment, MemorySegment)] with explicit [ReadOptions].
@@ -192,7 +192,7 @@ public interface RocksDBReadOperations {
 	/// @return [CopyResult.Copied] if copied, [CopyResult.NotEnoughCapacity] if `value` is too
 	/// small, or [CopyResult.NotFound] if the key is absent
 	default CopyResult get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key, MemorySegment value) {
-		return RocksDB.getCfIntoSegment(this, readOptions, cf, key, key.byteSize(), value);
+		return RocksDB.getCfIntoSegment(this, readOptions, cf, key, value);
 	}
 
 	/// Scoped zero-copy get from `cf`. See [#get(MemorySegment, Mapper)] for
@@ -248,7 +248,7 @@ public interface RocksDBReadOperations {
 	/// @param key direct [ByteBuffer] containing the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ByteBuffer key) {
-		return RocksDB.keyMayExistSegment(this, RocksDB.DEFAULT_READ_OPTIONS, MemorySegment.ofBuffer(key), key.remaining());
+		return RocksDB.keyMayExistSegment(this, RocksDB.DEFAULT_READ_OPTIONS, MemorySegment.ofBuffer(key));
 	}
 
 	/// Zero-copy for [MemorySegment]s.
@@ -256,7 +256,7 @@ public interface RocksDBReadOperations {
 	/// @param key native segment containing the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(MemorySegment key) {
-		return RocksDB.keyMayExistSegment(this, RocksDB.DEFAULT_READ_OPTIONS, key, key.byteSize());
+		return RocksDB.keyMayExistSegment(this, RocksDB.DEFAULT_READ_OPTIONS, key);
 	}
 
 	/// Returns `false` if the key definitely does not exist in `cf`; `true` means it _may_ exist.
@@ -285,7 +285,7 @@ public interface RocksDBReadOperations {
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ColumnFamilyHandle cf, ByteBuffer key) {
 		return RocksDB.keyMayExistCfSegment(this, RocksDB.DEFAULT_READ_OPTIONS, cf,
-				MemorySegment.ofBuffer(key), key.remaining());
+				MemorySegment.ofBuffer(key));
 	}
 
 	/// Zero-copy keyMayExist in `cf` for [MemorySegment]s.
@@ -294,7 +294,7 @@ public interface RocksDBReadOperations {
 	/// @param key native segment containing the key to probe
 	/// @return `false` if definitely absent, `true` if possibly present
 	default boolean keyMayExist(ColumnFamilyHandle cf, MemorySegment key) {
-		return RocksDB.keyMayExistCfSegment(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key, key.byteSize());
+		return RocksDB.keyMayExistCfSegment(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key);
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBWriteOperations.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBWriteOperations.java
@@ -59,8 +59,8 @@ public interface RocksDBWriteOperations {
 	/// @param value direct [ByteBuffer] containing the value
 	default void put(ByteBuffer key, ByteBuffer value) {
 		RocksDB.putSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS,
-				MemorySegment.ofBuffer(key), key.remaining(),
-				MemorySegment.ofBuffer(value), value.remaining());
+				MemorySegment.ofBuffer(key),
+				MemorySegment.ofBuffer(value));
 	}
 
 	/// Zero-copy put: caller supplies pre-allocated native segments.
@@ -68,7 +68,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	default void put(MemorySegment key, MemorySegment value) {
-		RocksDB.putSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize(), value, value.byteSize());
+		RocksDB.putSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
 	/// Zero-copy put using the caller's [Arena].
@@ -77,7 +77,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	default void put(Arena arena, MemorySegment key, MemorySegment value) {
-		RocksDB.putSegment(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize(), value, value.byteSize());
+		RocksDB.putSegment(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
 	/// Stores `value` under `key` in `cf`. Slow path: copies key/value into native memory.
@@ -96,8 +96,8 @@ public interface RocksDBWriteOperations {
 	/// @param value direct [ByteBuffer] containing the value
 	default void put(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
 		RocksDB.putCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf,
-				MemorySegment.ofBuffer(key), key.remaining(),
-				MemorySegment.ofBuffer(value), value.remaining());
+				MemorySegment.ofBuffer(key),
+				MemorySegment.ofBuffer(value));
 	}
 
 	/// Zero-copy put into `cf`: caller supplies pre-allocated native segments.
@@ -106,7 +106,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	default void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		RocksDB.putCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, key.byteSize(), value, value.byteSize());
+		RocksDB.putCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, value);
 	}
 
 	// -----------------------------------------------------------------------
@@ -137,8 +137,8 @@ public interface RocksDBWriteOperations {
 	/// @param value direct [ByteBuffer] containing the merge operand
 	default void merge(ByteBuffer key, ByteBuffer value) {
 		RocksDB.mergeSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS,
-				MemorySegment.ofBuffer(key), key.remaining(),
-				MemorySegment.ofBuffer(value), value.remaining());
+				MemorySegment.ofBuffer(key),
+				MemorySegment.ofBuffer(value));
 	}
 
 	/// Zero-copy merge: caller supplies pre-allocated native segments.
@@ -146,7 +146,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	default void merge(MemorySegment key, MemorySegment value) {
-		RocksDB.mergeSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize(), value, value.byteSize());
+		RocksDB.mergeSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
 	/// Zero-copy merge using the caller's [Arena].
@@ -155,7 +155,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	default void merge(Arena arena, MemorySegment key, MemorySegment value) {
-		RocksDB.mergeSegment(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize(), value, value.byteSize());
+		RocksDB.mergeSegment(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
 	/// Merges `value` into `key` in `cf`. Slow path: copies key/value into native memory.
@@ -174,8 +174,8 @@ public interface RocksDBWriteOperations {
 	/// @param value direct [ByteBuffer] containing the merge operand
 	default void merge(ColumnFamilyHandle cf, ByteBuffer key, ByteBuffer value) {
 		RocksDB.mergeCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf,
-				MemorySegment.ofBuffer(key), key.remaining(),
-				MemorySegment.ofBuffer(value), value.remaining());
+				MemorySegment.ofBuffer(key),
+				MemorySegment.ofBuffer(value));
 	}
 
 	/// Zero-copy merge into `cf`: caller supplies pre-allocated native segments.
@@ -184,7 +184,7 @@ public interface RocksDBWriteOperations {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	default void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
-		RocksDB.mergeCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, key.byteSize(), value, value.byteSize());
+		RocksDB.mergeCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, value);
 	}
 
 	// -----------------------------------------------------------------------
@@ -202,14 +202,14 @@ public interface RocksDBWriteOperations {
 	///
 	/// @param key direct [ByteBuffer] containing the key to remove
 	default void delete(ByteBuffer key) {
-		RocksDB.deleteSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, MemorySegment.ofBuffer(key), key.remaining());
+		RocksDB.deleteSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, MemorySegment.ofBuffer(key));
 	}
 
 	/// Zero-copy native-first path.
 	///
 	/// @param key native segment containing the key to remove
 	default void delete(MemorySegment key) {
-		RocksDB.deleteSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, key.byteSize());
+		RocksDB.deleteSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key);
 	}
 
 	/// Removes `key` from `cf`. Slow path: copies the key into native memory.
@@ -226,7 +226,7 @@ public interface RocksDBWriteOperations {
 	/// @param key direct [ByteBuffer] containing the key to remove
 	default void delete(ColumnFamilyHandle cf, ByteBuffer key) {
 		RocksDB.deleteCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf,
-				MemorySegment.ofBuffer(key), key.remaining());
+				MemorySegment.ofBuffer(key));
 	}
 
 	/// Zero-copy delete from `cf` for [MemorySegment]s.
@@ -234,7 +234,7 @@ public interface RocksDBWriteOperations {
 	/// @param cf  target column family
 	/// @param key native segment containing the key to remove
 	default void delete(ColumnFamilyHandle cf, MemorySegment key) {
-		RocksDB.deleteCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, key.byteSize());
+		RocksDB.deleteCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`putSegment`/`mergeSegment`/`deleteSegment`/`getIntoSegment`/`getIntoBuffer` and their `Cf`/`keyMayExist` counterparts took a separate `keyLen`/`valLen` parameter alongside the `MemorySegment` itself, even though every call site in the codebase computed it as exactly `key.byteSize()`/`value.byteSize()` (or `key.remaining()` after `MemorySegment.ofBuffer()`, which I verified is always identical to the resulting segment's `byteSize()`).

`withPinned`/`withPinnedCf` and `compactRangeSegment`/`deleteRangeCfSegment` already didn't take this redundant parameter — they compute the length internally from the segment. This brings the rest of the `*Segment` family in line with that existing precedent.

Pure refactor, no behavior change, no new tests needed.

## Test plan

- [x] `./mvnw -pl core -am clean test` — full core suite passes
- [x] `./mvnw -pl core javadoc:javadoc` — zero output
- [x] `./mvnw -pl integration-tests -am verify` — full integration suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)