### PR TITLE
fix: guard WalIterator.getBatch() against being called twice per position

### DIFF
--- a/core/src/main/java/io/github/dfa1/rocksdbffm/WalIterator.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/WalIterator.java
@@ -57,6 +57,11 @@ public final class WalIterator extends NativeObject {
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
 	}
 
+	// rocksdb_wal_iter_get_batch is only safe to call once per position: a second call before
+	// next() moves the iterator on crashes inside RocksDB's own WriteBatch move-assignment
+	// instead of raising a Java exception (see getBatch()'s guard below).
+	private boolean batchFetchedAtCurrentPosition;
+
 	private WalIterator(MemorySegment ptr) {
 		super(ptr);
 	}
@@ -80,6 +85,7 @@ public final class WalIterator extends NativeObject {
 	public void next() {
 		try {
 			MH_NEXT.invokeExact(ptr());
+			batchFetchedAtCurrentPosition = false;
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("wal_iter_next failed", t);
 		}
@@ -100,21 +106,29 @@ public final class WalIterator extends NativeObject {
 	}
 
 	/// Returns the current [WriteBatch] and the [SequenceNumber] of its first transaction.
-	/// The caller owns the returned [WalBatchResult] and must close it.
+	/// The caller owns the returned [WalBatchResult] and must close it. Only call once per
+	/// position — call [#next()] before calling this again.
 	///
 	/// @return the current batch and its sequence number
-	/// @throws IllegalStateException if [#isValid()] is `false` — RocksDB's C API
-	///                                (`rocksdb_wal_iter_get_batch`) dereferences a null
-	///                                internal pointer in that case and crashes the JVM
+	/// @throws IllegalStateException if [#isValid()] is `false`, or if this is called a second
+	///                                time at the same position without an intervening
+	///                                [#next()] — RocksDB's C API (`rocksdb_wal_iter_get_batch`)
+	///                                is only safe to call once per position; calling it again
+	///                                crashes the JVM (inside `WriteBatch`'s own move-assignment)
 	///                                instead of raising a Java exception
 	public WalBatchResult getBatch() {
 		if (!isValid()) {
 			throw new IllegalStateException("wal iterator is not valid: getBatch() can only be called while isValid() is true");
 		}
+		if (batchFetchedAtCurrentPosition) {
+			throw new IllegalStateException(
+					"getBatch() was already called at this position: call next() before calling it again");
+		}
 		try (Arena arena = Arena.ofConfined()) {
 			MemorySegment seqHolder = arena.allocate(ValueLayout.JAVA_LONG);
 			MemorySegment batchPtr = (MemorySegment) MH_GET_BATCH.invokeExact(ptr(), seqHolder);
 			long seq = seqHolder.get(ValueLayout.JAVA_LONG, 0);
+			batchFetchedAtCurrentPosition = true;
 			return new WalBatchResult(SequenceNumber.of(seq), WriteBatch.wrap(batchPtr));
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("wal_iter_get_batch failed", t);

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/WalIteratorTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/WalIteratorTest.java
@@ -151,6 +151,33 @@ class WalIteratorTest {
 	}
 
 	@Test
+	void getBatch_calledTwiceWithoutNext_throwsInsteadOfCrashing(@TempDir Path dir) {
+		// Given — rocksdb_wal_iter_get_batch is only safe to call once per position; a second
+		// call before next() moves the iterator on segfaults inside RocksDB's own WriteBatch
+		// move-assignment instead of raising a Java exception
+		try (var db = RocksDB.openReadWrite(dir)) {
+			SequenceNumber start = db.getLatestSequenceNumber();
+			db.put("a".getBytes(), "1".getBytes());
+			db.put("b".getBytes(), "2".getBytes());
+
+			try (WalIterator it = db.getUpdatesSince(start)) {
+				try (var first = it.getBatch()) {
+					// consume
+				}
+
+				// When / Then
+				assertThatThrownBy(it::getBatch).isInstanceOf(IllegalStateException.class);
+
+				// And — next() clears the guard, so getBatch() works again at the new position
+				it.next();
+				try (var second = it.getBatch()) {
+					assertThat(second.sequenceNumber().isAfter(start)).isTrue();
+				}
+			}
+		}
+	}
+
+	@Test
 	void walIterator_isClosedSafely(@TempDir Path dir) {
 		// Given
 		try (var db = RocksDB.openReadWrite(dir)) {


### PR DESCRIPTION
## Summary
- `rocksdb_wal_iter_get_batch` is only safe to call once per iterator position — a second call before `next()` moves the iterator on segfaults inside RocksDB's own `WriteBatch` move-assignment (`result->rep = std::move(*wal_batch.writeBatchPtr)` in `rocksdb/db/c.cc`), confirmed with a real SIGSEGV
- Unlike most of #144-#150, this is directly reachable through ordinary public-API usage — no internal code deletion needed, just `getBatch()` called twice in a row
- `WalIterator` now tracks whether `getBatch()` was already called at the current position (cleared by `next()`) and throws `IllegalStateException` on a repeat call instead of forwarding to the native call — the same shape as `getBatch()`'s existing `isValid()` guard
- Found via PIT during the #144-#150 verification pass (a `next()` mutant reproduced the same crash), then confirmed directly without any mutation

Fixes #152

## Test plan
- [x] Added `WalIteratorTest.getBatch_calledTwiceWithoutNext_throwsInsteadOfCrashing`
- [x] Re-ran the original SIGSEGV repro against the fix — now throws a clean `IllegalStateException`
- [x] `./mvnw -pl core -am test` — 1011 tests, 0 failures, 0 errors
- [x] `./mvnw javadoc:javadoc -pl core` — zero output