### PR TITLE
refactor: return nullable R instead of Optional<R> from zero-copy get(Mapper)

### DIFF
--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmBenchmark.java
@@ -231,7 +231,7 @@ public class FfmBenchmark {
 	@Benchmark
 	public Instant readsInstantViaPinned() {
 		return db.get(instantKeyMemorySegment,
-				value -> Instant.ofEpochSecond(value.get(ValueLayout.JAVA_LONG, 0))).orElseThrow();
+				value -> Instant.ofEpochSecond(value.get(ValueLayout.JAVA_LONG, 0)));
 	}
 
 	// ---- batch (byte[] keys, same as JNI) ---------------------------------

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmScaleBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmScaleBenchmark.java
@@ -112,7 +112,7 @@ public class FfmScaleBenchmark {
 
 	@Benchmark
 	public long getZeroCopy() {
-		return db.get(lookupKeySegment, MemorySegment::byteSize).orElseThrow();
+		return db.get(lookupKeySegment, MemorySegment::byteSize);
 	}
 
 	// ---- iteration ------------------------------------------------------------

--- a/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmValueSizeBenchmark.java
+++ b/benchmarks/src/test/java/io/github/dfa1/rocksdbffm/benchmark/FfmValueSizeBenchmark.java
@@ -146,7 +146,7 @@ public class FfmValueSizeBenchmark {
 
 	@Benchmark
 	public long readsValueViaPinned() {
-		return db.get(lookupKeyMemorySegment, MemorySegment::byteSize).orElseThrow();
+		return db.get(lookupKeyMemorySegment, MemorySegment::byteSize);
 	}
 
 	/// Runs this class with [GCProfiler] attached. `-Djmh.forks=<n>` overrides the `@Fork`

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -795,16 +795,16 @@ public final class RocksDB {
 
 	/// Scoped zero-copy get via `rocksdb_get_pinned_v2`. [PinnableHandle] owns the pinned
 	/// value's lifetime and every way it gets consumed.
-	static <R> Optional<R> withPinned(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, Mapper<R> fn) {
+	static <R> R withPinned(RocksDBReadOperations db, ReadOptions readOpts, MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment handle = (MemorySegment) MH_GET_PINNED_V2.invokeExact(db.dbPtr(), readOpts.ptr(), key, key.byteSize(), err);
 			checkError(err);
 			if (MemorySegment.NULL.equals(handle)) {
-				return Optional.empty();
+				return null;
 			}
 			try (PinnableHandle ph = PinnableHandle.wrap(handle)) {
-				return Optional.of(ph.map(arena, fn, err));
+				return ph.map(arena, fn, err);
 			}
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("get_pinned failed", t);
@@ -813,18 +813,18 @@ public final class RocksDB {
 
 	/// Scoped zero-copy get from `cf` via `rocksdb_get_pinned_cf_v2`. See [#withPinned]
 	/// for the lifetime contract.
-	static <R> Optional<R> withPinnedCf(RocksDBReadOperations db, ReadOptions readOpts, ColumnFamilyHandle cf,
-	                                     MemorySegment key, Mapper<R> fn) {
+	static <R> R withPinnedCf(RocksDBReadOperations db, ReadOptions readOpts, ColumnFamilyHandle cf,
+	                           MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = errHolder(arena);
 			MemorySegment handle = (MemorySegment) MH_GET_PINNED_CF_V2.invokeExact(
 					db.dbPtr(), readOpts.ptr(), cf.ptr(), key, key.byteSize(), err);
 			checkError(err);
 			if (MemorySegment.NULL.equals(handle)) {
-				return Optional.empty();
+				return null;
 			}
 			try (PinnableHandle ph = PinnableHandle.wrap(handle)) {
-				return Optional.of(ph.map(arena, fn, err));
+				return ph.map(arena, fn, err);
 			}
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("get_pinned failed", t);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDBReadOperations.java
@@ -111,8 +111,8 @@ public interface RocksDBReadOperations {
 	/// @param key native segment containing the key
 	/// @param fn  callback invoked with a zero-copy view of the pinned value
 	/// @throws NullPointerException if `fn` returns `null`
-	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
-	default <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+	/// @return the result of `fn`, or `null` if `key` is absent
+	default <R> R get(MemorySegment key, Mapper<R> fn) {
 		return RocksDB.withPinned(this, RocksDB.DEFAULT_READ_OPTIONS, key, fn);
 	}
 
@@ -123,8 +123,8 @@ public interface RocksDBReadOperations {
 	/// @param key         native segment containing the key
 	/// @param fn          callback invoked with a zero-copy view of the pinned value
 	/// @throws NullPointerException if `fn` returns `null`
-	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
-	default <R> Optional<R> get(ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
+	/// @return the result of `fn`, or `null` if `key` is absent
+	default <R> R get(ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
 		return RocksDB.withPinned(this, readOptions, key, fn);
 	}
 
@@ -205,8 +205,8 @@ public interface RocksDBReadOperations {
 	/// @param key native segment containing the key
 	/// @param fn  callback invoked with a zero-copy view of the pinned value
 	/// @throws NullPointerException if `fn` returns `null`
-	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
-	default <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
+	/// @return the result of `fn`, or `null` if `key` is absent
+	default <R> R get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
 		return RocksDB.withPinnedCf(this, RocksDB.DEFAULT_READ_OPTIONS, cf, key, fn);
 	}
 
@@ -218,8 +218,8 @@ public interface RocksDBReadOperations {
 	/// @param key         native segment containing the key
 	/// @param fn          callback invoked with a zero-copy view of the pinned value
 	/// @throws NullPointerException if `fn` returns `null`
-	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
-	default <R> Optional<R> get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
+	/// @return the result of `fn`, or `null` if `key` is absent
+	default <R> R get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
 		return RocksDB.withPinnedCf(this, readOptions, cf, key, fn);
 	}
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Transaction.java
@@ -6,7 +6,6 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
 /// FFM wrapper for `rocksdb_transaction_t`.
 ///
@@ -388,8 +387,8 @@ public final class Transaction extends NativeObject {
 	/// @param key         native segment containing the key
 	/// @param fn          callback invoked with a zero-copy view of the pinned value
 	/// @throws NullPointerException if `fn` returns `null`
-	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
-	public <R> Optional<R> get(ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
+	/// @return the result of `fn`, or `null` if `key` is absent
+	public <R> R get(ReadOptions readOptions, MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment pin;
@@ -400,10 +399,10 @@ public final class Transaction extends NativeObject {
 			}
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(pin)) {
-				return Optional.empty();
+				return null;
 			}
 			try (PinnableSlice slice = PinnableSlice.wrap(pin)) {
-				return Optional.of(slice.map(arena, fn, err));
+				return slice.map(arena, fn, err);
 			}
 		}
 	}
@@ -721,9 +720,9 @@ public final class Transaction extends NativeObject {
 	/// @param key         native segment containing the key
 	/// @param fn          callback invoked with a zero-copy view of the pinned value
 	/// @throws NullPointerException if `fn` returns `null`
-	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
-	public <R> Optional<R> get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key,
-	                            Mapper<R> fn) {
+	/// @return the result of `fn`, or `null` if `key` is absent
+	public <R> R get(ColumnFamilyHandle cf, ReadOptions readOptions, MemorySegment key,
+	                  Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment pin;
@@ -735,10 +734,10 @@ public final class Transaction extends NativeObject {
 			}
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(pin)) {
-				return Optional.empty();
+				return null;
 			}
 			try (PinnableSlice slice = PinnableSlice.wrap(pin)) {
-				return Optional.of(slice.map(arena, fn, err));
+				return slice.map(arena, fn, err);
 			}
 		}
 	}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -530,8 +530,8 @@ public final class TransactionDB extends NativeObjectWithBaseDb implements Monit
 	/// @param key native segment containing the key
 	/// @param fn  callback invoked with a zero-copy view of the pinned value
 	/// @throws NullPointerException if `fn` returns `null`
-	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
-	public <R> Optional<R> get(MemorySegment key, Mapper<R> fn) {
+	/// @return the result of `fn`, or `null` if `key` is absent
+	public <R> R get(MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment pin;
@@ -542,10 +542,10 @@ public final class TransactionDB extends NativeObjectWithBaseDb implements Monit
 			}
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(pin)) {
-				return Optional.empty();
+				return null;
 			}
 			try (PinnableSlice slice = PinnableSlice.wrap(pin)) {
-				return Optional.of(slice.map(arena, fn, err));
+				return slice.map(arena, fn, err);
 			}
 		}
 	}
@@ -958,8 +958,8 @@ public final class TransactionDB extends NativeObjectWithBaseDb implements Monit
 	/// @param key native segment containing the key
 	/// @param fn  callback invoked with a zero-copy view of the pinned value
 	/// @throws NullPointerException if `fn` returns `null`
-	/// @return the result of `fn`, wrapped in [Optional], or [Optional#empty()] if `key` is absent
-	public <R> Optional<R> get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
+	/// @return the result of `fn`, or `null` if `key` is absent
+	public <R> R get(ColumnFamilyHandle cf, MemorySegment key, Mapper<R> fn) {
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment err = RocksDB.errHolder(arena);
 			MemorySegment pin;
@@ -970,10 +970,10 @@ public final class TransactionDB extends NativeObjectWithBaseDb implements Monit
 			}
 			RocksDB.checkError(err);
 			if (MemorySegment.NULL.equals(pin)) {
-				return Optional.empty();
+				return null;
 			}
 			try (PinnableSlice slice = PinnableSlice.wrap(pin)) {
-				return Optional.of(slice.map(arena, fn, err));
+				return slice.map(arena, fn, err);
 			}
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BlobDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BlobDBTest.java
@@ -461,7 +461,7 @@ class BlobDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("v".getBytes());
+			assertThat(result).isEqualTo("v".getBytes());
 		}
 	}
 
@@ -476,7 +476,7 @@ class BlobDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isEmpty();
+			assertThat(result).isNull();
 		}
 	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/OptimisticTransactionDBTest.java
@@ -775,7 +775,7 @@ class OptimisticTransactionDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("v".getBytes());
+			assertThat(result).isEqualTo("v".getBytes());
 		}
 	}
 
@@ -791,7 +791,7 @@ class OptimisticTransactionDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isEmpty();
+			assertThat(result).isNull();
 		}
 	}
 
@@ -809,7 +809,7 @@ class OptimisticTransactionDBTest {
 			var result = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("v".getBytes());
+			assertThat(result).isEqualTo("v".getBytes());
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/PinnedGetTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/PinnedGetTest.java
@@ -33,7 +33,7 @@ class PinnedGetTest {
 				var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then
-				assertThat(result).contains("v".getBytes());
+				assertThat(result).isEqualTo("v".getBytes());
 			}
 		}
 	}
