### PR TITLE
Throw UnsupportedOperationException for unlinked compression types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   views of the key, existing value, and operands instead of copied `byte[]`s — benchmarking
   showed the copies dominating once operands exceed ~1KB, so there's no separate copying tier.
   (closes [#94](https://github.com/dfa1/rocksdbffm/issues/94))
+- `Options.setCompression`/`setBlobCompressionType` now throw `UnsupportedOperationException` for
+  `SNAPPY`, `ZLIB`, `BZLIB2`, `XPRESS` — not linked into the bundled native library yet — instead
+  of failing opaquely at DB-open time. ([#114](https://github.com/dfa1/rocksdbffm/pull/114),
+  part of [#83](https://github.com/dfa1/rocksdbffm/issues/83))
 
 ## [0.9] — 2026-08-21
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/CompressionType.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/CompressionType.java
@@ -4,7 +4,9 @@ package io.github.dfa1.rocksdbffm;
 ///
 /// Integer values match the `rocksdb_*_compression` constants in `rocksdb/c.h`.
 ///
-/// Not every algorithm is available in every RocksDB build.
+/// `SNAPPY`, `ZLIB`, `BZLIB2`, and `XPRESS` aren't linked into the bundled native library yet;
+/// [Options#setCompression(CompressionType)] and [Options#setBlobCompressionType(CompressionType)]
+/// throw [UnsupportedOperationException] for those values.
 ///
 /// ```
 /// try (Options opts = Options.newOptions().setCompression(CompressionType.LZ4)) { ... }
@@ -15,15 +17,12 @@ public enum CompressionType {
 	NO_COMPRESSION(0),
 
 	/// Snappy compression.
-	/// TODO: not supported yet
 	SNAPPY(1),
 
 	/// zlib compression.
-	/// TODO: not supported yet
 	ZLIB(2),
 
 	/// bzip2 compression.
-	/// TODO: not supported yet
 	BZLIB2(3),
 
 	/// LZ4 compression.
@@ -33,7 +32,6 @@ public enum CompressionType {
 	LZ4HC(5),
 
 	/// Express compression (Windows only).
-	/// TODO: not supported yet
 	XPRESS(6),
 
 	/// Zstandard compression.
@@ -48,6 +46,16 @@ public enum CompressionType {
 	// don't expose the raw value
 	int getValue() {
 		return value;
+	}
+
+	/// Whether this algorithm is linked into the bundled native library.
+	///
+	/// @return `true` if usable, `false` if setting it throws `UnsupportedOperationException`
+	boolean isSupported() {
+		return switch (this) {
+			case SNAPPY, ZLIB, BZLIB2, XPRESS -> false;
+			case NO_COMPRESSION, LZ4, LZ4HC, ZSTD -> true;
+		};
 	}
 
 	static CompressionType fromValue(int value) {

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
@@ -396,7 +396,11 @@ public final class Options extends NativeObject {
 	///
 	/// @param type the compression algorithm to use
 	/// @return `this` for chaining
+	/// @throws UnsupportedOperationException if `type` isn't linked into the bundled native library
 	public Options setCompression(CompressionType type) {
+		if (!type.isSupported()) {
+			throw new UnsupportedOperationException(type + " compression is not linked into the bundled native library");
+		}
 		try {
 			MH_SET_COMPRESSION.invokeExact(ptr(), type.getValue());
 			return this;
@@ -515,7 +519,11 @@ public final class Options extends NativeObject {
 	///
 	/// @param type the compression algorithm for blob values
 	/// @return `this` for chaining
+	/// @throws UnsupportedOperationException if `type` isn't linked into the bundled native library
 	public Options setBlobCompressionType(CompressionType type) {
+		if (!type.isSupported()) {
+			throw new UnsupportedOperationException(type + " compression is not linked into the bundled native library");
+		}
 		try {
 			MH_SET_BLOB_COMPRESSION_TYPE.invokeExact(ptr(), type.getValue());
 			return this;

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/CompressionTypeTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/CompressionTypeTest.java
@@ -110,24 +110,28 @@ class CompressionTypeTest {
 		assertThat(compressedSize).isLessThan(uncompressedSize / 2);
 	}
 
-	// SNAPPY is force-disabled in the bundled native library (see
-	// scripts/build-rocksdb.sh), so this exercises RocksDB's own
-	// ColumnFamilyData::ValidateOptions -> CheckCompressionSupported check: DB::Open
-	// rejects a compression type that isn't linked into the binary with
-	// Status::InvalidArgument, rather than silently opening and no-op'ing the
-	// compression, so misconfiguration is caught at open time, not discovered later
-	// as an unexplained lack of compression.
-	@Test
-	void openDb_withUnsupportedCompression_throws(@TempDir Path dir) {
-		// Given
-		try (Options opts = Options.newOptions()
-				.setCreateIfMissing(true)
-				.setCompression(CompressionType.SNAPPY)) {
+	// SNAPPY, ZLIB, BZLIB2, and XPRESS are not linked into the bundled native library
+	// (see scripts/build-rocksdb.sh); setCompression/setBlobCompressionType reject them
+	// eagerly rather than letting RocksDB::Open fail later with an opaque native error.
+	@ParameterizedTest
+	@EnumSource(value = CompressionType.class, names = {"SNAPPY", "ZLIB", "BZLIB2", "XPRESS"})
+	void setCompression_withUnsupportedType_throws(CompressionType type) {
+		try (Options opts = Options.newOptions()) {
 
-			// When / Then
-			assertThatThrownBy(() -> RocksDB.openReadWrite(opts, dir))
-					.isInstanceOf(RocksDBException.class)
-					.hasMessageContaining("not linked with the binary");
+			// Given / When / Then
+			assertThatThrownBy(() -> opts.setCompression(type))
+					.isInstanceOf(UnsupportedOperationException.class);
+		}
+	}
+
+	@ParameterizedTest
+	@EnumSource(value = CompressionType.class, names = {"SNAPPY", "ZLIB", "BZLIB2", "XPRESS"})
+	void setBlobCompressionType_withUnsupportedType_throws(CompressionType type) {
+		try (Options opts = Options.newOptions()) {
+
+			// Given / When / Then
+			assertThatThrownBy(() -> opts.setBlobCompressionType(type))
+					.isInstanceOf(UnsupportedOperationException.class);
 		}
 	}
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -338,8 +338,9 @@ Reopening requires listing every existing column family, `default` included — 
 | `BlockBasedTableOptions.IndexType`  | Block-based index layout selection                                                             |
 | `Property`, `TickerType`, `HistogramType`, `PerfMetric` | Large enumerations; see the Javadoc for the full lists                     |
 
-Which compression codecs actually work depends on what the bundled `librocksdb` was linked
-against — selecting an unavailable one surfaces as a `RocksDBException` at open time.
+`SNAPPY`, `ZLIB`, `BZLIB2`, and `XPRESS` aren't linked into the bundled `librocksdb` yet —
+`Options.setCompression`/`setBlobCompressionType` reject them eagerly with
+`UnsupportedOperationException` rather than deferring to a native failure at DB-open time.
 
 ## System properties
 


### PR DESCRIPTION
## Summary
- `Options.setCompression`/`setBlobCompressionType` now reject `SNAPPY`, `ZLIB`, `BZLIB2`, and `XPRESS` eagerly with `UnsupportedOperationException`, instead of silently accepting them and letting `DB::Open` fail later with an opaque native error.
- Replaces the per-constant `TODO: not supported yet` javadoc with a single class-level note plus a package-private `CompressionType#isSupported()`.

## Test plan
- [x] `./mvnw test -Dtest=CompressionTypeTest -pl core -am` — 24 tests pass, including new eager-rejection tests for `setCompression`/`setBlobCompressionType`.
- [x] `./mvnw javadoc:javadoc -pl core` — zero output, no checkstyle violations.

Part of #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)