### PR TITLE
Explicit WriteOptions overloads for direct write ops

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBWriteOperations.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBWriteOperations.java
@@ -44,6 +44,15 @@ public interface RocksDBWriteOperations {
 		RocksDB.putBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
+	/// [#put(byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to store
+	/// @param value        the value to associate with the key
+	default void put(WriteOptions writeOptions, byte[] key, byte[] value) {
+		RocksDB.putBytes(this, writeOptions, key, value);
+	}
+
 	/// Stores `value` under `key` using the caller's [Arena] for native allocation.
 	///
 	/// @param arena arena used for temporary native allocations
@@ -51,6 +60,16 @@ public interface RocksDBWriteOperations {
 	/// @param value the value to associate with the key
 	default void put(Arena arena, byte[] key, byte[] value) {
 		RocksDB.putBytes(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
+	}
+
+	/// [#put(Arena, byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param arena        arena used for temporary native allocations
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to store
+	/// @param value        the value to associate with the key
+	default void put(Arena arena, WriteOptions writeOptions, byte[] key, byte[] value) {
+		RocksDB.putBytes(arena, this, writeOptions, key, value);
 	}
 
 	/// Zero-copy put: wraps the direct buffers' native memory without heap→native copy.
@@ -63,12 +82,32 @@ public interface RocksDBWriteOperations {
 				MemorySegment.ofBuffer(value));
 	}
 
+	/// [#put(ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [ByteBuffer] containing the key
+	/// @param value        direct [ByteBuffer] containing the value
+	default void put(WriteOptions writeOptions, ByteBuffer key, ByteBuffer value) {
+		RocksDB.putSegment(this, writeOptions,
+				MemorySegment.ofBuffer(key),
+				MemorySegment.ofBuffer(value));
+	}
+
 	/// Zero-copy put: caller supplies pre-allocated native segments.
 	///
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	default void put(MemorySegment key, MemorySegment value) {
 		RocksDB.putSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
+	}
+
+	/// [#put(MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the value
+	default void put(WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
+		RocksDB.putSegment(this, writeOptions, key, value);
 	}
 
 	/// Zero-copy put using the caller's [Arena].
@@ -80,6 +119,16 @@ public interface RocksDBWriteOperations {
 		RocksDB.putSegment(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
+	/// [#put(Arena, MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param arena        arena used for temporary native allocations
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the value
+	default void put(Arena arena, WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
+		RocksDB.putSegment(arena, this, writeOptions, key, value);
+	}
+
 	/// Stores `value` under `key` in `cf`. Slow path: copies key/value into native memory.
 	///
 	/// @param cf    target column family
@@ -87,6 +136,16 @@ public interface RocksDBWriteOperations {
 	/// @param value the value to associate with the key
 	default void put(ColumnFamilyHandle cf, byte[] key, byte[] value) {
 		RocksDB.putCfBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, value);
+	}
+
+	/// [#put(ColumnFamilyHandle, byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to store
+	/// @param value        the value to associate with the key
+	default void put(ColumnFamilyHandle cf, WriteOptions writeOptions, byte[] key, byte[] value) {
+		RocksDB.putCfBytes(this, writeOptions, cf, key, value);
 	}
 
 	/// Zero-copy put into `cf`: wraps the direct buffers' native memory without heap→native copy.
@@ -100,6 +159,18 @@ public interface RocksDBWriteOperations {
 				MemorySegment.ofBuffer(value));
 	}
 
+	/// [#put(ColumnFamilyHandle, ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [ByteBuffer] containing the key
+	/// @param value        direct [ByteBuffer] containing the value
+	default void put(ColumnFamilyHandle cf, WriteOptions writeOptions, ByteBuffer key, ByteBuffer value) {
+		RocksDB.putCfSegment(this, writeOptions, cf,
+				MemorySegment.ofBuffer(key),
+				MemorySegment.ofBuffer(value));
+	}
+
 	/// Zero-copy put into `cf`: caller supplies pre-allocated native segments.
 	///
 	/// @param cf    target column family
@@ -107,6 +178,16 @@ public interface RocksDBWriteOperations {
 	/// @param value native segment containing the value
 	default void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		RocksDB.putCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, value);
+	}
+
+	/// [#put(ColumnFamilyHandle, MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the value
+	default void put(ColumnFamilyHandle cf, WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
+		RocksDB.putCfSegment(this, writeOptions, cf, key, value);
 	}
 
 	// -----------------------------------------------------------------------
@@ -122,6 +203,15 @@ public interface RocksDBWriteOperations {
 		RocksDB.mergeBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
+	/// [#merge(byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to merge into
+	/// @param value        the merge operand
+	default void merge(WriteOptions writeOptions, byte[] key, byte[] value) {
+		RocksDB.mergeBytes(this, writeOptions, key, value);
+	}
+
 	/// Merges `value` into `key` using the caller's [Arena] for native allocation.
 	///
 	/// @param arena arena used for temporary native allocations
@@ -129,6 +219,16 @@ public interface RocksDBWriteOperations {
 	/// @param value the merge operand
 	default void merge(Arena arena, byte[] key, byte[] value) {
 		RocksDB.mergeBytes(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
+	}
+
+	/// [#merge(Arena, byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param arena        arena used for temporary native allocations
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to merge into
+	/// @param value        the merge operand
+	default void merge(Arena arena, WriteOptions writeOptions, byte[] key, byte[] value) {
+		RocksDB.mergeBytes(arena, this, writeOptions, key, value);
 	}
 
 	/// Zero-copy merge: wraps the direct buffers' native memory without heap→native copy.
@@ -141,12 +241,32 @@ public interface RocksDBWriteOperations {
 				MemorySegment.ofBuffer(value));
 	}
 
+	/// [#merge(ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [ByteBuffer] containing the key
+	/// @param value        direct [ByteBuffer] containing the merge operand
+	default void merge(WriteOptions writeOptions, ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeSegment(this, writeOptions,
+				MemorySegment.ofBuffer(key),
+				MemorySegment.ofBuffer(value));
+	}
+
 	/// Zero-copy merge: caller supplies pre-allocated native segments.
 	///
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the merge operand
 	default void merge(MemorySegment key, MemorySegment value) {
 		RocksDB.mergeSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
+	}
+
+	/// [#merge(MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the merge operand
+	default void merge(WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
+		RocksDB.mergeSegment(this, writeOptions, key, value);
 	}
 
 	/// Zero-copy merge using the caller's [Arena].
@@ -158,6 +278,16 @@ public interface RocksDBWriteOperations {
 		RocksDB.mergeSegment(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, key, value);
 	}
 
+	/// [#merge(Arena, MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param arena        arena used for temporary native allocations
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the merge operand
+	default void merge(Arena arena, WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
+		RocksDB.mergeSegment(arena, this, writeOptions, key, value);
+	}
+
 	/// Merges `value` into `key` in `cf`. Slow path: copies key/value into native memory.
 	///
 	/// @param cf    target column family
@@ -165,6 +295,16 @@ public interface RocksDBWriteOperations {
 	/// @param value the merge operand
 	default void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
 		RocksDB.mergeCfBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, value);
+	}
+
+	/// [#merge(ColumnFamilyHandle, byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to merge into
+	/// @param value        the merge operand
+	default void merge(ColumnFamilyHandle cf, WriteOptions writeOptions, byte[] key, byte[] value) {
+		RocksDB.mergeCfBytes(this, writeOptions, cf, key, value);
 	}
 
 	/// Zero-copy merge into `cf`: wraps the direct buffers' native memory without heap→native copy.
@@ -178,6 +318,18 @@ public interface RocksDBWriteOperations {
 				MemorySegment.ofBuffer(value));
 	}
 
+	/// [#merge(ColumnFamilyHandle, ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [ByteBuffer] containing the key
+	/// @param value        direct [ByteBuffer] containing the merge operand
+	default void merge(ColumnFamilyHandle cf, WriteOptions writeOptions, ByteBuffer key, ByteBuffer value) {
+		RocksDB.mergeCfSegment(this, writeOptions, cf,
+				MemorySegment.ofBuffer(key),
+				MemorySegment.ofBuffer(value));
+	}
+
 	/// Zero-copy merge into `cf`: caller supplies pre-allocated native segments.
 	///
 	/// @param cf    target column family
@@ -185,6 +337,16 @@ public interface RocksDBWriteOperations {
 	/// @param value native segment containing the merge operand
 	default void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		RocksDB.mergeCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key, value);
+	}
+
+	/// [#merge(ColumnFamilyHandle, MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the merge operand
+	default void merge(ColumnFamilyHandle cf, WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
+		RocksDB.mergeCfSegment(this, writeOptions, cf, key, value);
 	}
 
 	// -----------------------------------------------------------------------
@@ -198,11 +360,27 @@ public interface RocksDBWriteOperations {
 		RocksDB.deleteBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, key);
 	}
 
