### PR TITLE
Fix 5 SonarCloud blocker findings in OptimisticTransactionDBTest

### DIFF
--- a/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
@@ -893,9 +893,10 @@ class OptimisticTransactionDBTest {
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
 		     var db = RocksDB.openOptimistic(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
+			ThrowingCallable action = () -> db.cancelAllBackgroundWork(false);
 
-			// When / Then — no exception
-			db.cancelAllBackgroundWork(false);
+			// When / Then
+			assertThatCode(action).doesNotThrowAnyException();
 		}
 	}
 
@@ -904,10 +905,13 @@ class OptimisticTransactionDBTest {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
 		     var db = RocksDB.openOptimistic(opts, dir)) {
+			ThrowingCallable action = () -> {
+				db.disableManualCompaction();
+				db.enableManualCompaction();
+			};
 
-			// When / Then — no exception
-			db.disableManualCompaction();
-			db.enableManualCompaction();
+			// When / Then
+			assertThatCode(action).doesNotThrowAnyException();
 		}
 	}
 
@@ -918,9 +922,10 @@ class OptimisticTransactionDBTest {
 		     var db = RocksDB.openOptimistic(opts, dir);
 		     var waitOpts = WaitForCompactOptions.create()) {
 			db.put("k".getBytes(), "v".getBytes());
+			ThrowingCallable action = () -> db.waitForCompact(waitOpts);
 
-			// When / Then — no exception
-			db.waitForCompact(waitOpts);
+			// When / Then
+			assertThatCode(action).doesNotThrowAnyException();
 		}
 	}
 
@@ -970,10 +975,13 @@ class OptimisticTransactionDBTest {
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
 		     var db = RocksDB.openOptimistic(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
+			ThrowingCallable action = () -> {
+				db.disableFileDeletions();
+				db.enableFileDeletions();
+			};
 
-			// When / Then — no exception
-			db.disableFileDeletions();
-			db.enableFileDeletions();
+			// When / Then
+			assertThatCode(action).doesNotThrowAnyException();
 		}
 	}
 
@@ -983,9 +991,10 @@ class OptimisticTransactionDBTest {
 		try (var opts = Options.newOptions().setCreateIfMissing(true);
 		     var db = RocksDB.openOptimistic(opts, dir)) {
 			db.put("k".getBytes(), "v".getBytes());
+			ThrowingCallable action = db::compactRange;
 
-			// When / Then — no exception
-			db.compactRange();
+			// When / Then
+			assertThatCode(action).doesNotThrowAnyException();
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixes SonarCloud's S2699 ("Add at least one assertion to this test case") blocker findings at lines 891, 903, 915, 968, 981 of `OptimisticTransactionDBTest.java`.
- These 5 `*_doesNotThrow` tests called the operation under test with no assertion at all. Wrapped each in `assertThatCode(action).doesNotThrowAnyException()`, matching the existing pattern already used for the same operations in `CompactionControlTest`, `BlobDBTest`, and `BackupEngineTest`.

## Test plan
- [x] `./mvnw test -Dtest=OptimisticTransactionDBTest -pl core -am` — 57 tests pass.
- [x] Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)