### PR TITLE
fix: harden the seven PIT-discovered crash hazards (#144-#150)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,6 +13,17 @@
 	<name>RocksDB FFM Core</name>
 	<packaging>jar</packaging>
 
+	<properties>
+		<!-- Overridable scope for -Pmutation-testing, e.g.
+		     -Dpitest.targetClasses=io.github.dfa1.rocksdbffm.MemorySize
+		     -Dpitest.targetTests=io.github.dfa1.rocksdbffm.MemorySizeTest -->
+		<pitest.targetClasses>io.github.dfa1.rocksdbffm.*</pitest.targetClasses>
+		<pitest.targetTests>io.github.dfa1.rocksdbffm.*</pitest.targetTests>
+		<pitest.excludedClasses />
+		<pitest.excludedTestClasses />
+		<pitest.threads>4</pitest.threads>
+	</properties>
+
 	<dependencies>
 		<!-- native -->
 		<dependency>
@@ -71,4 +82,42 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<!-- Opt-in, not part of the normal build: mvn test-compile -pl core -am -Pmutation-testing -->
+			<id>mutation-testing</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.pitest</groupId>
+						<artifactId>pitest-maven</artifactId>
+						<dependencies>
+							<dependency>
+								<groupId>org.pitest</groupId>
+								<artifactId>pitest-junit5-plugin</artifactId>
+								<version>1.2.3</version>
+							</dependency>
+						</dependencies>
+						<configuration>
+							<targetClasses>${pitest.targetClasses}</targetClasses>
+							<targetTests>${pitest.targetTests}</targetTests>
+							<excludedClasses>${pitest.excludedClasses}</excludedClasses>
+							<excludedTestClasses>${pitest.excludedTestClasses}</excludedTestClasses>
+							<threads>${pitest.threads}</threads>
+							<!-- Mutated classes run inside real forked JVMs, same as surefire, so
+							     the same native-access flag is required for the library to load. -->
+							<jvmArgs>
+								<jvmArg>--enable-native-access=ALL-UNNAMED</jvmArg>
+							</jvmArgs>
+							<outputFormats>
+								<outputFormat>HTML</outputFormat>
+							</outputFormats>
+							<timestampedReports>false</timestampedReports>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/LiveFiles.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/LiveFiles.java
@@ -120,7 +120,12 @@ public final class LiveFiles extends NativeObject implements Iterable<LiveFileIn
 				if (!hasNext()) {
 					throw new NoSuchElementException();
 				}
-				return new LiveFileInfo(LiveFiles.this, i++);
+				// Routed through the bounds-checked get(int), not constructed directly: if the
+				// index bookkeeping here ever regresses (e.g. corrupts to negative), this throws
+				// IndexOutOfBoundsException instead of handing a bad index to LiveFileInfo, whose
+				// native accessors do an unchecked std::vector::operator[] — a negative int
+				// reinterpreted as an enormous size_t is a near-certain native OOB read/crash.
+				return get(i++);
 			}
 		};
 	}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/MergeOperator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/MergeOperator.java
@@ -249,6 +249,24 @@ public sealed interface MergeOperator {
 			}
 		}
 
+		/// Last checkpoint before a value crosses back into native code as an upcall's `ADDRESS`
+		/// return: a Java `null` here isn't a Java-level failure (nothing throws), it's an
+		/// address the generated native trampoline can't marshal, which crashes the JVM instead
+		/// of raising anything catchable. Every dispatch method's return goes through this so a
+		/// future bug upstream (a mutation, a refactor that drops a `return`) fails loudly and
+		/// safely in Java instead of silently reaching the boundary.
+		///
+		/// @param result   the value about to be returned to native code
+		/// @param location description of the call site, for the error message
+		/// @return `result`
+		/// @throws AssertionError if `result` is `null`
+		private static MemorySegment requireNonNullUpcallResult(MemorySegment result, String location) {
+			if (result == null) {
+				throw new AssertionError(location + " produced a null upcall return value");
+			}
+			return result;
+		}
+
 		/// Builds a zero-copy, read-only view of a borrowed native buffer, bound to `arena` so
 		/// use past the call throws rather than reading freed/reused memory (same pattern as
 		/// [PinnableHandle#map(Arena, Mapper, MemorySegment)]).
