### PR TITLE
Cover remaining explicit-WriteOptions overloads (#109)

### DIFF
--- a/core/src/test/java/io/github/dfa1/rocksdbffm/MergeOperatorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/MergeOperatorTest.java
@@ -202,6 +202,159 @@ class MergeOperatorTest {
 		}
 	}
 
+	// -----------------------------------------------------------------------
+	// merge() with explicit WriteOptions — same 7 tiers, the WriteOptions-taking overloads
+	// added alongside #109's write-side WriteOptions overloads.
+	// -----------------------------------------------------------------------
+
+	@Test
+	void uint64Add_viaCallerArena_withExplicitWriteOptions_sumsOperands(@TempDir Path dir) throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions()) {
+			db.merge(arena, wo, "views".getBytes(), encodeUint64(1));
+			db.merge(arena, wo, "views".getBytes(), encodeUint64(4));
+
+			// When
+			long total = decodeUint64(db.get("views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(5);
+		}
+	}
+
+	@Test
+	void uint64Add_viaByteBuffer_withExplicitWriteOptions_sumsOperands(@TempDir Path dir) throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir);
+		     var wo = WriteOptions.newWriteOptions()) {
+			ByteBuffer key = ByteBuffer.allocateDirect(5).put("views".getBytes()).flip();
+			db.merge(wo, key.duplicate(), directBuffer(encodeUint64(1)));
+			db.merge(wo, key.duplicate(), directBuffer(encodeUint64(4)));
+
+			// When
+			long total = decodeUint64(db.get("views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(5);
+		}
+	}
+
+	@Test
+	void uint64Add_viaMemorySegment_withExplicitWriteOptions_sumsOperands(@TempDir Path dir) throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions()) {
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "views".getBytes());
+			db.merge(wo, key, arena.allocateFrom(ValueLayout.JAVA_BYTE, encodeUint64(1)));
+			db.merge(wo, key, arena.allocateFrom(ValueLayout.JAVA_BYTE, encodeUint64(4)));
+
+			// When
+			long total = decodeUint64(db.get("views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(5);
+		}
+	}
+
+	@Test
+	void uint64Add_viaCallerArenaMemorySegment_withExplicitWriteOptions_sumsOperands(@TempDir Path dir)
+			throws RocksDBException {
+		// Given
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions()) {
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "views".getBytes());
+			db.merge(arena, wo, key, arena.allocateFrom(ValueLayout.JAVA_BYTE, encodeUint64(1)));
+			db.merge(arena, wo, key, arena.allocateFrom(ValueLayout.JAVA_BYTE, encodeUint64(4)));
+
+			// When
+			long total = decodeUint64(db.get("views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(5);
+		}
+	}
+
+	@Test
+	void uint64Add_columnFamily_bytes_withExplicitWriteOptions_sumsOperands(@TempDir Path dir)
+			throws RocksDBException {
+		// Given — the merge operator is per-column-family, not inherited from the DB-open
+		// Options, so it must also be set on the new CF's own descriptor options.
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir);
+		     var cfOpts = Options.newOptions().setMergeOperator(MergeOperator.uint64Add());
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1", cfOpts));
+		     var wo = WriteOptions.newWriteOptions()) {
+			db.merge(cf, wo, "views".getBytes(), encodeUint64(1));
+			db.merge(cf, wo, "views".getBytes(), encodeUint64(4));
+
+			// When
+			long total = decodeUint64(db.get(cf, "views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(5);
+		}
+	}
+
+	@Test
+	void uint64Add_columnFamily_byteBuffer_withExplicitWriteOptions_sumsOperands(@TempDir Path dir)
+			throws RocksDBException {
+		// Given — the merge operator is per-column-family, not inherited from the DB-open
+		// Options, so it must also be set on the new CF's own descriptor options.
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir);
+		     var cfOpts = Options.newOptions().setMergeOperator(MergeOperator.uint64Add());
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1", cfOpts));
+		     var wo = WriteOptions.newWriteOptions()) {
+			ByteBuffer key = ByteBuffer.allocateDirect(5).put("views".getBytes()).flip();
+			db.merge(cf, wo, key.duplicate(), directBuffer(encodeUint64(1)));
+			db.merge(cf, wo, key.duplicate(), directBuffer(encodeUint64(4)));
+
+			// When
+			long total = decodeUint64(db.get(cf, "views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(5);
+		}
+	}
+
+	@Test
+	void uint64Add_columnFamily_memorySegment_withExplicitWriteOptions_sumsOperands(@TempDir Path dir)
+			throws RocksDBException {
+		// Given — the merge operator is per-column-family, not inherited from the DB-open
+		// Options, so it must also be set on the new CF's own descriptor options.
+		try (var opts = Options.newOptions().setCreateIfMissing(true)
+				.setMergeOperator(MergeOperator.uint64Add());
+		     var db = RocksDB.openReadWrite(opts, dir);
+		     var cfOpts = Options.newOptions().setMergeOperator(MergeOperator.uint64Add());
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1", cfOpts));
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions()) {
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "views".getBytes());
+			db.merge(cf, wo, key, arena.allocateFrom(ValueLayout.JAVA_BYTE, encodeUint64(1)));
+			db.merge(cf, wo, key, arena.allocateFrom(ValueLayout.JAVA_BYTE, encodeUint64(4)));
+
+			// When
+			long total = decodeUint64(db.get(cf, "views".getBytes()));
+
+			// Then
+			assertThat(total).isEqualTo(5);
+		}
+	}
+
 	private static ByteBuffer directBuffer(byte[] bytes) {
 		return (ByteBuffer) ByteBuffer.allocateDirect(bytes.length).put(bytes).flip();
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/WriteOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/WriteOptionsTest.java
@@ -3,6 +3,9 @@ package io.github.dfa1.rocksdbffm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -191,6 +194,130 @@ class WriteOptionsTest {
 	}
 
 	@Test
+	void put_arena_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.put(arena, wo, "k".getBytes(), "v".getBytes());
+
+			// Then
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void put_byteBuffer_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+			ByteBuffer key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+			ByteBuffer value = ByteBuffer.allocateDirect(1).put((byte) 'v').flip();
+
+			// When
+			db.put(wo, key, value);
+
+			// Then
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void put_memorySegment_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+			var value = arena.allocateFrom(ValueLayout.JAVA_BYTE, "v".getBytes());
+
+			// When
+			db.put(wo, key, value);
+
+			// Then
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void put_arenaMemorySegment_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+			var value = arena.allocateFrom(ValueLayout.JAVA_BYTE, "v".getBytes());
+
+			// When
+			db.put(arena, wo, key, value);
+
+			// Then
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void put_cfScoped_byteBuffer_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+			ByteBuffer key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+			ByteBuffer value = ByteBuffer.allocateDirect(1).put((byte) 'v').flip();
+
+			// When
+			db.put(cf, wo, key, value);
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void put_cfScoped_memorySegment_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+			var value = arena.allocateFrom(ValueLayout.JAVA_BYTE, "v".getBytes());
+
+			// When
+			db.put(cf, wo, key, value);
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
 	void merge_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true).setMergeOperator(MergeOperator.uint64Add());
