### PR TITLE
feat: map BlockBasedTableOptions auto-readahead + cache pinning/priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BlockBasedTableOptions`: auto-readahead tuning — `setMaxAutoReadaheadSize`/`getMaxAutoReadaheadSize`,
   `setInitialAutoReadaheadSize`/`getInitialAutoReadaheadSize`, `setNumFileReadsForAutoReadahead`/
   `getNumFileReadsForAutoReadahead`.
+- `BlockBasedTableOptions`: cache pinning and priority — new `PinningTier` enum plus
+  `setTopLevelIndexPinningTier`, `setPartitionPinningTier`, `setUnpartitionedPinningTier`
+  (setter-only in `c.h`, no getters), and `setCacheIndexAndFilterBlocksWithHighPriority`/
+  `setPinL0FilterAndIndexBlocksInCache`/`setPinTopLevelIndexAndFilter` with their getters.
 
 ## [0.10] — 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `BlockBasedTableOptions`: auto-readahead tuning — `setMaxAutoReadaheadSize`/`getMaxAutoReadaheadSize`,
+  `setInitialAutoReadaheadSize`/`getInitialAutoReadaheadSize`, `setNumFileReadsForAutoReadahead`/
+  `getNumFileReadsForAutoReadahead`.
+
 ## [0.10] — 2026-08-30
 
 `ReadBatch` (a reusable, preallocated multiGet), full SST-file inspection (`LiveFiles`,

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlockBasedTableOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlockBasedTableOptions.java
@@ -94,6 +94,29 @@ public final class BlockBasedTableOptions extends NativeObject {
 		}
 	}
 
+	/// Which tier of block-based tables a metadata-block cache-pinning setting affects
+	/// ([#setTopLevelIndexPinningTier], [#setPartitionPinningTier],
+	/// [#setUnpartitionedPinningTier]), per `table.h`'s `PinningTier`.
+	public enum PinningTier {
+		/// Falls back to the deprecated [#setPinL0FilterAndIndexBlocksInCache] /
+		/// [#setPinTopLevelIndexAndFilter] booleans instead of a tier-based rule.
+		FALLBACK(0),
+		/// No block-based tables in this tier are pinned.
+		NONE(1),
+		/// Tables that may have originated from a memtable flush -- includes L0 tables smaller
+		/// than 1.5x the current write buffer size, so also intra-L0 compaction outputs and
+		/// ingested files not abnormally large compared to flushed L0 files.
+		FLUSHED_AND_SIMILAR(2),
+		/// Every block-based table in this tier is pinned.
+		ALL(3);
+
+		final int value;
+
+		PinningTier(int value) {
+			this.value = value;
+		}
+	}
+
 	// -----------------------------------------------------------------------
 	// Method handles
 	// -----------------------------------------------------------------------
@@ -134,6 +157,24 @@ public final class BlockBasedTableOptions extends NativeObject {
 	private static final MethodHandle MH_SET_NUM_FILE_READS_FOR_AUTO_READAHEAD;
 	/// `uint64_t rocksdb_block_based_options_get_num_file_reads_for_auto_readahead(rocksdb_block_based_table_options_t* opt);`
 	private static final MethodHandle MH_GET_NUM_FILE_READS_FOR_AUTO_READAHEAD;
+	/// `void rocksdb_block_based_options_set_cache_index_and_filter_blocks_with_high_priority(rocksdb_block_based_table_options_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_CACHE_INDEX_AND_FILTER_BLOCKS_WITH_HIGH_PRIORITY;
+	/// `unsigned char rocksdb_block_based_options_get_cache_index_and_filter_blocks_with_high_priority(rocksdb_block_based_table_options_t* opt);`
+	private static final MethodHandle MH_GET_CACHE_INDEX_AND_FILTER_BLOCKS_WITH_HIGH_PRIORITY;
+	/// `void rocksdb_block_based_options_set_pin_l0_filter_and_index_blocks_in_cache(rocksdb_block_based_table_options_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_PIN_L0_FILTER_AND_INDEX_BLOCKS_IN_CACHE;
+	/// `unsigned char rocksdb_block_based_options_get_pin_l0_filter_and_index_blocks_in_cache(rocksdb_block_based_table_options_t* opt);`
+	private static final MethodHandle MH_GET_PIN_L0_FILTER_AND_INDEX_BLOCKS_IN_CACHE;
+	/// `void rocksdb_block_based_options_set_pin_top_level_index_and_filter(rocksdb_block_based_table_options_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_PIN_TOP_LEVEL_INDEX_AND_FILTER;
+	/// `unsigned char rocksdb_block_based_options_get_pin_top_level_index_and_filter(rocksdb_block_based_table_options_t* opt);`
+	private static final MethodHandle MH_GET_PIN_TOP_LEVEL_INDEX_AND_FILTER;
+	/// `void rocksdb_block_based_options_set_top_level_index_pinning_tier(rocksdb_block_based_table_options_t* options, int v);`
+	private static final MethodHandle MH_SET_TOP_LEVEL_INDEX_PINNING_TIER;
+	/// `void rocksdb_block_based_options_set_partition_pinning_tier(rocksdb_block_based_table_options_t* options, int v);`
+	private static final MethodHandle MH_SET_PARTITION_PINNING_TIER;
+	/// `void rocksdb_block_based_options_set_unpartitioned_pinning_tier(rocksdb_block_based_table_options_t* options, int v);`
+	private static final MethodHandle MH_SET_UNPARTITIONED_PINNING_TIER;
 
 	static {
 		MH_CREATE = NativeLibrary.lookup("rocksdb_block_based_options_create",
@@ -198,6 +239,42 @@ public final class BlockBasedTableOptions extends NativeObject {
 		MH_GET_NUM_FILE_READS_FOR_AUTO_READAHEAD = NativeLibrary.lookup(
 				"rocksdb_block_based_options_get_num_file_reads_for_auto_readahead",
 				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_CACHE_INDEX_AND_FILTER_BLOCKS_WITH_HIGH_PRIORITY = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_cache_index_and_filter_blocks_with_high_priority",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_CACHE_INDEX_AND_FILTER_BLOCKS_WITH_HIGH_PRIORITY = NativeLibrary.lookup(
+				"rocksdb_block_based_options_get_cache_index_and_filter_blocks_with_high_priority",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_PIN_L0_FILTER_AND_INDEX_BLOCKS_IN_CACHE = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_pin_l0_filter_and_index_blocks_in_cache",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_PIN_L0_FILTER_AND_INDEX_BLOCKS_IN_CACHE = NativeLibrary.lookup(
+				"rocksdb_block_based_options_get_pin_l0_filter_and_index_blocks_in_cache",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_PIN_TOP_LEVEL_INDEX_AND_FILTER = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_pin_top_level_index_and_filter",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_PIN_TOP_LEVEL_INDEX_AND_FILTER = NativeLibrary.lookup(
+				"rocksdb_block_based_options_get_pin_top_level_index_and_filter",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_TOP_LEVEL_INDEX_PINNING_TIER = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_top_level_index_pinning_tier",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_SET_PARTITION_PINNING_TIER = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_partition_pinning_tier",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_SET_UNPARTITIONED_PINNING_TIER = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_unpartitioned_pinning_tier",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
 	}
 
 	private BlockBasedTableOptions(MemorySegment ptr) {
@@ -436,6 +513,133 @@ public final class BlockBasedTableOptions extends NativeObject {
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("getNumFileReadsForAutoReadahead failed", t);
 		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Cache pinning and priority
+	// -----------------------------------------------------------------------
+
+	/// If true, index and filter blocks are inserted into the block cache with high priority,
+	/// making them less likely to be evicted than normal-priority data blocks. Only takes
+	/// effect when [#setCacheIndexAndFilterBlocks] is `true`. Default: false.
+	///
+	/// @param value `true` to insert index/filter blocks at high cache priority
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setCacheIndexAndFilterBlocksWithHighPriority(boolean value) {
+		try {
+			MH_SET_CACHE_INDEX_AND_FILTER_BLOCKS_WITH_HIGH_PRIORITY.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setCacheIndexAndFilterBlocksWithHighPriority failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether index/filter blocks are inserted into the block cache at high priority.
+	///
+	/// @return `true` if index/filter blocks are inserted at high cache priority
+	public boolean getCacheIndexAndFilterBlocksWithHighPriority() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_CACHE_INDEX_AND_FILTER_BLOCKS_WITH_HIGH_PRIORITY.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getCacheIndexAndFilterBlocksWithHighPriority failed", t);
+		}
+	}
+
+	/// Deprecated pinning control, superseded by [#setUnpartitionedPinningTier] and
+	/// [#setPartitionPinningTier] (used only when those are left at
+	/// [PinningTier#FALLBACK]). If true, pins L0 filter and index blocks in the block cache.
+	/// Default: false.
+	///
+	/// @param value `true` to pin L0 filter and index blocks in the block cache
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setPinL0FilterAndIndexBlocksInCache(boolean value) {
+		try {
+			MH_SET_PIN_L0_FILTER_AND_INDEX_BLOCKS_IN_CACHE.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setPinL0FilterAndIndexBlocksInCache failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether L0 filter and index blocks are pinned in the block cache.
+	///
+	/// @return `true` if L0 filter and index blocks are pinned in the block cache
+	public boolean getPinL0FilterAndIndexBlocksInCache() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_PIN_L0_FILTER_AND_INDEX_BLOCKS_IN_CACHE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getPinL0FilterAndIndexBlocksInCache failed", t);
+		}
+	}
+
+	/// Deprecated pinning control, superseded by [#setTopLevelIndexPinningTier] (used only
+	/// when that is left at [PinningTier#FALLBACK]). If true, pins the top-level index and
+	/// filter on partitioned index/filter tables. Default: false.
+	///
+	/// @param value `true` to pin the top-level index and filter
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setPinTopLevelIndexAndFilter(boolean value) {
+		try {
+			MH_SET_PIN_TOP_LEVEL_INDEX_AND_FILTER.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setPinTopLevelIndexAndFilter failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether the top-level index and filter are pinned.
+	///
+	/// @return `true` if the top-level index and filter are pinned
+	public boolean getPinTopLevelIndexAndFilter() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_PIN_TOP_LEVEL_INDEX_AND_FILTER.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getPinTopLevelIndexAndFilter failed", t);
+		}
+	}
+
+	/// The tier of block-based tables whose top-level index into metadata partitions will be
+	/// pinned in the block cache. Requires [#setCacheIndexAndFilterBlocks] to be `true` to have
+	/// any effect. Default: [PinningTier#FALLBACK].
+	///
+	/// @param tier the pinning tier to apply
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setTopLevelIndexPinningTier(PinningTier tier) {
+		try {
+			MH_SET_TOP_LEVEL_INDEX_PINNING_TIER.invokeExact(ptr(), tier.value);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setTopLevelIndexPinningTier failed", t);
+		}
+		return this;
+	}
+
+	/// The tier of block-based tables whose metadata partitions (index and filter) will be
+	/// pinned in the block cache. Default: [PinningTier#FALLBACK].
+	///
+	/// @param tier the pinning tier to apply
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setPartitionPinningTier(PinningTier tier) {
+		try {
+			MH_SET_PARTITION_PINNING_TIER.invokeExact(ptr(), tier.value);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setPartitionPinningTier failed", t);
+		}
+		return this;
+	}
+
+	/// The tier of block-based tables whose unpartitioned metadata blocks will be pinned in
+	/// the block cache. Requires [#setCacheIndexAndFilterBlocks] to be `true` to have any
+	/// effect. Default: [PinningTier#FALLBACK].
+	///
+	/// @param tier the pinning tier to apply
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setUnpartitionedPinningTier(PinningTier tier) {
+		try {
+			MH_SET_UNPARTITIONED_PINNING_TIER.invokeExact(ptr(), tier.value);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setUnpartitionedPinningTier failed", t);
+		}
+		return this;
 	}
 
 	@Override

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/BlockBasedTableOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/BlockBasedTableOptions.java
@@ -122,6 +122,18 @@ public final class BlockBasedTableOptions extends NativeObject {
 	private static final MethodHandle MH_SET_WHOLE_KEY_FILTERING;
 	/// `void rocksdb_block_based_options_set_partition_filters(rocksdb_block_based_table_options_t* options, unsigned char partition_filters);`
 	private static final MethodHandle MH_SET_PARTITION_FILTERS;
+	/// `void rocksdb_block_based_options_set_max_auto_readahead_size(rocksdb_block_based_table_options_t* opt, size_t v);`
+	private static final MethodHandle MH_SET_MAX_AUTO_READAHEAD_SIZE;
+	/// `size_t rocksdb_block_based_options_get_max_auto_readahead_size(rocksdb_block_based_table_options_t* opt);`
+	private static final MethodHandle MH_GET_MAX_AUTO_READAHEAD_SIZE;
+	/// `void rocksdb_block_based_options_set_initial_auto_readahead_size(rocksdb_block_based_table_options_t* opt, size_t v);`
+	private static final MethodHandle MH_SET_INITIAL_AUTO_READAHEAD_SIZE;
+	/// `size_t rocksdb_block_based_options_get_initial_auto_readahead_size(rocksdb_block_based_table_options_t* opt);`
+	private static final MethodHandle MH_GET_INITIAL_AUTO_READAHEAD_SIZE;
+	/// `void rocksdb_block_based_options_set_num_file_reads_for_auto_readahead(rocksdb_block_based_table_options_t* opt, uint64_t v);`
+	private static final MethodHandle MH_SET_NUM_FILE_READS_FOR_AUTO_READAHEAD;
+	/// `uint64_t rocksdb_block_based_options_get_num_file_reads_for_auto_readahead(rocksdb_block_based_table_options_t* opt);`
+	private static final MethodHandle MH_GET_NUM_FILE_READS_FOR_AUTO_READAHEAD;
 
 	static {
 		MH_CREATE = NativeLibrary.lookup("rocksdb_block_based_options_create",
@@ -162,6 +174,30 @@ public final class BlockBasedTableOptions extends NativeObject {
 		MH_SET_PARTITION_FILTERS = NativeLibrary.lookup(
 				"rocksdb_block_based_options_set_partition_filters",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_SET_MAX_AUTO_READAHEAD_SIZE = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_max_auto_readahead_size",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_MAX_AUTO_READAHEAD_SIZE = NativeLibrary.lookup(
+				"rocksdb_block_based_options_get_max_auto_readahead_size",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_INITIAL_AUTO_READAHEAD_SIZE = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_initial_auto_readahead_size",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_INITIAL_AUTO_READAHEAD_SIZE = NativeLibrary.lookup(
+				"rocksdb_block_based_options_get_initial_auto_readahead_size",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_NUM_FILE_READS_FOR_AUTO_READAHEAD = NativeLibrary.lookup(
+				"rocksdb_block_based_options_set_num_file_reads_for_auto_readahead",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_NUM_FILE_READS_FOR_AUTO_READAHEAD = NativeLibrary.lookup(
+				"rocksdb_block_based_options_get_num_file_reads_for_auto_readahead",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
 	}
 
 	private BlockBasedTableOptions(MemorySegment ptr) {
@@ -319,6 +355,87 @@ public final class BlockBasedTableOptions extends NativeObject {
 			throw RocksDB.wrapInvokeFailure("setPartitionFilters failed", t);
 		}
 		return this;
+	}
+
+	// -----------------------------------------------------------------------
+	// Auto-readahead tuning
+	// -----------------------------------------------------------------------
+
+	/// Upper bound on the read-ahead size RocksDB grows to for sequential scans of this
+	/// table. Auto-readahead starts at [#setInitialAutoReadaheadSize] and doubles after every
+	/// [#setNumFileReadsForAutoReadahead] sequential reads, capped at this value. Default: 256 KB.
+	///
+	/// @param size maximum auto-readahead size
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setMaxAutoReadaheadSize(MemorySize size) {
+		try {
+			MH_SET_MAX_AUTO_READAHEAD_SIZE.invokeExact(ptr(), size.toBytes());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setMaxAutoReadaheadSize failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured maximum auto-readahead size.
+	///
+	/// @return current maximum auto-readahead size
+	public MemorySize getMaxAutoReadaheadSize() {
+		try {
+			return MemorySize.ofBytes((long) MH_GET_MAX_AUTO_READAHEAD_SIZE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getMaxAutoReadaheadSize failed", t);
+		}
+	}
+
+	/// Read-ahead size RocksDB starts with for a new sequential scan of this table, before it
+	/// grows toward [#setMaxAutoReadaheadSize]. Default: 8 KB.
+	///
+	/// @param size initial auto-readahead size
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setInitialAutoReadaheadSize(MemorySize size) {
+		try {
+			MH_SET_INITIAL_AUTO_READAHEAD_SIZE.invokeExact(ptr(), size.toBytes());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setInitialAutoReadaheadSize failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured initial auto-readahead size.
+	///
+	/// @return current initial auto-readahead size
+	public MemorySize getInitialAutoReadaheadSize() {
+		try {
+			return MemorySize.ofBytes((long) MH_GET_INITIAL_AUTO_READAHEAD_SIZE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getInitialAutoReadaheadSize failed", t);
+		}
+	}
+
+	/// Number of sequential file reads that must be observed before RocksDB doubles the
+	/// auto-readahead size (up to [#setMaxAutoReadaheadSize]). Default: 2.
+	///
+	/// @param count number of sequential reads that triggers doubling the readahead size
+	/// @return `this` for chaining
+	public BlockBasedTableOptions setNumFileReadsForAutoReadahead(long count) {
+		try {
+			MH_SET_NUM_FILE_READS_FOR_AUTO_READAHEAD.invokeExact(ptr(), count);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setNumFileReadsForAutoReadahead failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured number of sequential reads that triggers doubling the
+	/// auto-readahead size.
+	///
+	/// @return current number of sequential reads that triggers doubling the readahead size
+	public long getNumFileReadsForAutoReadahead() {
+		try {
+			return (long) MH_GET_NUM_FILE_READS_FOR_AUTO_READAHEAD.invokeExact(ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getNumFileReadsForAutoReadahead failed", t);
+		}
 	}
 
 	@Override

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TableOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TableOptionsTest.java
@@ -223,4 +223,70 @@ class TableOptionsTest {
 			assertThat(result).isEqualTo(BlockBasedTableOptions.FormatVersion.V5);
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// Auto-readahead tuning
+	// -----------------------------------------------------------------------
+
+	@Test
+	void autoReadaheadTuning_allowsReadWrite(@TempDir Path dir) {
+		// Given
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig()
+				     .setInitialAutoReadaheadSize(MemorySize.ofKB(4))
+				     .setMaxAutoReadaheadSize(MemorySize.ofKB(128))
+				     .setNumFileReadsForAutoReadahead(3);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+
+			// When
+			var result = db.get("k".getBytes());
+
+			// Then
+			assertThat(result).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void setMaxAutoReadaheadSize_roundTrips() {
+		// Given
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig()
+				     .setMaxAutoReadaheadSize(MemorySize.ofKB(128))) {
+
+			// When
+			var result = tbl.getMaxAutoReadaheadSize();
+
+			// Then
+			assertThat(result).isEqualTo(MemorySize.ofKB(128));
+		}
+	}
+
+	@Test
+	void setInitialAutoReadaheadSize_roundTrips() {
+		// Given
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig()
+				     .setInitialAutoReadaheadSize(MemorySize.ofKB(4))) {
+
+			// When
+			var result = tbl.getInitialAutoReadaheadSize();
+
+			// Then
+			assertThat(result).isEqualTo(MemorySize.ofKB(4));
+		}
+	}
+
+	@Test
+	void setNumFileReadsForAutoReadahead_roundTrips() {
+		// Given
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig()
+				     .setNumFileReadsForAutoReadahead(5)) {
+
+			// When
+			var result = tbl.getNumFileReadsForAutoReadahead();
+
+			// Then
+			assertThat(result).isEqualTo(5L);
+		}
+	}
 }

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/TableOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/TableOptionsTest.java
@@ -289,4 +289,74 @@ class TableOptionsTest {
 			assertThat(result).isEqualTo(5L);
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// Cache pinning and priority
+	// -----------------------------------------------------------------------
+
+	@Test
+	void cachePinningAndPriority_allowsReadWrite(@TempDir Path dir) {
+		// Given
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig()
+				     .setCacheIndexAndFilterBlocks(true)
+				     .setCacheIndexAndFilterBlocksWithHighPriority(true)
+				     .setPinL0FilterAndIndexBlocksInCache(true)
+				     .setPinTopLevelIndexAndFilter(true)
+				     .setTopLevelIndexPinningTier(BlockBasedTableOptions.PinningTier.ALL)
+				     .setPartitionPinningTier(BlockBasedTableOptions.PinningTier.FLUSHED_AND_SIMILAR)
+				     .setUnpartitionedPinningTier(BlockBasedTableOptions.PinningTier.NONE);
+		     var opts = Options.newOptions().setCreateIfMissing(true).setTableFormatConfig(tbl);
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+
+			// When
+			var result = db.get("k".getBytes());
+
+			// Then
+			assertThat(result).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void setCacheIndexAndFilterBlocksWithHighPriority_roundTrips() {
+		// Given
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig()
+				     .setCacheIndexAndFilterBlocksWithHighPriority(true)) {
+
+			// When
+			var result = tbl.getCacheIndexAndFilterBlocksWithHighPriority();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setPinL0FilterAndIndexBlocksInCache_roundTrips() {
+		// Given
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig()
+				     .setPinL0FilterAndIndexBlocksInCache(true)) {
+
+			// When
+			var result = tbl.getPinL0FilterAndIndexBlocksInCache();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setPinTopLevelIndexAndFilter_roundTrips() {
+		// Given
+		try (var tbl = BlockBasedTableOptions.newBlockBasedConfig()
+				     .setPinTopLevelIndexAndFilter(true)) {
+
+			// When
+			var result = tbl.getPinTopLevelIndexAndFilter();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Two chunks of `BlockBasedTableOptions` C API coverage (see [c.h gap discussion]), each its own commit:

**1. Auto-readahead tuning**
- `setMaxAutoReadaheadSize`/`getMaxAutoReadaheadSize` (`MemorySize`)
- `setInitialAutoReadaheadSize`/`getInitialAutoReadaheadSize` (`MemorySize`)
- `setNumFileReadsForAutoReadahead`/`getNumFileReadsForAutoReadahead` (`long`)

Controls how aggressively RocksDB prefetches sequential SST reads: readahead starts at the initial size and doubles after every N sequential file reads, capped at the max size. The two size-based setters follow `setBlockSize`'s existing `size_t` ↔ `MemorySize` pattern; all three have both a setter and getter in `c.h`.

**2. Cache pinning and priority**
- New `PinningTier` enum (`FALLBACK`/`NONE`/`FLUSHED_AND_SIMILAR`/`ALL`, per `table.h`) shared by `setTopLevelIndexPinningTier`, `setPartitionPinningTier`, `setUnpartitionedPinningTier` — these are setter-only in `c.h` (part of the auto-generated "BlockBasedOptions simple" subset), no getters exist
- `setCacheIndexAndFilterBlocksWithHighPriority`, extending the already-mapped `setCacheIndexAndFilterBlocks`
- `setPinL0FilterAndIndexBlocksInCache`/`setPinTopLevelIndexAndFilter` — the two deprecated booleans the tier-based settings fall back to at `PinningTier.FALLBACK` (the default); both have getters, mapped both ways

Next planned chunk: block layout tuning (`block_restart_interval`, `metadata_block_size`, etc.) — no new types needed there either.

## Test plan
- [x] `autoReadaheadTuning_allowsReadWrite`, `cachePinningAndPriority_allowsReadWrite` — each opens a real DB with the full chunk configured and does a put/get
- [x] Round-trip tests for every setter/getter pair
- [x] `./mvnw -pl core -am test` — 1019 tests, 0 failures, 0 errors
- [x] `./mvnw javadoc:javadoc -pl core` — zero output