+	/// [#delete(byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to remove
+	default void delete(WriteOptions writeOptions, byte[] key) {
+		RocksDB.deleteBytes(this, writeOptions, key);
+	}
+
 	/// Zero-copy for direct [ByteBuffer]s.
 	///
 	/// @param key direct [ByteBuffer] containing the key to remove
 	default void delete(ByteBuffer key) {
 		RocksDB.deleteSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, MemorySegment.ofBuffer(key));
+	}
+
+	/// [#delete(ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [ByteBuffer] containing the key to remove
+	default void delete(WriteOptions writeOptions, ByteBuffer key) {
+		RocksDB.deleteSegment(this, writeOptions, MemorySegment.ofBuffer(key));
 	}
 
 	/// Zero-copy native-first path.
@@ -212,12 +390,29 @@ public interface RocksDBWriteOperations {
 		RocksDB.deleteSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, key);
 	}
 
+	/// [#delete(MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key to remove
+	default void delete(WriteOptions writeOptions, MemorySegment key) {
+		RocksDB.deleteSegment(this, writeOptions, key);
+	}
+
 	/// Removes `key` from `cf`. Slow path: copies the key into native memory.
 	///
 	/// @param cf  target column family
 	/// @param key the key to remove
 	default void delete(ColumnFamilyHandle cf, byte[] key) {
 		RocksDB.deleteCfBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key);