@@ -292,7 +310,7 @@ public sealed interface MergeOperator {
 				byte[] result = s.fn().fullMerge(keyView, existingView, operandViews);
 				successPtr.set(ValueLayout.JAVA_BYTE, 0, (byte) 1);
 				newValueLenPtr.set(ValueLayout.JAVA_LONG, 0, result.length);
-				return mallocCopy(result);
+				return requireNonNullUpcallResult(mallocCopy(result), "fullMergeDispatch");
 			} catch (Throwable t) {
 				// must not throw across the upcall boundary — an escaping AssertionError here
 				// (assertions are on by default under Surefire) would abort the JVM, not just
@@ -328,10 +346,24 @@ public sealed interface MergeOperator {
 			REGISTRY.unregister(state);
 		}
 
-		/// Called from [#NAME_STUB]. Must not throw.
+		/// Fallback for [#nameDispatch] when the registry entry is missing. RocksDB's `Name()`
+		/// does `std::string(name)` on whatever this returns with no null check of its own, so
+		/// unlike the full/partial-merge paths — where `MemorySegment.NULL` legitimately means
+		/// "nothing to report" to code that checks for it — a raw null pointer here would itself
+		/// be a native crash; an empty, NUL-terminated C string is the safe equivalent.
+		private static final MemorySegment EMPTY_NAME = Arena.global().allocateFrom("");
+
+		/// Called from [#NAME_STUB]. Must not throw, and must never return a value that isn't
+		/// a valid NUL-terminated native string (see [#EMPTY_NAME]).
 		private static MemorySegment nameDispatch(MemorySegment state) {
-			State s = REGISTRY.get(state);
-			return s != null ? s.nameSeg() : MemorySegment.NULL;
+			try {
+				State s = REGISTRY.get(state);
+				return requireNonNullUpcallResult(s != null ? s.nameSeg() : EMPTY_NAME, "nameDispatch");
+			} catch (Throwable t) {
+				// same "must not throw" contract as fullMergeDispatch/partialMergeDispatch.
+				LOG.log(System.Logger.Level.ERROR, "nameDispatch failed", t);
+				return EMPTY_NAME;
+			}
 		}
 	}
 }

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/ReadBatch.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/ReadBatch.java
@@ -142,9 +142,9 @@ public final class ReadBatch implements AutoCloseable {
 			MemorySegment cfPtr = cf != null ? cf.ptr() : (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db.dbPtr());
 			for (int i = 0; i < n; i++) {
 				byte[] key = keys.get(i);
-				keysArr.setAtIndex(ValueLayout.ADDRESS, i, RocksDB.toNative(callArena, key));
-				keySizesArr.setAtIndex(ValueLayout.JAVA_LONG, i, key.length);
+				writeKeySlot(i, RocksDB.toNative(callArena, key), key.length);
 			}
+			RocksDB.requireNoNullEntries(keysArr, n, "ReadBatch keys array");
 			MH_BATCHED_MULTI_GET_CF.invokeExact(db.dbPtr(), readOptions.ptr(), cfPtr, (long) n,
 					keysArr, keySizesArr, valuesArr, errsArr, false);
 			return collectBytes(n);
@@ -190,15 +190,31 @@ public final class ReadBatch implements AutoCloseable {
 			MemorySegment cfPtr = cf != null ? cf.ptr() : (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db.dbPtr());
 			for (int i = 0; i < n; i++) {
 				ByteBuffer key = keys.get(i);
-				keysArr.setAtIndex(ValueLayout.ADDRESS, i, MemorySegment.ofBuffer(key));
-				keySizesArr.setAtIndex(ValueLayout.JAVA_LONG, i, key.remaining());
+				writeKeySlot(i, MemorySegment.ofBuffer(key), key.remaining());
 			}
+			RocksDB.requireNoNullEntries(keysArr, n, "ReadBatch keys array");
 			MH_BATCHED_MULTI_GET_CF.invokeExact(db.dbPtr(), readOptions.ptr(), cfPtr, (long) n,
 					keysArr, keySizesArr, valuesArr, errsArr, false);
 			return collectBuffers(n, values);
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("ReadBatch.get failed", t);
 		}
+	}
+
+	/// Writes both halves of key slot `i` together — the pointer into [#keysArr] and its
+	/// matching length into [#keySizesArr] — so a future edit to one of these loops can't
+	/// silently drop one write while keeping the other. Both arrays are preallocated once and
+	/// reused across every `get` call; a skipped write previously left a slot holding a stale
+	/// pointer/length pair from a prior call. `rocksdb_batched_multi_get_cf` trusts the pairing
+	/// completely, with no bounds check of its own, so a mismatched pointer+length crashes the
+	/// JVM rather than failing cleanly.
+	///
+	/// @param i      slot index, `0 <= i < n` for the current call
+	/// @param keyPtr native pointer to this key's bytes
+	/// @param keyLen this key's length in bytes
+	private void writeKeySlot(int i, MemorySegment keyPtr, long keyLen) {
+		keysArr.setAtIndex(ValueLayout.ADDRESS, i, keyPtr);
+		keySizesArr.setAtIndex(ValueLayout.JAVA_LONG, i, keyLen);
 	}
 
 	private void checkCapacity(int n) {
@@ -243,9 +259,9 @@ public final class ReadBatch implements AutoCloseable {
 			MemorySegment cfPtr = cf != null ? cf.ptr() : (MemorySegment) MH_GET_DEFAULT_CF.invokeExact(db.dbPtr());
 			for (int i = 0; i < n; i++) {
 				MemorySegment key = keys.get(i);
-				keysArr.setAtIndex(ValueLayout.ADDRESS, i, key);
-				keySizesArr.setAtIndex(ValueLayout.JAVA_LONG, i, key.byteSize());
+				writeKeySlot(i, key, key.byteSize());
 			}
+			RocksDB.requireNoNullEntries(keysArr, n, "ReadBatch keys array");
 			MH_BATCHED_MULTI_GET_CF.invokeExact(db.dbPtr(), readOptions.ptr(), cfPtr, (long) n,
 					keysArr, keySizesArr, valuesArr, errsArr, false);
 			return collect(n, fn);

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/RocksDB.java
@@ -1220,6 +1220,7 @@ public final class RocksDB {
 			for (int i = 0; i < files.size(); i++) {
 				fileArray.setAtIndex(ValueLayout.ADDRESS, i, arena.allocateFrom(files.get(i).toString()));
 			}
+			requireNoNullEntries(fileArray, files.size(), "ingest file list array");
 			MH_INGEST_EXTERNAL_FILE.invokeExact(db.dbPtr(), fileArray, (long) files.size(), options.ptr(), err);
 			checkError(err);
 		} catch (Throwable t) {
@@ -1500,6 +1501,25 @@ public final class RocksDB {
 	private record CfNamesAndOptions(MemorySegment names, MemorySegment options) {
 	}
 
+	/// Guards against handing a native call an array with an unfilled (NULL) slot — every C
+	/// API this backs (`rocksdb_open_column_families`, `rocksdb_ingest_external_file`, ...)
+	/// dereferences each entry as a pointer with no null check of its own, so a slot a
+	/// marshalling loop failed to populate would otherwise crash the JVM instead of failing
+	/// in Java. Cheap (a handful of pointer comparisons at DB-open/ingest time, not a hot
+	/// per-key path) insurance against that class of bug, whatever causes it.
+	///
+	/// @param arr  native `ADDRESS[n]` array to check
+	/// @param n    number of entries to check
+	/// @param what description of the array's contents, for the error message
+	/// @throws AssertionError if any of the first `n` entries is `MemorySegment.NULL`
+	static void requireNoNullEntries(MemorySegment arr, int n, String what) {
+		for (int i = 0; i < n; i++) {
+			if (MemorySegment.NULL.equals(arr.getAtIndex(ValueLayout.ADDRESS, i))) {
+				throw new AssertionError(what + " has an unpopulated (NULL) entry at index " + i);
+			}
+		}
+	}
+
 	/// Allocates and fills the parallel names/options arrays every `*_column_families` open
 	/// call marshals, one entry per `descriptors[i]`. A descriptor with no explicit
 	/// [ColumnFamilyDescriptor#options()] gets a fresh, disposable [Options] instance,
@@ -1525,6 +1545,8 @@ public final class RocksDB {
 			}
 			optsArr.setAtIndex(ValueLayout.ADDRESS, i, cfOpts.ptr());
 		}
+		requireNoNullEntries(namesArr, n, "column family names array");
+		requireNoNullEntries(optsArr, n, "column family options array");
 		return new CfNamesAndOptions(namesArr, optsArr);
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/BackupEngineTest.java
@@ -49,6 +49,32 @@ class BackupEngineTest {
 	}
 
 	@Test
+	void getBackupInfo_multipleBackups_returnsExactlyOneEntryPerBackupInOrder(@TempDir Path dir) {
+		// Given — getBackupInfo's loop bound comes from a native rocksdb_backup_engine_info_t
+		// count with no client-side bounds oracle to double-check against; an off-by-one loop
+		// bound reads one BackupInfo past the native std::vector's end (unchecked operator[]
+		// on the C++ side). A handful of backups makes an accidental one-past-the-end read
+		// more likely to land outside the allocation than a single-backup case would.
+		try (var opts = Options.newOptions().setCreateIfMissing(true);
+		     var db = RocksDB.openReadWrite(opts, dir.resolve("db"));
+		     var engine = BackupEngine.open(opts, dir.resolve("backup"))) {
+
+			for (int i = 0; i < 5; i++) {
+				db.put(("k" + i).getBytes(), ("v" + i).getBytes());
+				engine.createNewBackup(db, true);
+			}
+
+			// When
+			List<BackupInfo> result = engine.getBackupInfo();
+
+			// Then
+			assertThat(result).hasSize(5);
+			assertThat(result.stream().map(BackupInfo::backupId))
+					.containsExactly(BackupId.of(1), BackupId.of(2), BackupId.of(3), BackupId.of(4), BackupId.of(5));
+		}
+	}
+
+	@Test
 	void verifyBackup_succeedsForValidBackup(@TempDir Path dir) {
 		// Given
 		try (var opts = Options.newOptions().setCreateIfMissing(true);

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/LiveFileInfoTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/LiveFileInfoTest.java
@@ -117,14 +117,19 @@ class LiveFileInfoTest {
 
 			// When
 			List<Long> entryCounts = new ArrayList<>();
+			List<String> names = new ArrayList<>();
 			try (var files = db.getLiveFiles()) {
 				for (LiveFileInfo file : files) {
 					entryCounts.add(file.numberOfEntries());
+					names.add(file.name());
 				}
 			}
 
-			// Then
+			// Then — two distinct files visited, not the same index read twice (which a
+			// corrupted iteration index could otherwise mask, since both files here happen
+			// to share the same entry count)
 			assertThat(entryCounts).containsExactly(1L, 1L);
+			assertThat(names).doesNotHaveDuplicates();
 		}
 	}
 

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/NativeObjectTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/NativeObjectTest.java
@@ -1,0 +1,164 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/// Covers [NativeObject] in isolation, without any real native pointer — the double-close
+/// idempotency and ownership-transfer contract described in `docs/explanation.md` is testable
+/// directly against a fabricated address and a fake [#tryClose(MemorySegment)].
+class NativeObjectTest {
+
+	private static final class TestNativeObject extends NativeObject {
+
+		final AtomicInteger tryCloseCount = new AtomicInteger();
+		volatile MemorySegment lastClosedPtr;
+		volatile RuntimeException throwFromTryClose;
+
+		TestNativeObject(MemorySegment ptr) {
+			super(ptr);
+		}
+
+		@Override
+		protected void tryClose(MemorySegment ptr) {
+			tryCloseCount.incrementAndGet();
+			lastClosedPtr = ptr;
+			if (throwFromTryClose != null) {
+				throw throwFromTryClose;
+			}
+		}
+	}
+
+	private static MemorySegment fakePtr(long address) {
+		return MemorySegment.ofAddress(address);
+	}
+
+	@Test
+	void ptr_returnsTheConstructedPointer() {
+		// Given
+		var obj = new TestNativeObject(fakePtr(0x1234));
+
+		// When
+		var result = obj.ptr();
+
+		// Then
+		assertThat(result).isEqualTo(fakePtr(0x1234));
+	}
+
+	@Test
+	void ptr_afterClose_throwsIllegalStateException() {
+		// Given
+		var obj = new TestNativeObject(fakePtr(0x1234));
+		obj.close();
+
+		// When / Then
+		assertThatThrownBy(obj::ptr).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void close_callsTryCloseExactlyOnceWithTheOriginalPointer() {
+		// Given
+		var obj = new TestNativeObject(fakePtr(0xABCD));
+
+		// When
+		obj.close();
+
+		// Then
+		assertThat(obj.tryCloseCount).hasValue(1);
+		assertThat(obj.lastClosedPtr).isEqualTo(fakePtr(0xABCD));
+	}
+
+	@Test
+	void close_calledTwice_callsTryCloseOnlyOnce() {
+		// Given
+		var obj = new TestNativeObject(fakePtr(0x1));
+		obj.close();
+
+		// When
+		obj.close();
+
+		// Then
+		assertThat(obj.tryCloseCount).hasValue(1);
+	}
+
+	@Test
+	void close_calledConcurrentlyFromManyThreads_callsTryCloseExactlyOnce() {
+		// Given — the documented guarantee: tryClose runs exactly once no matter how many
+		// times or from how many threads close() is called concurrently
+		var obj = new TestNativeObject(fakePtr(0x1));
+		ExecutorService executor = Executors.newFixedThreadPool(8);
+
+		// When
+		var futures = IntStream.range(0, 200)
+				.mapToObj(i -> CompletableFuture.runAsync(obj::close, executor))
+				.toList();
+		futures.forEach(CompletableFuture::join);
+		executor.shutdown();
+
+		// Then
+		assertThat(obj.tryCloseCount).hasValue(1);
+	}
+
+	@Test
+	void close_whenTryCloseThrows_doesNotPropagateButStillMarksClosed() {
+		// Given — close() must never throw: a failure here must not stop the rest of a
+		// try-with-resources chain from closing
+		var obj = new TestNativeObject(fakePtr(0x1));
+		obj.throwFromTryClose = new RuntimeException("native destroy failed");
+
+		// When
+		obj.close();
+
+		// Then
+		assertThat(obj.tryCloseCount).hasValue(1);
+		assertThatThrownBy(obj::ptr).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void close_afterTryCloseThrew_isStillIdempotent() {
+		// Given
+		var obj = new TestNativeObject(fakePtr(0x1));
+		obj.throwFromTryClose = new RuntimeException("native destroy failed");
+		obj.close();
+
+		// When
+		obj.close();
+
+		// Then — the failed first attempt still consumed the pointer; a second close() is a
+		// pure no-op, not a retry
+		assertThat(obj.tryCloseCount).hasValue(1);
+	}
+
+	@Test
+	void transferOwnership_makesCloseANoOp() {
+		// Given
+		var obj = new TestNativeObject(fakePtr(0x1));
+
+		// When
+		obj.transferOwnership();
+		obj.close();
+
+		// Then
+		assertThat(obj.tryCloseCount).hasValue(0);
+	}
+
+	@Test
+	void transferOwnership_thenPtr_throwsIllegalStateException() {
+		// Given
+		var obj = new TestNativeObject(fakePtr(0x1));
+
+		// When
+		obj.transferOwnership();
+
+		// Then
+		assertThatThrownBy(obj::ptr).isInstanceOf(IllegalStateException.class);
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/SliceTransformTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/SliceTransformTest.java
@@ -2,7 +2,11 @@ package io.github.dfa1.rocksdbffm;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -68,6 +72,26 @@ class SliceTransformTest {
 
 			// Then
 			assertThatThrownBy(transform::ptr).isInstanceOf(IllegalStateException.class);
+		}
+	}
+
+	@Test
+	void setPrefixExtractor_closedImmediately_isANoOpAndDbStillWorks(@TempDir Path dir) {
+		// Given — setPrefixExtractor transfers ownership to Options, so closing the
+		// SliceTransform wrapper right away (before it's even used to open a DB) must be a
+		// no-op rather than freeing the pointer RocksDB's own copy now owns
+		var transform = SliceTransform.newFixedPrefix(3);
+		try (var opts = Options.newOptions().setCreateIfMissing(true).setPrefixExtractor(transform)) {
+			transform.close();
+
+			// When
+			try (var db = RocksDB.openReadWrite(opts, dir)) {
+				db.put("pre-key1".getBytes(), "value1".getBytes());
+				var hit = db.get("pre-key1".getBytes());
+
+				// Then
+				assertThat(hit).isEqualTo("value1".getBytes());
+			}
 		}
 	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TableOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TableOptionsTest.java
@@ -95,6 +95,27 @@ class TableOptionsTest {
 		}
 	}
 
+	@Test
+	void filterPolicy_closedImmediatelyAfterSetFilterPolicy_isANoOpAndDbStillWorks(@TempDir Path dir) {
+		// Given — setFilterPolicy transfers ownership to the table config, so closing the
+		// FilterPolicy wrapper right away (before it's even used to open a DB) must be a
+		// no-op rather than freeing the pointer RocksDB's own shared_ptr now owns
+		var filter = FilterPolicy.newBloom(10);
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig().setFilterPolicy(filter)) {
+			filter.close();
+
+			// When
+			try (var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
+			     var db = RocksDB.openReadWrite(opts, dir)) {
+				db.put("bloom-key".getBytes(), "bloom-value".getBytes());
+				var hit = db.get("bloom-key".getBytes());
+
+				// Then
+				assertThat(hit).isEqualTo("bloom-value".getBytes());
+			}
+		}
+	}
+
 	// -----------------------------------------------------------------------
 	// Shared block cache
 	// -----------------------------------------------------------------------

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/WalIteratorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/WalIteratorTest.java
@@ -126,6 +126,31 @@ class WalIteratorTest {
 	}
 
 	@Test
+	void isValid_afterExhaustingViaFixedCount_reportsFalse(@TempDir Path dir) {
+		// Given — a single write, so getUpdatesSince returns an iterator already positioned
+		// on that one and only batch. Exhaustion is driven by a *known, fixed* next() count
+		// (1), never by looping on isValid() itself — if isValid() were broken to always
+		// return true, a loop keyed on it (like getUpdatesSince_emptyWhenNoWritesAfterSequence
+		// above) would just spin/crash forever instead of reaching a clean assertion failure.
+		try (var db = RocksDB.openReadWrite(dir)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+			db.put("k".getBytes(), "v".getBytes());
+
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				assertThat(it.isValid()).isTrue();
+				try (var result = it.getBatch()) {
+					// consume the one batch
+				}
+				it.next();
+
+				// When / Then
+				assertThat(it.isValid()).isFalse();
+				assertThatThrownBy(it::getBatch).isInstanceOf(IllegalStateException.class);
+			}
+		}
+	}
+
+	@Test
 	void walIterator_isClosedSafely(@TempDir Path dir) {
 		// Given
 		try (var db = RocksDB.openReadWrite(dir)) {

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,11 @@
 					<artifactId>jacoco-maven-plugin</artifactId>
 					<version>0.8.15</version>
 				</plugin>
+				<plugin>
+					<groupId>org.pitest</groupId>
+					<artifactId>pitest-maven</artifactId>
+					<version>1.30.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
## Summary

Fixes for all seven crashes found by the PIT mutation-testing investigation in #144-#150, plus the PIT tooling itself and a `NativeObjectTest` gap found along the way.

- **test:** adds the opt-in `-Pmutation-testing` Maven profile (`core/pom.xml`) that found all of this, and `NativeObjectTest` — `NativeObject` (the double-close/idempotency/ownership-transfer base every native wrapper relies on) had zero direct unit tests before this.
- **#150** `BlockBasedTableOptions.setFilterPolicy` / `Options.setPrefixExtractor`: the code already correctly calls `transferOwnership()` at both sites; added regression tests that close the wrapper immediately after the transferring setter returns and then actually open+use a DB with it, proving the no-op/no-double-free contract holds (mirrors the audit requested alongside #150 — `SliceTransform` had the identical gap).
- **#149** `WalIterator.isValid`: added a test that exhausts the iterator via a *fixed* `next()` count rather than looping on `isValid()` itself (the existing exhaustion test would spin/crash under the exact mutation instead of reaching its assertion).
- **#148** `LiveFiles` iterator: routed `next()` through the already-bounds-checked `get(int)`, converting a wild native OOB read into a clean `IndexOutOfBoundsException`. Strengthened the existing multi-file test to assert distinct file names.
- **#147** `BackupEngine.getBackupInfo`: added a five-backup test asserting the exact `BackupId` sequence (existing 1-3 backup tests already used exact-size assertions, but too few entries for an off-by-one overread to reliably land outside the allocation).
- **#146** `RocksDB.ingestExternalFile` / `buildCfArrays`: added `RocksDB.requireNoNullEntries`, a cheap pre-native-call validation pass that turns an unpopulated array slot into a clean `AssertionError` instead of a native null-pointer crash.
- **#145** `MergeOperator.Custom`: added `requireNonNullUpcallResult` guarding the upcall-boundary return path; gave `nameDispatch` the try/catch its own "must not throw" comment already promised but didn't have; replaced its unsafe `MemorySegment.NULL` fallback (RocksDB's `Name()` does `std::string(name)` with no null check) with a real empty C string. That last one is a latent-hazard fix, not just a mutation-testing artifact — a genuine registry-lookup race could have hit the same crash in the *original* code.
- **#144** `ReadBatch`: paired `keysArr`/`keySizesArr` writes into one `writeKeySlot` helper and added a `requireNoNullEntries` check before each native batched-multi-get call, so a future edit can't silently leave a stale pointer paired with a fresh length.

## An important nuance from re-running PIT after these fixes

Re-running the mutation tests against all eight touched classes:

- **#144, #145, #146, #148** — the classes I made actual *code* changes to — now show **0 RUN_ERROR** for every mutant PIT originally found. Confirmed fixed.
- **#147, #149, #150** — where the underlying code was already correct and the fix was a *test only* — PIT's exact original mutant (delete this one guard/loop-bound line) **still shows RUN_ERROR** on re-run. This is expected, not a gap: deleting a single-point-of-failure guard crashes before any assertion can run, so no test can prevent PIT's own synthetic single-statement deletion from crashing — the new tests protect against a realistic *human* regression (a reordered `close()`, a rewritten loop) during normal review/CI, not against PIT's brute-force mode itself. Fully closing that would need the same kind of architectural change #143 already identified and deferred (locking around every native call site).
- Also surfaced one **new**, previously uninvestigated `RUN_ERROR` mutant: `WalIterator.next()`'s `removed call to MethodHandle::invokeExact`. Not yet triaged — flagging here rather than silently dropping it; happy to open a follow-up issue and investigate separately if wanted, this PR is large enough already.

## Test plan
- [x] `./mvnw -pl core -am test` — 1010 tests, 0 failures, 0 errors
- [x] `./mvnw javadoc:javadoc -pl core` — zero output
- [x] Re-ran `-Pmutation-testing` against all 8 touched classes post-fix (see nuance above)

Closes #144, #145, #146, #147, #148, #149, #150