@@ -49,7 +49,7 @@ class PinnedGetTest {
 				var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then
-				assertThat(result).isEmpty();
+				assertThat(result).isNull();
 			}
 		}
 	}
@@ -67,7 +67,7 @@ class PinnedGetTest {
 				var result = db.get(key, MemorySegment::byteSize);
 
 				// Then
-				assertThat(result).contains(0L);
+				assertThat(result).isEqualTo(0L);
 			}
 		}
 	}
@@ -172,7 +172,7 @@ class PinnedGetTest {
 				// And a later, independent call still succeeds — proving the handle and
 				// arena from the failed call were destroyed/closed rather than leaked
 				var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
-				assertThat(result).contains("v".getBytes());
+				assertThat(result).isEqualTo("v".getBytes());
 			}
 		}
 	}
@@ -194,7 +194,7 @@ class PinnedGetTest {
 				// or exhaust memory; reaching the end without error is the signal.
 				for (int i = 0; i < 50_000; i++) {
 					var result = db.get(key, value -> value.get(ValueLayout.JAVA_BYTE, 0));
-					assertThat(result).contains((byte) 'v');
+					assertThat(result).isEqualTo((byte) 'v');
 				}
 			}
 		}
@@ -218,7 +218,7 @@ class PinnedGetTest {
 				var result = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then
-				assertThat(result).contains("v".getBytes());
+				assertThat(result).isEqualTo("v".getBytes());
 			}
 		}
 	}