@@ -231,6 +358,114 @@ class WriteOptionsTest {
 	}
 
 	@Test
+	void delete_byteBuffer_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			// Setup write is itself WAL-disabled — see comment in
+			// delete_withExplicitDisableWal_isAbsentFromWal for why.
+			db.put(wo, "k".getBytes(), "v".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+			ByteBuffer key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+
+			// When
+			db.delete(wo, key);
+
+			// Then
+			assertThat(db.get("k".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void delete_memorySegment_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			// Setup write is itself WAL-disabled — see comment in
+			// delete_withExplicitDisableWal_isAbsentFromWal for why.
+			db.put(wo, "k".getBytes(), "v".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+
+			// When
+			db.delete(wo, key);
+
+			// Then
+			assertThat(db.get("k".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void delete_cfScoped_bytes_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			db.put(cf, wo, "k".getBytes(), "v".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.delete(cf, wo, "k".getBytes());
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void delete_cfScoped_byteBuffer_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			db.put(cf, wo, "k".getBytes(), "v".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+			ByteBuffer key = ByteBuffer.allocateDirect(1).put((byte) 'k').flip();
+
+			// When
+			db.delete(cf, wo, key);
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void delete_cfScoped_memorySegment_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			db.put(cf, wo, "k".getBytes(), "v".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+			var key = arena.allocateFrom(ValueLayout.JAVA_BYTE, "k".getBytes());
+
+			// When
+			db.delete(cf, wo, key);
+
+			// Then
+			assertThat(db.get(cf, "k".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
 	void deleteRange_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
 		// Given
 		try (var db = RocksDB.openReadWrite(dir);
@@ -253,6 +488,119 @@ class WriteOptionsTest {
 	}
 
 	@Test
+	void deleteRange_byteBuffer_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			db.put(wo, "a".getBytes(), "1".getBytes());
+			db.put(wo, "b".getBytes(), "2".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+			ByteBuffer startKey = ByteBuffer.allocateDirect(1).put((byte) 'a').flip();
+			ByteBuffer endKey = ByteBuffer.allocateDirect(1).put((byte) 'c').flip();
+
+			// When
+			db.deleteRange(wo, startKey, endKey);
+
+			// Then
+			assertThat(db.get("a".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void deleteRange_memorySegment_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			db.put(wo, "a".getBytes(), "1".getBytes());
+			db.put(wo, "b".getBytes(), "2".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+			var startKey = arena.allocateFrom(ValueLayout.JAVA_BYTE, "a".getBytes());
+			var endKey = arena.allocateFrom(ValueLayout.JAVA_BYTE, "c".getBytes());
+
+			// When
+			db.deleteRange(wo, startKey, endKey);
+
+			// Then
+			assertThat(db.get("a".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void deleteRange_cfScoped_bytes_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			db.put(cf, wo, "a".getBytes(), "1".getBytes());
+			db.put(cf, wo, "b".getBytes(), "2".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.deleteRange(cf, wo, "a".getBytes(), "c".getBytes());
+
+			// Then
+			assertThat(db.get(cf, "a".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void deleteRange_cfScoped_byteBuffer_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			db.put(cf, wo, "a".getBytes(), "1".getBytes());
+			db.put(cf, wo, "b".getBytes(), "2".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+			ByteBuffer startKey = ByteBuffer.allocateDirect(1).put((byte) 'a').flip();
+			ByteBuffer endKey = ByteBuffer.allocateDirect(1).put((byte) 'c').flip();
+
+			// When
+			db.deleteRange(cf, wo, startKey, endKey);
+
+			// Then
+			assertThat(db.get(cf, "a".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void deleteRange_cfScoped_memorySegment_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var cf = db.createColumnFamily(ColumnFamilyDescriptor.of("cf1"));
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true)) {
+			db.put(cf, wo, "a".getBytes(), "1".getBytes());
+			db.put(cf, wo, "b".getBytes(), "2".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+			var startKey = arena.allocateFrom(ValueLayout.JAVA_BYTE, "a".getBytes());
+			var endKey = arena.allocateFrom(ValueLayout.JAVA_BYTE, "c".getBytes());
+
+			// When
+			db.deleteRange(cf, wo, startKey, endKey);
+
+			// Then
+			assertThat(db.get(cf, "a".getBytes())).isNull();
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
 	void write_batch_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
 		// Given
 		try (var db = RocksDB.openReadWrite(dir);
@@ -263,6 +611,27 @@ class WriteOptionsTest {
 
 			// When
 			db.write(wo, batch);
+
+			// Then
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isFalse();
+			}
+		}
+	}
+
+	@Test
+	void write_batch_arena_withExplicitDisableWal_isAbsentFromWal(@TempDir Path dir) {
+		// Given
+		try (var db = RocksDB.openReadWrite(dir);
+		     var arena = Arena.ofConfined();
+		     var wo = WriteOptions.newWriteOptions().setDisableWal(true);
+		     var batch = WriteBatch.create()) {
+			batch.put("k".getBytes(), "v".getBytes());
+			SequenceNumber start = db.getLatestSequenceNumber();
+
+			// When
+			db.write(arena, wo, batch);
 
 			// Then
 			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());


### PR DESCRIPTION
## Summary
- Adds test coverage for the 24 Arena/ByteBuffer/MemorySegment/column-family explicit-`WriteOptions` overloads added in #109 (put/merge/delete/deleteRange/write) that only had the byte[] tier covered.
- 17 tests in `WriteOptionsTest` (WAL-absence proof, matching that file's existing style), 7 `merge()` variants in `MergeOperatorTest` (uint64Add summing, matching that file's existing style).

Motivated by the SonarCloud quality gate failing at 79.0% `new_coverage` (< 80% threshold) after merging #114 — all 73 uncovered new-code lines predated that PR, and 57 of them were exactly these overloads.

## Test plan
- [x] `./mvnw test -pl core -am` — 940 tests pass.
- [x] `./mvnw javadoc:javadoc -pl core` — zero output, no checkstyle violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)