+	}
+
+	/// [#delete(ColumnFamilyHandle, byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to remove
+	default void delete(ColumnFamilyHandle cf, WriteOptions writeOptions, byte[] key) {
+		RocksDB.deleteCfBytes(this, writeOptions, cf, key);
 	}
 
 	/// Zero-copy delete from `cf` for direct [ByteBuffer]s.
@@ -229,12 +424,31 @@ public interface RocksDBWriteOperations {
 				MemorySegment.ofBuffer(key));
 	}
 
+	/// [#delete(ColumnFamilyHandle, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [ByteBuffer] containing the key to remove
+	default void delete(ColumnFamilyHandle cf, WriteOptions writeOptions, ByteBuffer key) {
+		RocksDB.deleteCfSegment(this, writeOptions, cf,
+				MemorySegment.ofBuffer(key));
+	}
+
 	/// Zero-copy delete from `cf` for [MemorySegment]s.
 	///
 	/// @param cf  target column family
 	/// @param key native segment containing the key to remove
 	default void delete(ColumnFamilyHandle cf, MemorySegment key) {
 		RocksDB.deleteCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, key);
+	}
+
+	/// [#delete(ColumnFamilyHandle, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key to remove
+	default void delete(ColumnFamilyHandle cf, WriteOptions writeOptions, MemorySegment key) {
+		RocksDB.deleteCfSegment(this, writeOptions, cf, key);
 	}
 
 	// -----------------------------------------------------------------------
@@ -250,6 +464,15 @@ public interface RocksDBWriteOperations {
 		RocksDB.deleteRangeCfBytes(this, RocksDB.DEFAULT_WRITE_OPTIONS, startKey, endKey);
 	}
 
+	/// [#deleteRange(byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param startKey     inclusive lower bound
+	/// @param endKey       exclusive upper bound
+	default void deleteRange(WriteOptions writeOptions, byte[] startKey, byte[] endKey) {
+		RocksDB.deleteRangeCfBytes(this, writeOptions, startKey, endKey);
+	}
+
 	/// Zero-copy for direct [ByteBuffer]s.
 	///
 	/// @param startKey direct [ByteBuffer] with inclusive lower bound
@@ -258,12 +481,30 @@ public interface RocksDBWriteOperations {
 		RocksDB.deleteRangeCfBuffer(this, RocksDB.DEFAULT_WRITE_OPTIONS, startKey, endKey);
 	}
 
