### PR TITLE
refactor: make RocksDB's internal FFM plumbing package-private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SNAPPY`, `ZLIB`, `BZLIB2`, `XPRESS` — not linked into the bundled native library yet — instead
   of failing opaquely at DB-open time. ([#114](https://github.com/dfa1/rocksdbffm/pull/114),
   part of [#83](https://github.com/dfa1/rocksdbffm/issues/83))
+- **Breaking:** the scoped zero-copy `get(key, Mapper<R>)` (and its `ColumnFamilyHandle`/
+  `ReadOptions` overloads, across `RocksDBReadOperations`, `TransactionDB`, `Transaction`) now
+  returns `R` directly instead of `Optional<R>`, with `null` meaning "key not found" — matching
+  the existing `byte[] get(key)` convention. `Optional` boxed a result on every present read,
+  defeating the point of a zero-copy path. ([#130](https://github.com/dfa1/rocksdbffm/pull/130))
+- **Breaking:** `RocksDB.errHolder`, `toNative`, `free`, `checkError`, `toByteArray`,
+  `toBorrowedJavaString`, `toJavaString`, `toOptionalString`, `toByte`, `fromByte` are now
+  package-private. They're internal FFM plumbing consumed only by other wrapper classes in this
+  library, never meant for callers — being `public` just meant they cluttered `RocksDB`'s javadoc
+  page alongside the `open*`/`listColumnFamilies` factories users actually want.
+  ([#132](https://github.com/dfa1/rocksdbffm/pull/132), part of
+  [#131](https://github.com/dfa1/rocksdbffm/issues/131))
 
 ## [0.9] — 2026-08-21
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1860,7 +1860,7 @@ public final class RocksDB {
 	///
 	/// @param arena arena to allocate the holder from
 	/// @return a zeroed `char**` segment suitable for RocksDB error-out parameters
-	public static MemorySegment errHolder(Arena arena) {
+	static MemorySegment errHolder(Arena arena) {
 		MemorySegment holder = arena.allocate(ValueLayout.ADDRESS);
 		holder.set(ValueLayout.ADDRESS, 0, MemorySegment.NULL);
 		return holder;
@@ -1872,7 +1872,7 @@ public final class RocksDB {
 	/// @param arena arena to allocate the segment from
 	/// @param bytes source bytes to copy
 	/// @return native segment containing a copy of `bytes`
-	public static MemorySegment toNative(Arena arena, byte[] bytes) {
+	static MemorySegment toNative(Arena arena, byte[] bytes) {
 		MemorySegment seg = arena.allocate(bytes.length);
 		// TODO: check if this is better seg.copyFrom(MemorySegment.ofArray(bytes));
 		MemorySegment.copy(bytes, 0, seg, ValueLayout.JAVA_BYTE, 0, bytes.length);
@@ -1882,7 +1882,7 @@ public final class RocksDB {
 	/// Frees a malloc'd pointer returned by the RocksDB C API.
 	///
 	/// @param ptr pointer to free; must have been allocated by RocksDB
-	public static void free(MemorySegment ptr) {
+	static void free(MemorySegment ptr) {
 		try {
 			MH_FREE.invokeExact(ptr);
 		} catch (Throwable ignored) {
@@ -1894,7 +1894,7 @@ public final class RocksDB {
 	/// If so, throws a [RocksDBException] and frees the C string.
 	///
 	/// @param errHolder the `char**` segment previously passed to a RocksDB C call
-	public static void checkError(MemorySegment errHolder) {
+	static void checkError(MemorySegment errHolder) {
 		MemorySegment errPtr = errHolder.get(ValueLayout.ADDRESS, 0);
 		if (!MemorySegment.NULL.equals(errPtr)) {
 			String msg = toJavaString(errPtr);
@@ -1942,7 +1942,7 @@ public final class RocksDB {
 	/// @param ptr non-NULL native pointer to a borrowed buffer
 	/// @param len number of bytes to copy
 	/// @return a new array containing a copy of the bytes
-	public static byte[] toByteArray(MemorySegment ptr, long len) {
+	static byte[] toByteArray(MemorySegment ptr, long len) {
 		return ptr.reinterpret(len).toArray(ValueLayout.JAVA_BYTE);
 	}
 
@@ -1953,7 +1953,7 @@ public final class RocksDB {
 	///
 	/// @param ptr non-NULL native pointer to a borrowed, NUL-terminated string
 	/// @return the decoded string
-	public static String toBorrowedJavaString(MemorySegment ptr) {
+	static String toBorrowedJavaString(MemorySegment ptr) {
 		return ptr.reinterpret(Long.MAX_VALUE).getString(0);
 	}
 
@@ -1962,7 +1962,7 @@ public final class RocksDB {
 	///
 	/// @param ptr non-NULL `char*` allocated by RocksDB
 	/// @return the decoded string
-	public static String toJavaString(MemorySegment ptr) {
+	static String toJavaString(MemorySegment ptr) {
 		String s = ptr.reinterpret(Long.MAX_VALUE).getString(0);
 		free(ptr);
 		return s;
@@ -1972,7 +1972,7 @@ public final class RocksDB {
 	///
 	/// @param ptr `char*` allocated by RocksDB, or `MemorySegment.NULL`
 	/// @return the decoded string, or [Optional#empty()] if `ptr` is NULL
-	public static Optional<String> toOptionalString(MemorySegment ptr) {
+	static Optional<String> toOptionalString(MemorySegment ptr) {
 		if (MemorySegment.NULL.equals(ptr)) {
 			return Optional.empty();
 		}
@@ -1983,7 +1983,7 @@ public final class RocksDB {
 	///
 	/// @param value the boolean to convert
 	/// @return `(byte) 1` if `value` is `true`, `(byte) 0` otherwise
-	public static byte toByte(boolean value) {
+	static byte toByte(boolean value) {
 		return value ? (byte) 1 : (byte) 0;
 	}
 
@@ -1991,7 +1991,7 @@ public final class RocksDB {
 	///
 	/// @param value the native byte to convert
 	/// @return `false` if `value` is `0`, `true` otherwise
-	public static boolean fromByte(byte value) {
+	static boolean fromByte(byte value) {
 		return value != 0;
 	}
 }


### PR DESCRIPTION
## Summary
- First step of #131: `errHolder`, `toNative`, `free`, `checkError`, `toByteArray`, `toBorrowedJavaString`, `toJavaString`, `toOptionalString`, `toByte`, `fromByte` on `RocksDB` drop `public` -> package-private
- These are internal FFM plumbing consumed only by other wrapper classes in `io.github.dfa1.rocksdbffm`, never by library users -- being `public` meant they showed up on `RocksDB`'s public javadoc page mixed in with the `open*`/`listColumnFamilies` factories users actually want
- Confirmed no usages outside the package (`integration-tests`, `benchmarks`, `.github/smoke` all clean)
- `wrapInvokeFailure` was already package-private, untouched

## Test plan
- [x] `./mvnw test` -- 974/974 pass
- [x] `./mvnw javadoc:javadoc -pl core` -- zero output (clean)
- [x] `./mvnw test-compile` (root, all modules incl. `integration-tests`/`benchmarks`) -- compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)