### PR TITLE
fix: don't assert-false inside Logger's upcall dispatch

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Logger.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Logger.java
@@ -34,6 +34,8 @@ import java.nio.charset.StandardCharsets;
 /// ```
 public final class Logger extends NativeObject {
 
+	private static final System.Logger LOG = System.getLogger(Logger.class.getName());
+
 	/// Receives a log message from RocksDB. Must not throw.
 	@FunctionalInterface
 	public interface LogCallback {
@@ -163,8 +165,10 @@ public final class Logger extends NativeObject {
 			}
 			cb.log(level, message);
 		} catch (Throwable throwable) {
-			// exceptions must not escape into native code, but they must be shown to the user somehow
-			assert false; // fail at least the build
+			// must not throw across the upcall boundary — an escaping AssertionError here
+			// (assertions are on by default under Surefire) would abort the JVM, not just
+			// this call, so report failure via System.Logger instead of asserting.
+			LOG.log(System.Logger.Level.ERROR, "LogCallback threw", throwable);
 		}
 	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/LoggerTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/LoggerTest.java
@@ -51,6 +51,25 @@ class LoggerTest {
 	}
 
 	@Test
+	void callbackLogger_throwingCallback_doesNotCrashJvm(@TempDir Path dir) {
+		// Given — a callback that violates its "must not throw" contract
+		try (var logger = Logger.newCallbackLogger(LogLevel.INFO, (level, msg) -> {
+			throw new RuntimeException("boom from user callback");
+		});
+		     var opts = Options.newOptions().setCreateIfMissing(true).setInfoLog(logger);
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+
+			// When — opening the DB and writing triggers internal log events, which
+			// invoke the throwing callback from the native upcall dispatch
+			db.put("k".getBytes(), "v".getBytes());
+
+			// Then — reaching this line means the exception was swallowed inside the
+			// upcall dispatch rather than escaping into native code and aborting the JVM
+			assertThat(db.get("k".getBytes())).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
 	void setInfoLogLevel_roundTrips() {
 		// Given / When / Then
 		try (var opts = Options.newOptions()) {


### PR DESCRIPTION
## Summary
- `Logger.dispatch`'s catch-all fell back to `assert false`, which — under assertions enabled (Maven Surefire's own default) — throws `AssertionError` from inside the native→Java upcall handler when a `LogCallback` throws
- That exception escapes across the FFM upcall boundary; HotSpot responds by force-terminating the JVM with no catchable exception, no diagnostic a caller can intercept
- `MergeOperator.Custom.fullMergeDispatch` already dodges this exact trap (see its own comment) by logging via `System.Logger` instead of asserting — `Logger.dispatch` now does the same

## Repro (pre-fix)
```
java.lang.AssertionError
	at io.github.dfa1.rocksdbffm.Logger.dispatch(Logger.java:167)
	at io.github.dfa1.rocksdbffm.RocksDB.openReadWrite(RocksDB.java:471)
Unrecoverable uncaught exception encountered. The VM will now exit
```

Fixes #139

## Test plan
- [x] Added `LoggerTest.callbackLogger_throwingCallback_doesNotCrashJvm` — a throwing `LogCallback` wired through `Options.setInfoLog`, opening a DB and doing a `put`/`get`; passes under Surefire's default assertions-enabled mode
- [x] `./mvnw -pl core -am test` — full core suite green, no regressions
- [x] `./mvnw javadoc:javadoc -pl core` — zero output