+	/// [#deleteRange(ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param startKey     direct [ByteBuffer] with inclusive lower bound
+	/// @param endKey       direct [ByteBuffer] with exclusive upper bound
+	default void deleteRange(WriteOptions writeOptions, ByteBuffer startKey, ByteBuffer endKey) {
+		RocksDB.deleteRangeCfBuffer(this, writeOptions, startKey, endKey);
+	}
+
 	/// Zero-copy native-first path.
 	///
 	/// @param startKey native segment with inclusive lower bound
 	/// @param endKey   native segment with exclusive upper bound
 	default void deleteRange(MemorySegment startKey, MemorySegment endKey) {
 		RocksDB.deleteRangeCfSegment(this, RocksDB.DEFAULT_WRITE_OPTIONS, startKey, endKey);
+	}
+
+	/// [#deleteRange(MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param startKey     native segment with inclusive lower bound
+	/// @param endKey       native segment with exclusive upper bound
+	default void deleteRange(WriteOptions writeOptions, MemorySegment startKey, MemorySegment endKey) {
+		RocksDB.deleteRangeCfSegment(this, writeOptions, startKey, endKey);
 	}
 
 	/// Deletes all keys in the half-open range [`startKey`, `endKey`) from `cf`. Slow path.
@@ -275,6 +516,16 @@ public interface RocksDBWriteOperations {
 		RocksDB.deleteRangeCfBytesExplicit(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, startKey, endKey);
 	}
 
+	/// [#deleteRange(ColumnFamilyHandle, byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param startKey     inclusive lower bound
+	/// @param endKey       exclusive upper bound
+	default void deleteRange(ColumnFamilyHandle cf, WriteOptions writeOptions, byte[] startKey, byte[] endKey) {
+		RocksDB.deleteRangeCfBytesExplicit(this, writeOptions, cf, startKey, endKey);
+	}
+
 	/// Zero-copy deleteRange from `cf` for direct [ByteBuffer]s.
 	///
 	/// @param cf       target column family
@@ -284,6 +535,16 @@ public interface RocksDBWriteOperations {
 		RocksDB.deleteRangeCfBufferExplicit(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, startKey, endKey);
 	}
 
+	/// [#deleteRange(ColumnFamilyHandle, ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param startKey     direct [ByteBuffer] with inclusive lower bound
+	/// @param endKey       direct [ByteBuffer] with exclusive upper bound
+	default void deleteRange(ColumnFamilyHandle cf, WriteOptions writeOptions, ByteBuffer startKey, ByteBuffer endKey) {
+		RocksDB.deleteRangeCfBufferExplicit(this, writeOptions, cf, startKey, endKey);
+	}
+
 	/// Zero-copy deleteRange from `cf` for [MemorySegment]s.
 	///
 	/// @param cf       target column family