@@ -236,7 +236,7 @@ class PinnedGetTest {
 				var result = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then
-				assertThat(result).isEmpty();
+				assertThat(result).isNull();
 			}
 		}
 	}
@@ -256,8 +256,8 @@ class PinnedGetTest {
 				var viaCf = db.get(cf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then
-				assertThat(viaDefault).isEmpty();
-				assertThat(viaCf).isPresent();
+				assertThat(viaDefault).isNull();
+				assertThat(viaCf).isNotNull();
 			}
 		}
 	}
@@ -284,9 +284,9 @@ class PinnedGetTest {
 				var viaDefaultCf = db.get(defaultCf, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then
-				assertThat(viaPlain).isPresent();
-				assertThat(viaDefaultCf).isPresent();
-				assertThat(viaPlain.get()).isEqualTo(viaDefaultCf.get()).isEqualTo("v".getBytes());
+				assertThat(viaPlain).isNotNull();
+				assertThat(viaDefaultCf).isNotNull();
+				assertThat(viaPlain).isEqualTo(viaDefaultCf).isEqualTo("v".getBytes());
 			}
 
 			defaultCf.close();

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/ReadOnlyDBTest.java
@@ -183,7 +183,7 @@ class ReadOnlyDBTest {
 			var result = ro.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("value".getBytes());
+			assertThat(result).isEqualTo("value".getBytes());
 		}
 	}
 
