### PR TITLE
fix: address SonarCloud new-code findings from #124/#125

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/LiveFilesStorageInfo.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/LiveFilesStorageInfo.java
@@ -68,8 +68,8 @@ public final class LiveFilesStorageInfo extends NativeObject implements Iterable
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment listPtr = (MemorySegment) MH_GET.invokeExact(dbPtr, optionsPtr, err);
 			RocksDB.checkError(err);
-			int count = (int) (long) MH_COUNT.invokeExact(listPtr);
-			return new LiveFilesStorageInfo(listPtr, count);
+			long count = (long) MH_COUNT.invokeExact(listPtr);
+			return new LiveFilesStorageInfo(listPtr, (int) count);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("getLiveFilesStorageInfo failed", t);
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/LiveFileInfoTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/LiveFileInfoTest.java
@@ -56,9 +56,10 @@ class LiveFileInfoTest {
 			db.flush(fo);
 
 			try (var files = db.getLiveFiles()) {
+				int size = files.size();
 
 				// When / Then
-				assertThatThrownBy(() -> files.get(files.size())).isInstanceOf(IndexOutOfBoundsException.class);
+				assertThatThrownBy(() -> files.get(size)).isInstanceOf(IndexOutOfBoundsException.class);
 			}
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/LiveFileStorageInfoTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/LiveFileStorageInfoTest.java
@@ -113,8 +113,8 @@ class LiveFileStorageInfoTest {
 				// this snapshot are captured directly rather than read back off disk later
 				assertThat(currentFile.relativeFilename()).isEqualTo("CURRENT");
 				assertThat(currentFile.fileNumber()).isZero();
-				assertThat(currentFile.replacementContents()).isNotEmpty();
-				assertThat(currentFile.replacementContents().length).isEqualTo((int) currentFile.size().toBytes());
+				assertThat(currentFile.replacementContents()).isNotEmpty()
+						.hasSize((int) currentFile.size().toBytes());
 			}
 		}
 	}
@@ -160,9 +160,10 @@ class LiveFileStorageInfoTest {
 		// Given
 		try (var db = RocksDB.openReadWrite(dir);
 		     var info = db.getLiveFilesStorageInfo()) {
+			int size = info.size();
 
 			// When / Then
-			assertThatThrownBy(() -> info.get(info.size())).isInstanceOf(IndexOutOfBoundsException.class);
+			assertThatThrownBy(() -> info.get(size)).isInstanceOf(IndexOutOfBoundsException.class);
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SstPartitionerFactoryTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SstPartitionerFactoryTest.java
@@ -35,7 +35,7 @@ class SstPartitionerFactoryTest {
 		var factory = SstPartitionerFactory.newFixedPrefix(4);
 
 		// When
-		try (var opts = Options.newOptions().setSstPartitionerFactory(factory)) {
+		try (var _ = Options.newOptions().setSstPartitionerFactory(factory)) {
 
 			// Then — no ownership transfer: factory.ptr() stays valid while opts is still open
 			assertThatCode(factory::ptr).doesNotThrowAnyException();


### PR DESCRIPTION
## Summary

Ran a fresh SonarCloud analysis after #124/#125 landed (quality gate: **OK**, all conditions pass — reliability/security/maintainability ratings, 85.3% new coverage, 0% duplication). Of the ~84 open new-code findings, 5 were actually in my own changes; the rest are pre-existing in files this work never touched (`MergeOperator`, `Transaction`, `WriteBatch`, etc.) and are out of scope here.

- `LiveFilesStorageInfo.fetch()`: split the combined `(int)(long)` cast into two statements.
- `LiveFileStorageInfoTest`/`LiveFileInfoTest`: hoisted `size()` out of `assertThatThrownBy` lambdas that also called `get()` — Sonar wants at most one call that can throw per lambda.
- `LiveFileStorageInfoTest`: replaced `.length` + `isEqualTo` with AssertJ's `hasSize()`.
- `SstPartitionerFactoryTest`: renamed the unused try-with-resources `opts` binding to `_`, matching the existing convention elsewhere (e.g. `PropertyTest`'s `Snapshot _`).

## Test plan

- [x] `./mvnw test` — full suite green
- [x] `./mvnw javadoc:javadoc -pl core` — zero output

🤖 Generated with [Claude Code](https://claude.com/claude-code)