@@ -291,6 +552,17 @@ public interface RocksDBWriteOperations {
 	/// @param endKey   native segment with exclusive upper bound
 	default void deleteRange(ColumnFamilyHandle cf, MemorySegment startKey, MemorySegment endKey) {
 		RocksDB.deleteRangeCfSegmentExplicit(this, RocksDB.DEFAULT_WRITE_OPTIONS, cf, startKey, endKey);
+	}
+
+	/// [#deleteRange(ColumnFamilyHandle, MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param startKey     native segment with inclusive lower bound
+	/// @param endKey       native segment with exclusive upper bound
+	default void deleteRange(ColumnFamilyHandle cf, WriteOptions writeOptions,
+	                          MemorySegment startKey, MemorySegment endKey) {
+		RocksDB.deleteRangeCfSegmentExplicit(this, writeOptions, cf, startKey, endKey);
 	}
 
 	// -----------------------------------------------------------------------
@@ -304,12 +576,29 @@ public interface RocksDBWriteOperations {
 		RocksDB.writeBatch(this, RocksDB.DEFAULT_WRITE_OPTIONS, batch);
 	}
 
+	/// [#write(WriteBatch)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param batch        the write batch to apply
+	default void write(WriteOptions writeOptions, WriteBatch batch) {
+		RocksDB.writeBatch(this, writeOptions, batch);
+	}
+
 	/// Applies all mutations in `batch` atomically, using the caller's [Arena] for native allocation.
 	///
 	/// @param arena arena used for temporary native allocations
 	/// @param batch the write batch to apply
 	default void write(Arena arena, WriteBatch batch) {
 		RocksDB.writeBatch(arena, this, RocksDB.DEFAULT_WRITE_OPTIONS, batch);
+	}
+
+	/// [#write(Arena, WriteBatch)] with explicit [WriteOptions].
+	///
+	/// @param arena        arena used for temporary native allocations
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param batch        the write batch to apply
+	default void write(Arena arena, WriteOptions writeOptions, WriteBatch batch) {
+		RocksDB.writeBatch(arena, this, writeOptions, batch);
 	}
 
 	// -----------------------------------------------------------------------

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -268,11 +268,20 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param key   the key to store
 	/// @param value the value to associate with the key
 	public void put(byte[] key, byte[] value) {
+		put(writeOpts, key, value);
+	}
+
+	/// [#put(byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to store
+	/// @param value        the value to associate with the key
+	public void put(WriteOptions writeOptions, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment k = RocksDB.toNative(arena, key);
 			MemorySegment v = RocksDB.toNative(arena, value);
-			MH_PUT.invokeExact(ptr(), writeOpts.ptr(), k, (long) key.length, v, (long) value.length, err);
+			MH_PUT.invokeExact(ptr(), writeOptions.ptr(), k, (long) key.length, v, (long) value.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -284,9 +293,18 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param key   direct [java.nio.ByteBuffer] containing the key
 	/// @param value direct [java.nio.ByteBuffer] containing the value
 	public void put(java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
+		put(writeOpts, key, value);
+	}
+
+	/// [#put(ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [java.nio.ByteBuffer] containing the key
+	/// @param value        direct [java.nio.ByteBuffer] containing the value
+	public void put(WriteOptions writeOptions, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_PUT.invokeExact(ptr(), writeOpts.ptr(),
+			MH_PUT.invokeExact(ptr(), writeOptions.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining(),
 					MemorySegment.ofBuffer(value), (long) value.remaining(),
 					err);
@@ -301,9 +319,18 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	public void put(MemorySegment key, MemorySegment value) {
+		put(writeOpts, key, value);
+	}
+
+	/// [#put(MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the value
+	public void put(WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_PUT.invokeExact(ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize(), err);
+			MH_PUT.invokeExact(ptr(), writeOptions.ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("put failed", t);
@@ -316,7 +343,18 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param value the merge operand
 	public void merge(byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			merge(arena, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
+			merge(arena, writeOpts, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
+		}
+	}
+
+	/// [#merge(byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to merge into
+	/// @param value        the merge operand
+	public void merge(WriteOptions writeOptions, byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, writeOptions, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
 		}
 	}
 
@@ -326,7 +364,18 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param value direct [java.nio.ByteBuffer] containing the merge operand
 	public void merge(java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
-			merge(arena, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
+			merge(arena, writeOpts, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
+		}
+	}
+
+	/// [#merge(ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [java.nio.ByteBuffer] containing the key
+	/// @param value        direct [java.nio.ByteBuffer] containing the merge operand
+	public void merge(WriteOptions writeOptions, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, writeOptions, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
 		}
 	}
 
@@ -336,15 +385,26 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param value native segment containing the merge operand
 	public void merge(MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
-			merge(arena, key, value);
+			merge(arena, writeOpts, key, value);
+		}
+	}
+
+	/// [#merge(MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the merge operand
+	public void merge(WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, writeOptions, key, value);
 		}
 	}
 
 	/// Merge core using the caller's arena — every tier above builds its segments then delegates here.
-	private void merge(Arena arena, MemorySegment key, MemorySegment value) {
+	private void merge(Arena arena, WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
 		try {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_MERGE.invokeExact(ptr(), writeOpts.ptr(), key, key.byteSize(), value, value.byteSize(), err);
+			MH_MERGE.invokeExact(ptr(), writeOptions.ptr(), key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("merge failed", t);
@@ -519,10 +579,18 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	///
 	/// @param key the key to remove
 	public void delete(byte[] key) {
+		delete(writeOpts, key);
+	}
+
+	/// [#delete(byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to remove
+	public void delete(WriteOptions writeOptions, byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment k = RocksDB.toNative(arena, key);
-			MH_DELETE.invokeExact(ptr(), writeOpts.ptr(), k, (long) key.length, err);
+			MH_DELETE.invokeExact(ptr(), writeOptions.ptr(), k, (long) key.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("delete failed", t);
@@ -533,9 +601,17 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	///
 	/// @param key direct [java.nio.ByteBuffer] containing the key to remove
 	public void delete(java.nio.ByteBuffer key) {
+		delete(writeOpts, key);
+	}
+
+	/// [#delete(ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [java.nio.ByteBuffer] containing the key to remove
+	public void delete(WriteOptions writeOptions, java.nio.ByteBuffer key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_DELETE.invokeExact(ptr(), writeOpts.ptr(),
+			MH_DELETE.invokeExact(ptr(), writeOptions.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
@@ -547,9 +623,17 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	///
 	/// @param key native segment containing the key to remove
 	public void delete(MemorySegment key) {
+		delete(writeOpts, key);
+	}
+
+	/// [#delete(MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key to remove
+	public void delete(WriteOptions writeOptions, MemorySegment key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_DELETE.invokeExact(ptr(), writeOpts.ptr(), key, key.byteSize(), err);
+			MH_DELETE.invokeExact(ptr(), writeOptions.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("delete failed", t);
@@ -608,9 +692,19 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param key   the key to store
 	/// @param value the value to associate with the key
 	public void put(ColumnFamilyHandle cf, byte[] key, byte[] value) {
+		put(cf, writeOpts, key, value);
+	}
+
+	/// [#put(ColumnFamilyHandle, byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to store
+	/// @param value        the value to associate with the key
+	public void put(ColumnFamilyHandle cf, WriteOptions writeOptions, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_PUT_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+			MH_PUT_CF.invokeExact(ptr(), writeOptions.ptr(), cf.ptr(),
 					RocksDB.toNative(arena, key), (long) key.length,
 					RocksDB.toNative(arena, value), (long) value.length, err);
 			RocksDB.checkError(err);
@@ -625,9 +719,19 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param key   direct [java.nio.ByteBuffer] containing the key
 	/// @param value direct [java.nio.ByteBuffer] containing the value
 	public void put(ColumnFamilyHandle cf, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
+		put(cf, writeOpts, key, value);
+	}
+
+	/// [#put(ColumnFamilyHandle, ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [java.nio.ByteBuffer] containing the key
+	/// @param value        direct [java.nio.ByteBuffer] containing the value
+	public void put(ColumnFamilyHandle cf, WriteOptions writeOptions, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_PUT_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+			MH_PUT_CF.invokeExact(ptr(), writeOptions.ptr(), cf.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining(),
 					MemorySegment.ofBuffer(value), (long) value.remaining(), err);
 			RocksDB.checkError(err);
@@ -642,9 +746,19 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param key   native segment containing the key
 	/// @param value native segment containing the value
 	public void put(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+		put(cf, writeOpts, key, value);
+	}
+
+	/// [#put(ColumnFamilyHandle, MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the value
+	public void put(ColumnFamilyHandle cf, WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_PUT_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+			MH_PUT_CF.invokeExact(ptr(), writeOptions.ptr(), cf.ptr(),
 					key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
@@ -663,7 +777,19 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param value the merge operand
 	public void merge(ColumnFamilyHandle cf, byte[] key, byte[] value) {
 		try (Arena arena = Arena.ofConfined()) {
-			merge(arena, cf, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
+			merge(arena, cf, writeOpts, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
+		}
+	}
+
+	/// [#merge(ColumnFamilyHandle, byte\[\], byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to merge into
+	/// @param value        the merge operand
+	public void merge(ColumnFamilyHandle cf, WriteOptions writeOptions, byte[] key, byte[] value) {
+		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, cf, writeOptions, RocksDB.toNative(arena, key), RocksDB.toNative(arena, value));
 		}
 	}
 
@@ -674,7 +800,19 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param value direct [java.nio.ByteBuffer] containing the merge operand
 	public void merge(ColumnFamilyHandle cf, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
 		try (Arena arena = Arena.ofConfined()) {
-			merge(arena, cf, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
+			merge(arena, cf, writeOpts, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
+		}
+	}
+
+	/// [#merge(ColumnFamilyHandle, ByteBuffer, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [java.nio.ByteBuffer] containing the key
+	/// @param value        direct [java.nio.ByteBuffer] containing the merge operand
+	public void merge(ColumnFamilyHandle cf, WriteOptions writeOptions, java.nio.ByteBuffer key, java.nio.ByteBuffer value) {
+		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, cf, writeOptions, MemorySegment.ofBuffer(key), MemorySegment.ofBuffer(value));
 		}
 	}
 
@@ -685,15 +823,27 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param value native segment containing the merge operand
 	public void merge(ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
 		try (Arena arena = Arena.ofConfined()) {
-			merge(arena, cf, key, value);
+			merge(arena, cf, writeOpts, key, value);
+		}
+	}
+
+	/// [#merge(ColumnFamilyHandle, MemorySegment, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key
+	/// @param value        native segment containing the merge operand
+	public void merge(ColumnFamilyHandle cf, WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
+		try (Arena arena = Arena.ofConfined()) {
+			merge(arena, cf, writeOptions, key, value);
 		}
 	}
 
 	/// Merge-into-cf core using the caller's arena — every tier above delegates here.
-	private void merge(Arena arena, ColumnFamilyHandle cf, MemorySegment key, MemorySegment value) {
+	private void merge(Arena arena, ColumnFamilyHandle cf, WriteOptions writeOptions, MemorySegment key, MemorySegment value) {
 		try {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_MERGE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+			MH_MERGE_CF.invokeExact(ptr(), writeOptions.ptr(), cf.ptr(),
 					key, key.byteSize(), value, value.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
@@ -826,9 +976,18 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param cf  target column family
 	/// @param key the key to remove
 	public void delete(ColumnFamilyHandle cf, byte[] key) {
+		delete(cf, writeOpts, key);
+	}
+
+	/// [#delete(ColumnFamilyHandle, byte\[\])] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          the key to remove
+	public void delete(ColumnFamilyHandle cf, WriteOptions writeOptions, byte[] key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_DELETE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+			MH_DELETE_CF.invokeExact(ptr(), writeOptions.ptr(), cf.ptr(),
 					RocksDB.toNative(arena, key), (long) key.length, err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
@@ -841,9 +1000,18 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param cf  target column family
 	/// @param key direct [java.nio.ByteBuffer] containing the key to remove
 	public void delete(ColumnFamilyHandle cf, java.nio.ByteBuffer key) {
+		delete(cf, writeOpts, key);
+	}
+
+	/// [#delete(ColumnFamilyHandle, ByteBuffer)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          direct [java.nio.ByteBuffer] containing the key to remove
+	public void delete(ColumnFamilyHandle cf, WriteOptions writeOptions, java.nio.ByteBuffer key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_DELETE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(),
+			MH_DELETE_CF.invokeExact(ptr(), writeOptions.ptr(), cf.ptr(),
 					MemorySegment.ofBuffer(key), (long) key.remaining(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
@@ -856,9 +1024,18 @@ public final class TransactionDB extends NativeObjectWithBaseDb {
 	/// @param cf  target column family
 	/// @param key native segment containing the key to remove
 	public void delete(ColumnFamilyHandle cf, MemorySegment key) {
+		delete(cf, writeOpts, key);
+	}
+
+	/// [#delete(ColumnFamilyHandle, MemorySegment)] with explicit [WriteOptions].
+	///
+	/// @param cf           target column family
+	/// @param writeOptions write options, e.g. to disable the WAL for this write
+	/// @param key          native segment containing the key to remove
+	public void delete(ColumnFamilyHandle cf, WriteOptions writeOptions, MemorySegment key) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
-			MH_DELETE_CF.invokeExact(ptr(), writeOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
+			MH_DELETE_CF.invokeExact(ptr(), writeOptions.ptr(), cf.ptr(), key, key.byteSize(), err);
 			RocksDB.checkError(err);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("delete failed", t);

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/WriteOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/WriteOptionsTest.java
@@ -1,6 +1,9 @@
 package io.github.dfa1.rocksdbffm;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -124,6 +127,202 @@ class WriteOptionsTest {
 			assertThat(sut.isMemtableInsertHintPerBatch()).isFalse();
 			assertThat(sut.getRateLimiterPriority()).isEqualTo(IOPriority.TOTAL);
 			assertThat(sut.getIoActivity()).isEqualTo(IOActivity.UNKNOWN);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Explicit WriteOptions overloads actually reach the native write —
+	// proven via WAL absence, not just "the overload compiles"
+	// -----------------------------------------------------------------------
+
+	@Test
+	void put_withExplicitDisableWal_isReadableButAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.put(wo, "k".getBytes(), "v".getBytes());
+
+			// Then — the write is visible through a normal read...
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+			// ...but never reached the WAL, proving the explicit WriteOptions was
+			// actually threaded through rather than the default (WAL-enabled) options
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void put_withoutExplicitOptions_appearsInWal(@TempDir Path dir) {
+		// Given — same workload as above, but via the default-options overload
+		try (var db = RocksDB.openReadWrite(dir)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.put("k".getBytes(), "v".getBytes());
+
+			// Then — contrast case: the default WriteOptions has WAL enabled
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isTrue();
+			}
+		}
+	}
+
+	@Test
+	void put_withExplicitDisableWal_cfScoped_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.put(cf, wo, "k".getBytes(), "v".getBytes());
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void merge_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true).setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir);
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.merge(wo, "k".getBytes(), "v".getBytes());
+
+			// Then
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void delete_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			// Setup write is itself WAL-disabled: getUpdatesSince(seq) is inclusive of the
+			// batch at seq, so a WAL-enabled setup put here would make start coincide with
+			// a real WAL entry and the assertion below would pass for the wrong reason.
+			db.put(wo, "k".getBytes(), "v".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.delete(wo, "k".getBytes());
+
+			// Then
+			assertThat(db.get("k".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void deleteRange_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			// Setup writes are themselves WAL-disabled — see comment in
+			// delete_withExplicitDisableWal_isAbsentFromWal for why.
+			db.put(wo, "a".getBytes(), "1".getBytes());
+			db.put(wo, "b".getBytes(), "2".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.deleteRange(wo, "a".getBytes(), "c".getBytes());
+
+			// Then
+			assertThat(db.get("a".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void write_batch_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true);
+		     var batch = WriteBatch.create()) {
+			batch.put("k".getBytes(), "v".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.write(wo, batch);
+
+			// Then
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// TransactionDB direct ops — WriteOptions overload wiring
+	// -----------------------------------------------------------------------
+
+	@Test
+	void transactionDB_put_withExplicitWriteOptions_isReadable(@TempDir Path dir) {
+		// Given
+		try (var txnDbOpts = TransactionDBOptions.newTransactionDBOptions();
+		     var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openTransaction(opts, txnDbOpts, dir);
+		     var wo = WriteOptions.newWriteOptions().setSync(false)) {
+
+			// When
+			db.put(wo, "k".getBytes(), "v".getBytes());
+
+			// Then — the explicit-options overload is not silently ignored: the value lands
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void transactionDB_put_cfScoped_withExplicitWriteOptions_isReadable(@TempDir Path dir) {
+		// Given
+		try (var txnDbOpts = TransactionDBOptions.newTransactionDBOptions();
+		     var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openTransaction(opts, txnDbOpts, dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var wo = WriteOptions.newWriteOptions().setSync(false)) {
+
+			// When
+			db.put(cf, wo, "k".getBytes(), "v".getBytes());
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void transactionDB_delete_withExplicitWriteOptions_removesKey(@TempDir Path dir) {
+		// Given
+		try (var txnDbOpts = TransactionDBOptions.newTransactionDBOptions();
+		     var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openTransaction(opts, txnDbOpts, dir);
+		     var wo = WriteOptions.newWriteOptions().setSync(false)) {
+			db.put("k".getBytes(), "v".getBytes());
+
+			// When
+			db.delete(wo, "k".getBytes());
+
+			// Then
+			assertThat(db.get("k".getBytes())).isNull();
 		}
 	}
 }


### PR DESCRIPTION
Closes #109.

## Summary

- `RocksDBWriteOperations` (`put`/`merge`/`delete`/`deleteRange`/`write`, all tiers and CF variants, including the `Arena`-taking `put`/`merge`) gains a `WriteOptions` overload alongside every existing default-options method — 30 new methods. Mechanical now that `RocksDB.java`'s write helpers already accept `WriteOptions` objects (#111): each new overload just forwards the caller's `WriteOptions` instead of `RocksDB.DEFAULT_WRITE_OPTIONS`.
- `TransactionDB`'s own hand-rolled direct `put`/`merge`/`delete` (byte[]/ByteBuffer/MemorySegment, plain and CF-scoped) get the same 18 new overloads. The two private `merge()` core helpers (plain and CF-scoped) now take a `WriteOptions` parameter instead of reading the `writeOpts` field directly, so both the default-options and explicit-options public methods share them.

## Test plan

Tests prove the explicit `WriteOptions` is actually honored, not just accepted and ignored:
- `setDisableWal(true)` passed through the explicit overload leaves no trace in the WAL (checked via `getUpdatesSince`), contrasted with a default-options write that does appear.
- Covers `put`/`merge`/`delete`/`deleteRange`/`write(batch)`, plus a CF-scoped case.
- `TransactionDB`'s `put`/`delete` overloads have no WAL iteration to check against, so those are correctness-only (the value round-trips through the explicit-options path).

- [x] `./mvnw -pl core -am clean test` — full core suite passes
- [x] `./mvnw -pl core javadoc:javadoc` — zero output
- [x] `./mvnw -pl integration-tests -am verify` — full integration suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)