@@ -202,7 +202,7 @@ class ReadOnlyDBTest {
 			var result = ro.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isEmpty();
+			assertThat(result).isNull();
 		}
 	}
 
@@ -226,7 +226,7 @@ class ReadOnlyDBTest {
 			var result = ro.get(cf1, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("value".getBytes());
+			assertThat(result).isEqualTo("value".getBytes());
 
 			handles.forEach(ColumnFamilyHandle::close);
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SecondaryDBTest.java
@@ -304,7 +304,7 @@ class SecondaryDBTest {
 			var result = secondary.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("v".getBytes());
+			assertThat(result).isEqualTo("v".getBytes());
 		}
 	}
 
@@ -325,7 +325,7 @@ class SecondaryDBTest {
 			var result = secondary.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isEmpty();
+			assertThat(result).isNull();
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SnapshotTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SnapshotTest.java
@@ -217,7 +217,7 @@ class SnapshotTest {
 				var result = db.get(ro, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 				// Then — snapshot read sees the pre-write value
-				assertThat(result).contains("before".getBytes());
+				assertThat(result).isEqualTo("before".getBytes());
 			}
 		}
 	}
@@ -257,7 +257,7 @@ class SnapshotTest {
 				assertThat(segmentOut.asSlice(0, "before".getBytes().length).toArray(ValueLayout.JAVA_BYTE))
 						.isEqualTo("before".getBytes());
 
-				assertThat(mapperResult).contains("before".getBytes());
+				assertThat(mapperResult).isEqualTo("before".getBytes());
 			}
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TransactionDBTest.java
@@ -120,7 +120,7 @@ class TransactionDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("v".getBytes());
+			assertThat(result).isEqualTo("v".getBytes());
 		}
 	}
 
@@ -135,7 +135,7 @@ class TransactionDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isEmpty();
+			assertThat(result).isNull();
 		}
 	}
 
@@ -154,7 +154,7 @@ class TransactionDBTest {
 			var result = txn.get(ro, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("v".getBytes());
+			assertThat(result).isEqualTo("v".getBytes());
 			txn.commit();
 		}
 	}
@@ -173,7 +173,7 @@ class TransactionDBTest {
 			var result = txn.get(ro, key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isEmpty();
+			assertThat(result).isNull();
 			txn.rollback();
 		}
 	}
