### PR TITLE
fix: register RocksIterator as a child of its owning DB

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1812,7 +1812,8 @@ public final class RocksDB {
 		try {
 			MemorySegment iterPtr = (MemorySegment) MH_CREATE_ITERATOR_CF.invokeExact(
 					db.dbPtr(), readOpts.ptr(), cf.ptr());
-			return RocksIterator.create(iterPtr);
+			// Every implementor extends NativeObjectWithChildren (see RocksDBReadOperations#getSnapshot()).
+			return RocksIterator.create((NativeObjectWithChildren) db, iterPtr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("newIterator failed", t);
 		}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksIterator.java
@@ -11,7 +11,12 @@ import java.util.Optional;
 
 /// FFM wrapper for `rocksdb_iterator_t`.
 ///
-/// Always close after use.
+/// Always close after use. Closing the owning DB (or [TransactionDB]) first is safe when the
+/// iterator came from one of those — it registers itself as a [NativeObjectWithChildren] child
+/// of the DB that created it, the same way [Snapshot] does, so the DB closes any still-open
+/// iterator itself, synchronously, before destroying its own native handle. An iterator obtained
+/// from a [Transaction] (`Transaction.newIterator`) is not covered by this yet — `Transaction`
+/// is not a `NativeObjectWithChildren` — so close those before the transaction itself.
 ///
 /// ```
 /// try (RocksIterator it = db.newIterator()) {
@@ -101,26 +106,44 @@ public final class RocksIterator extends NativeObject {
 	private final Arena lenArena;
 	private final MemorySegment lenSegment;
 
+	/// The DB that produced this iterator, or `null` for a [Transaction]-owned iterator (see the
+	/// class-level doc — `Transaction` is not a [NativeObjectWithChildren] yet). Used in
+	/// [#tryClose(MemorySegment)] only to unregister once closed on its own; registration itself
+	/// happens here, via [NativeObjectWithChildren#registerChild(NativeObject)].
+	private final NativeObjectWithChildren owningDb;
+
 	/// Package-private: created via [#create].
-	private RocksIterator(MemorySegment ptr) {
+	private RocksIterator(NativeObjectWithChildren owningDb, MemorySegment ptr) {
 		super(ptr);
+		this.owningDb = owningDb;
 		this.lenArena = Arena.ofConfined();
 		this.lenSegment = lenArena.allocate(ValueLayout.JAVA_LONG);
+		if (owningDb != null) {
+			owningDb.registerChild(this);
+		}
 	}
 
 	/// Package-private factory called by RocksDB.
 	static RocksIterator create(RocksDBReadOperations db, ReadOptions readOptions) {
 		try {
 			MemorySegment iterPtr = (MemorySegment) MH_CREATE.invokeExact(db.dbPtr(), readOptions.ptr());
-			return new RocksIterator(iterPtr);
+			// Every implementor extends NativeObjectWithChildren (see RocksDBReadOperations#getSnapshot()).
+			return new RocksIterator((NativeObjectWithChildren) db, iterPtr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("iterator create failed", t);
 		}
 	}
 
-	/// Package-private factory for a pre-created iterator pointer (e.g. from rocksdb_create_iterator_cf).
+	/// Package-private factory for a pre-created iterator pointer scoped to a column family
+	/// (e.g. from `rocksdb_create_iterator_cf`), registered with `owningDb`.
+	static RocksIterator create(NativeObjectWithChildren owningDb, MemorySegment iterPtr) {
+		return new RocksIterator(owningDb, iterPtr);
+	}
+
+	/// Package-private factory for a pre-created iterator pointer with no owning
+	/// `NativeObjectWithChildren` to register with (currently only [Transaction]).
 	static RocksIterator create(MemorySegment iterPtr) {
-		return new RocksIterator(iterPtr);
+		return new RocksIterator(null, iterPtr);
 	}
 
 	// -----------------------------------------------------------------------
@@ -431,6 +454,16 @@ public final class RocksIterator extends NativeObject {
 
 	@Override
 	protected void tryClose(MemorySegment ptr) throws Throwable {
+		// Unregister first: if this runs because owningDb's own close() is sweeping its
+		// children (owningDb closed first), its pointer is still valid for the rest of this
+		// call (NativeObjectWithChildren captures its raw pointer before nulling its own
+		// AtomicReference and only then closes children) — same ordering guarantee Snapshot
+		// relies on, though rocksdb_iter_destroy itself never touches the DB pointer; what it
+		// must not touch is the DB's now-freed internal state, which is exactly what this
+		// registration prevents by destroying the iterator first.
+		if (owningDb != null) {
+			owningDb.unregisterChild(this);
+		}
 		MH_DESTROY.invokeExact(ptr);
 		lenArena.close();
 	}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/TransactionDB.java
@@ -1065,7 +1065,7 @@ public final class TransactionDB extends NativeObjectWithBaseDb implements Monit
 		try {
 			MemorySegment iterPtr = (MemorySegment) MH_CREATE_ITERATOR_CF.invokeExact(
 					ptr(), readOpts.ptr(), cf.ptr());
-			return RocksIterator.create(iterPtr);
+			return RocksIterator.create(this, iterPtr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("newIterator failed", t);
 		}
@@ -1080,7 +1080,7 @@ public final class TransactionDB extends NativeObjectWithBaseDb implements Monit
 		try {
 			MemorySegment iterPtr = (MemorySegment) MH_CREATE_ITERATOR_CF.invokeExact(
 					ptr(), readOptions.ptr(), cf.ptr());
-			return RocksIterator.create(iterPtr);
+			return RocksIterator.create(this, iterPtr);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("newIterator failed", t);
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/RocksIteratorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/RocksIteratorTest.java
@@ -606,4 +606,43 @@ class RocksIteratorTest {
 			}
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// Lifecycle — closing the owning DB before the iterator
+	// -----------------------------------------------------------------------
+
+	@Test
+	void closingDbFirst_closesStillOpenIteratorAutomatically(@TempDir Path dir) {
+		// Given — an iterator left open when its owning DB is closed
+		ReadWriteDB db = RocksDB.openReadWrite(dir);
+		db.put("k".getBytes(), "v".getBytes());
+		RocksIterator it = db.newIterator();
+		it.seekToFirst();
+
+		// When
+		db.close();
+
+		// Then — the DB closed the still-registered iterator itself before freeing its own
+		// native handle, so touching the iterator now throws a clean IllegalStateException
+		// instead of reading through a dangling rocksdb_iterator_t*
+		assertThatThrownBy(it::isValid).isInstanceOf(IllegalStateException.class);
+		it.close(); // no-op: already closed by the DB, must not double-free
+	}
+
+	@Test
+	void closingIteratorFirst_unregistersFromOwningDb(@TempDir Path dir) {
+		// Given — the ordinary order: iterator closed before its owning DB
+		try (var db = RocksDB.openReadWrite(dir)) {
+			db.put("k".getBytes(), "v".getBytes());
+			RocksIterator it = db.newIterator();
+			it.seekToFirst();
+			it.close();
+
+			// When — db.close() at the end of this try-with-resources must not attempt to
+			// close the already-closed iterator again (it unregistered itself above)
+
+			// Then — no exception from db.close()
+			assertThatThrownBy(it::isValid).isInstanceOf(IllegalStateException.class);
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- `RocksIterator` borrows its owning DB's `rocksdb_t*` to create a `rocksdb_iterator_t*`, and every subsequent call needs the DB to still be alive — but unlike `Snapshot`, it never registered itself with `NativeObjectWithChildren`, so closing the DB while an iterator was still open left the iterator pointing into memory whose lifetime it no longer controlled
- Confirmed as a real crash (not just theoretical UB): with `allow_mmap_reads` + `no_block_cache` + many small SSTs, closing the DB unmaps the backing files out from under a still-open iterator; walking it forward afterward hits unmapped memory directly inside `rocksdb::MergingIterator::Next()` → `SIGBUS`, no catchable Java exception, JVM dies. Full native stack and repro in #140.
- Fix mirrors `Snapshot` exactly: `RocksIterator` now registers with (and unregisters from) the `NativeObjectWithChildren` that created it, so the DB closes any still-open iterator itself, synchronously, before destroying its own native handle
- Wired through every DB-scoped iterator factory: `RocksDBReadOperations.newIterator()` (covers `ReadWriteDB`, `TtlDB`, `BlobDB`, `ReadOnlyDB`, `SecondaryDB`, `OptimisticTransactionDB`), the CF-scoped static helper in `RocksDB`, and `TransactionDB`'s two `newIterator` overloads
- `Transaction.newIterator` is intentionally left uncovered — `Transaction` extends plain `NativeObject`, not `NativeObjectWithChildren` — and documented as a follow-up on `RocksIterator`'s class javadoc

Fixes #140

## Test plan
- [x] Added `RocksIteratorTest.closingDbFirst_closesStillOpenIteratorAutomatically` and `closingIteratorFirst_unregistersFromOwningDb`
- [x] Re-ran the SIGBUS mmap repro from #140 against the fix — now throws a clean `IllegalStateException` instead of crashing
- [x] `./mvnw -pl core -am test` — 997 tests, 0 failures, 0 errors
- [x] `./mvnw javadoc:javadoc -pl core` — zero output