@@ -816,7 +816,7 @@ class TransactionDBTest {
 			var result = db.get(cf, key.asSlice(0, 7), value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isEmpty();
+			assertThat(result).isNull();
 			handles.forEach(ColumnFamilyHandle::close);
 		}
 	}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TtlDBTest.java
@@ -1118,7 +1118,7 @@ class TtlDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).contains("v".getBytes());
+			assertThat(result).isEqualTo("v".getBytes());
 		}
 	}
 
@@ -1133,7 +1133,7 @@ class TtlDBTest {
 			var result = db.get(key, value -> value.toArray(ValueLayout.JAVA_BYTE));
 
 			// Then
-			assertThat(result).isEmpty();
+			assertThat(result).isNull();
 		}
 	}
 }

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -171,9 +171,11 @@ be structurally impossible for a correctly configured native call becomes an `As
 [ADR-0004](adr/0004-error-handling.md) for the full reasoning — this split exists so that
 `catch (RocksDBException e)` is always meaningful, never a library bug wearing a "real error" costume.
 
-`null` survives in exactly one place: `byte[] get(byte[])` returns `null` for a missing key, because
-a miss is a normal outcome on the hot read path and boxing it in an `Optional` would allocate on
-every read. The buffer and segment tiers do better — they return a sealed `CopyResult`, so "the key
+`null` survives as a return value on the tiers where a miss is a normal outcome on the hot read path
+and boxing it in an `Optional` would allocate on every read: `byte[] get(byte[])` returns `null` for
+a missing key, and `get(key, Mapper<R>)` returns a `null` `R` for the same reason — there's no
+destination buffer to be too small for, so "present, mapped to a result" and "absent" are the only
+two outcomes. The buffer and segment tiers do better — they return a sealed `CopyResult`, so "the key
 is absent" and "the value did not fit in your buffer" are different cases the compiler makes you
 handle:
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -70,15 +70,15 @@ try (Arena arena = Arena.ofConfined()) {
 // straight into RocksDB's own pinned memory; nothing is copied.
 try (Arena arena = Arena.ofConfined()) {
 	MemorySegment k = arena.allocateFrom("k");
-	Optional<Integer> len = db.get(k, value -> (int) value.byteSize());
+	Integer len = db.get(k, value -> (int) value.byteSize());
 }
 ```
 
 The `byte[]` `get` returns `null` when the key is absent. The buffer/segment tiers return a
 [`CopyResult`](reference.md#domain-types) instead, which distinguishes "missing" from "present but
 your destination is too small" — a distinction the old `int` return could not make. `get(key, Mapper)`
-returns an `Optional<R>` instead — there's no destination to be too small for, so the only two
-outcomes are "present, mapped to a result" and "absent." See
+returns `R` directly, nullable, like the `byte[]` tier — wrapping it in `Optional` would allocate a
+box on every present result, defeating the point of a zero-copy path. See
 [explanation.md#three-access-tiers](explanation.md#three-access-tiers) for why `byte[]`/`ByteBuffer`/
 `MemorySegment` exist as three separate tiers, and for the zero-copy `Mapper` path layered on top of
 the `MemorySegment` tier.


### PR DESCRIPTION
## Summary
- `get(key, Mapper<R>)` and its `ColumnFamilyHandle`/`ReadOptions` overloads (`RocksDBReadOperations`, `RocksDB.withPinned`/`withPinnedCf`, `TransactionDB`, `Transaction`) now return `R` directly instead of `Optional<R>`, with `null` meaning "key not found"
- `Optional<R>` allocates a box on every present result, defeating the point of a zero-copy read path; this now matches the existing `byte[] get(key)` convention (`null` = absent) already used by every other tier
- `getProperty`/`getLongProperty` are untouched — still `Optional<String>`/`OptionalLong`, since they're not a hot read path

## Test plan
- [x] `./mvnw test` — 974/974 pass
- [x] `./mvnw javadoc:javadoc -pl core` — zero output (clean)
- [x] `./mvnw test-compile` (root, includes `benchmarks` module) — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)