### PR TITLE
feat: add FifoCompactionOptions and UniversalCompactionOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `getSeparateKeyValueInDataBlock`.
 - `FifoCompactionOptions`: new wrapper for FIFO compaction, attached via `Options#setCompactionStyle`
   (new `Options.CompactionStyle` enum) and `Options#setFifoCompactionOptions`.
+- `UniversalCompactionOptions`: new wrapper for universal compaction (new `StopStyle` enum),
+  attached via `Options#setCompactionStyle` and `Options#setUniversalCompactionOptions`.
 
 ## [0.10] — 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `setMetadataBlockSize`/`getMetadataBlockSize`, `setBlockSizeDeviation`/`getBlockSizeDeviation`,
   `setUseDeltaEncoding`/`getUseDeltaEncoding`, `setSeparateKeyValueInDataBlock`/
   `getSeparateKeyValueInDataBlock`.
+- `FifoCompactionOptions`: new wrapper for FIFO compaction, attached via `Options#setCompactionStyle`
+  (new `Options.CompactionStyle` enum) and `Options#setFifoCompactionOptions`.
 
 ## [0.10] — 2026-08-30
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/FifoCompactionOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/FifoCompactionOptions.java
@@ -1,0 +1,207 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/// FFM wrapper for `rocksdb_fifo_compaction_options_t`.
+///
+/// Attach via [Options#setFifoCompactionOptions(FifoCompactionOptions)] after also setting
+/// [Options#setCompactionStyle(Options.CompactionStyle)] to [Options.CompactionStyle#FIFO] --
+/// RocksDB ignores these settings under any other compaction style. `FifoCompactionOptions`
+/// may be closed once attached; RocksDB copies the underlying struct by value.
+///
+/// ```
+/// try (var fifo = FifoCompactionOptions.newFifoCompactionOptions()
+///         .setMaxTableFilesSize(MemorySize.ofGB(1));
+///      var opts = Options.newOptions()
+///          .setCreateIfMissing(true)
+///          .setCompactionStyle(Options.CompactionStyle.FIFO)
+///          .setFifoCompactionOptions(fifo)) {
+///     ...
+/// }
+/// ```
+public final class FifoCompactionOptions extends NativeObject {
+
+	/// `rocksdb_fifo_compaction_options_t* rocksdb_fifo_compaction_options_create(void);`
+	private static final MethodHandle MH_CREATE;
+	/// `void rocksdb_fifo_compaction_options_destroy(rocksdb_fifo_compaction_options_t* fifo_opts);`
+	private static final MethodHandle MH_DESTROY;
+	/// `void rocksdb_fifo_compaction_options_set_allow_compaction(rocksdb_fifo_compaction_options_t* fifo_opts, unsigned char allow_compaction);`
+	private static final MethodHandle MH_SET_ALLOW_COMPACTION;
+	/// `unsigned char rocksdb_fifo_compaction_options_get_allow_compaction(rocksdb_fifo_compaction_options_t* fifo_opts);`
+	private static final MethodHandle MH_GET_ALLOW_COMPACTION;
+	/// `void rocksdb_fifo_compaction_options_set_max_table_files_size(rocksdb_fifo_compaction_options_t* fifo_opts, uint64_t size);`
+	private static final MethodHandle MH_SET_MAX_TABLE_FILES_SIZE;
+	/// `uint64_t rocksdb_fifo_compaction_options_get_max_table_files_size(rocksdb_fifo_compaction_options_t* fifo_opts);`
+	private static final MethodHandle MH_GET_MAX_TABLE_FILES_SIZE;
+	/// `void rocksdb_fifo_compaction_options_set_max_data_files_size(rocksdb_fifo_compaction_options_t* fifo_opts, uint64_t size);`
+	private static final MethodHandle MH_SET_MAX_DATA_FILES_SIZE;
+	/// `uint64_t rocksdb_fifo_compaction_options_get_max_data_files_size(rocksdb_fifo_compaction_options_t* fifo_opts);`
+	private static final MethodHandle MH_GET_MAX_DATA_FILES_SIZE;
+	/// `void rocksdb_fifo_compaction_options_set_use_kv_ratio_compaction(rocksdb_fifo_compaction_options_t* fifo_opts, unsigned char use_kv_ratio_compaction);`
+	private static final MethodHandle MH_SET_USE_KV_RATIO_COMPACTION;
+	/// `unsigned char rocksdb_fifo_compaction_options_get_use_kv_ratio_compaction(rocksdb_fifo_compaction_options_t* fifo_opts);`
+	private static final MethodHandle MH_GET_USE_KV_RATIO_COMPACTION;
+
+	static {
+		MH_CREATE = NativeLibrary.lookup("rocksdb_fifo_compaction_options_create",
+				FunctionDescriptor.of(ValueLayout.ADDRESS));
+
+		MH_DESTROY = NativeLibrary.lookup("rocksdb_fifo_compaction_options_destroy",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+		MH_SET_ALLOW_COMPACTION = NativeLibrary.lookup("rocksdb_fifo_compaction_options_set_allow_compaction",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_ALLOW_COMPACTION = NativeLibrary.lookup("rocksdb_fifo_compaction_options_get_allow_compaction",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_MAX_TABLE_FILES_SIZE = NativeLibrary.lookup(
+				"rocksdb_fifo_compaction_options_set_max_table_files_size",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_MAX_TABLE_FILES_SIZE = NativeLibrary.lookup(
+				"rocksdb_fifo_compaction_options_get_max_table_files_size",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_MAX_DATA_FILES_SIZE = NativeLibrary.lookup(
+				"rocksdb_fifo_compaction_options_set_max_data_files_size",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_MAX_DATA_FILES_SIZE = NativeLibrary.lookup(
+				"rocksdb_fifo_compaction_options_get_max_data_files_size",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_USE_KV_RATIO_COMPACTION = NativeLibrary.lookup(
+				"rocksdb_fifo_compaction_options_set_use_kv_ratio_compaction",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_USE_KV_RATIO_COMPACTION = NativeLibrary.lookup(
+				"rocksdb_fifo_compaction_options_get_use_kv_ratio_compaction",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+	}
+
+	private FifoCompactionOptions(MemorySegment ptr) {
+		super(ptr);
+	}
+
+	/// Creates FIFO compaction options with RocksDB defaults.
+	///
+	/// @return a new instance; caller must close it
+	public static FifoCompactionOptions newFifoCompactionOptions() {
+		try {
+			return new FifoCompactionOptions((MemorySegment) MH_CREATE.invokeExact());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("fifo_compaction_options create failed", t);
+		}
+	}
+
+	/// If true, allows compacting the oldest files into a single, larger file once the total
+	/// size exceeds [#setMaxTableFilesSize] instead of just dropping the oldest file. Default:
+	/// false.
+	///
+	/// @param value `true` to allow compacting old files together instead of dropping them
+	/// @return `this` for chaining
+	public FifoCompactionOptions setAllowCompaction(boolean value) {
+		try {
+			MH_SET_ALLOW_COMPACTION.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setAllowCompaction failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether compacting old files together is allowed.
+	///
+	/// @return `true` if compacting old files together is allowed
+	public boolean getAllowCompaction() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_ALLOW_COMPACTION.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getAllowCompaction failed", t);
+		}
+	}
+
+	/// Once the total size of all SST files exceeds this, the oldest file is dropped (or, with
+	/// [#setAllowCompaction], compacted). Default: unlimited (`0`, FIFO compaction disabled by
+	/// size).
+	///
+	/// @param size maximum total size of all SST files
+	/// @return `this` for chaining
+	public FifoCompactionOptions setMaxTableFilesSize(MemorySize size) {
+		try {
+			MH_SET_MAX_TABLE_FILES_SIZE.invokeExact(ptr(), size.toBytes());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setMaxTableFilesSize failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured maximum total size of all SST files.
+	///
+	/// @return current maximum total SST file size
+	public MemorySize getMaxTableFilesSize() {
+		try {
+			return MemorySize.ofBytes((long) MH_GET_MAX_TABLE_FILES_SIZE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getMaxTableFilesSize failed", t);
+		}
+	}
+
+	/// Upper bound on the total size of data files (excludes metadata like index/filter
+	/// blocks) before the oldest file is dropped. Default: unlimited (`0`).
+	///
+	/// @param size maximum total size of data files
+	/// @return `this` for chaining
+	public FifoCompactionOptions setMaxDataFilesSize(MemorySize size) {
+		try {
+			MH_SET_MAX_DATA_FILES_SIZE.invokeExact(ptr(), size.toBytes());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setMaxDataFilesSize failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured maximum total size of data files.
+	///
+	/// @return current maximum total data file size
+	public MemorySize getMaxDataFilesSize() {
+		try {
+			return MemorySize.ofBytes((long) MH_GET_MAX_DATA_FILES_SIZE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getMaxDataFilesSize failed", t);
+		}
+	}
+
+	/// If true, uses the key-value ratio (rather than raw file size) to decide when to drop
+	/// the oldest file. Default: false.
+	///
+	/// @param value `true` to use the key-value ratio for FIFO compaction decisions
+	/// @return `this` for chaining
+	public FifoCompactionOptions setUseKvRatioCompaction(boolean value) {
+		try {
+			MH_SET_USE_KV_RATIO_COMPACTION.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setUseKvRatioCompaction failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether the key-value ratio is used for FIFO compaction decisions.
+	///
+	/// @return `true` if the key-value ratio is used for FIFO compaction decisions
+	public boolean getUseKvRatioCompaction() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_USE_KV_RATIO_COMPACTION.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getUseKvRatioCompaction failed", t);
+		}
+	}
+
+	@Override
+	protected void tryClose(MemorySegment ptr) throws Throwable {
+		MH_DESTROY.invokeExact(ptr);
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
@@ -51,6 +51,8 @@ public final class Options extends NativeObject {
 	private static final MethodHandle MH_GET_COMPACTION_STYLE;
 	/// `void rocksdb_options_set_fifo_compaction_options(rocksdb_options_t* opt, rocksdb_fifo_compaction_options_t* fifo);`
 	private static final MethodHandle MH_SET_FIFO_COMPACTION_OPTIONS;
+	/// `void rocksdb_options_set_universal_compaction_options(rocksdb_options_t*, rocksdb_universal_compaction_options_t*);`
+	private static final MethodHandle MH_SET_UNIVERSAL_COMPACTION_OPTIONS;
 	/// `void rocksdb_options_set_enable_blob_files(rocksdb_options_t* opt, unsigned char val);`
 	private static final MethodHandle MH_SET_ENABLE_BLOB_FILES;
 	/// `unsigned char rocksdb_options_get_enable_blob_files(rocksdb_options_t* opt);`
@@ -177,6 +179,10 @@ public final class Options extends NativeObject {
 				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
 
 		MH_SET_FIFO_COMPACTION_OPTIONS = NativeLibrary.lookup("rocksdb_options_set_fifo_compaction_options",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+		MH_SET_UNIVERSAL_COMPACTION_OPTIONS = NativeLibrary.lookup(
+				"rocksdb_options_set_universal_compaction_options",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
 		MH_SET_ENABLE_BLOB_FILES = NativeLibrary.lookup("rocksdb_options_set_enable_blob_files",
@@ -452,7 +458,8 @@ public final class Options extends NativeObject {
 		/// general-purpose read/write/space balance.
 		LEVEL(0),
 		/// Merges files of similar size, minimizing write amplification at the cost of higher
-		/// read/space amplification and periodic large compactions.
+		/// read/space amplification and periodic large compactions. Configure further via
+		/// [#setUniversalCompactionOptions].
 		UNIVERSAL(1),
 		/// First-in-first-out: never compacts, just drops (or, with
 		/// [FifoCompactionOptions#setAllowCompaction], compacts) the oldest SST once a size
@@ -511,6 +518,21 @@ public final class Options extends NativeObject {
 			MH_SET_FIFO_COMPACTION_OPTIONS.invokeExact(ptr(), fifoOptions.ptr());
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("setFifoCompactionOptions failed", t);
+		}
+		return this;
+	}
+
+	/// Configures universal compaction. Only takes effect when [#setCompactionStyle] is
+	/// [CompactionStyle#UNIVERSAL]. RocksDB copies the config internally; `universalOptions`
+	/// may be closed after this call.
+	///
+	/// @param universalOptions the universal compaction options to apply
+	/// @return `this` for chaining
+	public Options setUniversalCompactionOptions(UniversalCompactionOptions universalOptions) {
+		try {
+			MH_SET_UNIVERSAL_COMPACTION_OPTIONS.invokeExact(ptr(), universalOptions.ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setUniversalCompactionOptions failed", t);
 		}
 		return this;
 	}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/Options.java
@@ -45,6 +45,12 @@ public final class Options extends NativeObject {
 	private static final MethodHandle MH_SET_COMPRESSION;
 	/// `int rocksdb_options_get_compression(rocksdb_options_t*);`
 	private static final MethodHandle MH_GET_COMPRESSION;
+	/// `void rocksdb_options_set_compaction_style(rocksdb_options_t*, int);`
+	private static final MethodHandle MH_SET_COMPACTION_STYLE;
+	/// `int rocksdb_options_get_compaction_style(rocksdb_options_t*);`
+	private static final MethodHandle MH_GET_COMPACTION_STYLE;
+	/// `void rocksdb_options_set_fifo_compaction_options(rocksdb_options_t* opt, rocksdb_fifo_compaction_options_t* fifo);`
+	private static final MethodHandle MH_SET_FIFO_COMPACTION_OPTIONS;
 	/// `void rocksdb_options_set_enable_blob_files(rocksdb_options_t* opt, unsigned char val);`
 	private static final MethodHandle MH_SET_ENABLE_BLOB_FILES;
 	/// `unsigned char rocksdb_options_get_enable_blob_files(rocksdb_options_t* opt);`
@@ -163,6 +169,15 @@ public final class Options extends NativeObject {
 
 		MH_GET_COMPRESSION = NativeLibrary.lookup("rocksdb_options_get_compression",
 				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_COMPACTION_STYLE = NativeLibrary.lookup("rocksdb_options_set_compaction_style",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_COMPACTION_STYLE = NativeLibrary.lookup("rocksdb_options_get_compaction_style",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_FIFO_COMPACTION_OPTIONS = NativeLibrary.lookup("rocksdb_options_set_fifo_compaction_options",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
 		MH_SET_ENABLE_BLOB_FILES = NativeLibrary.lookup("rocksdb_options_set_enable_blob_files",
 				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
@@ -428,6 +443,76 @@ public final class Options extends NativeObject {
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("getCompression failed", t);
 		}
+	}
+
+	/// Which strategy RocksDB uses to pick which SST files to compact and when, per `c.h`'s
+	/// anonymous `rocksdb_*_compaction` enum (backed by C++'s `CompactionStyle`).
+	public enum CompactionStyle {
+		/// The default: organizes SSTs into levels of exponentially increasing size: good
+		/// general-purpose read/write/space balance.
+		LEVEL(0),
+		/// Merges files of similar size, minimizing write amplification at the cost of higher
+		/// read/space amplification and periodic large compactions.
+		UNIVERSAL(1),
+		/// First-in-first-out: never compacts, just drops (or, with
+		/// [FifoCompactionOptions#setAllowCompaction], compacts) the oldest SST once a size
+		/// bound is exceeded. For TTL-like or ring-buffer workloads. Configure further via
+		/// [#setFifoCompactionOptions].
+		FIFO(2);
+
+		final int value;
+
+		CompactionStyle(int value) {
+			this.value = value;
+		}
+
+		static CompactionStyle fromValue(int value) {
+			return switch (value) {
+				case 0 -> LEVEL;
+				case 1 -> UNIVERSAL;
+				case 2 -> FIFO;
+				default -> throw new IllegalArgumentException("Unknown CompactionStyle value: " + value);
+			};
+		}
+	}
+
+	/// Sets the compaction style. Default: [CompactionStyle#LEVEL].
+	///
+	/// @param style the compaction style to use
+	/// @return `this` for chaining
+	public Options setCompactionStyle(CompactionStyle style) {
+		try {
+			MH_SET_COMPACTION_STYLE.invokeExact(ptr(), style.value);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setCompactionStyle failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured compaction style.
+	///
+	/// @return current compaction style
+	public CompactionStyle getCompactionStyle() {
+		try {
+			return CompactionStyle.fromValue((int) MH_GET_COMPACTION_STYLE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getCompactionStyle failed", t);
+		}
+	}
+
+	/// Configures FIFO compaction. Only takes effect when [#setCompactionStyle] is
+	/// [CompactionStyle#FIFO]. RocksDB copies the config internally; `fifoOptions` may be
+	/// closed after this call.
+	///
+	/// @param fifoOptions the FIFO compaction options to apply
+	/// @return `this` for chaining
+	public Options setFifoCompactionOptions(FifoCompactionOptions fifoOptions) {
+		try {
+			MH_SET_FIFO_COMPACTION_OPTIONS.invokeExact(ptr(), fifoOptions.ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setFifoCompactionOptions failed", t);
+		}
+		return this;
 	}
 
 	/// Configures block-based table format for this DB.

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/UniversalCompactionOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/UniversalCompactionOptions.java
@@ -1,0 +1,303 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/// FFM wrapper for `rocksdb_universal_compaction_options_t`.
+///
+/// Attach via [Options#setUniversalCompactionOptions(UniversalCompactionOptions)] after also
+/// setting [Options#setCompactionStyle(Options.CompactionStyle)] to
+/// [Options.CompactionStyle#UNIVERSAL] -- RocksDB ignores these settings under any other
+/// compaction style. `UniversalCompactionOptions` may be closed once attached; RocksDB copies
+/// the underlying struct by value.
+///
+/// ```
+/// try (var universal = UniversalCompactionOptions.newUniversalCompactionOptions()
+///         .setMaxSizeAmplificationPercent(200);
+///      var opts = Options.newOptions()
+///          .setCreateIfMissing(true)
+///          .setCompactionStyle(Options.CompactionStyle.UNIVERSAL)
+///          .setUniversalCompactionOptions(universal)) {
+///     ...
+/// }
+/// ```
+public final class UniversalCompactionOptions extends NativeObject {
+
+	/// When a universal compaction run stops adding more files to the batch, per
+	/// `universal_compaction.h`'s `CompactionStopStyle`.
+	public enum StopStyle {
+		/// Stop once the next candidate file's size is not "similar" to the files already
+		/// picked (per [#setSizeRatio]).
+		SIMILAR_SIZE(0),
+		/// Stop once the total size of files already picked exceeds the next candidate file's
+		/// size. Default.
+		TOTAL_SIZE(1);
+
+		final int value;
+
+		StopStyle(int value) {
+			this.value = value;
+		}
+
+		static StopStyle fromValue(int value) {
+			return switch (value) {
+				case 0 -> SIMILAR_SIZE;
+				case 1 -> TOTAL_SIZE;
+				default -> throw new IllegalArgumentException("Unknown StopStyle value: " + value);
+			};
+		}
+	}
+
+	/// `rocksdb_universal_compaction_options_t* rocksdb_universal_compaction_options_create(void);`
+	private static final MethodHandle MH_CREATE;
+	/// `void rocksdb_universal_compaction_options_destroy(rocksdb_universal_compaction_options_t*);`
+	private static final MethodHandle MH_DESTROY;
+	/// `void rocksdb_universal_compaction_options_set_size_ratio(rocksdb_universal_compaction_options_t*, int);`
+	private static final MethodHandle MH_SET_SIZE_RATIO;
+	/// `int rocksdb_universal_compaction_options_get_size_ratio(rocksdb_universal_compaction_options_t*);`
+	private static final MethodHandle MH_GET_SIZE_RATIO;
+	/// `void rocksdb_universal_compaction_options_set_min_merge_width(rocksdb_universal_compaction_options_t*, int);`
+	private static final MethodHandle MH_SET_MIN_MERGE_WIDTH;
+	/// `int rocksdb_universal_compaction_options_get_min_merge_width(rocksdb_universal_compaction_options_t*);`
+	private static final MethodHandle MH_GET_MIN_MERGE_WIDTH;
+	/// `void rocksdb_universal_compaction_options_set_max_merge_width(rocksdb_universal_compaction_options_t*, int);`
+	private static final MethodHandle MH_SET_MAX_MERGE_WIDTH;
+	/// `int rocksdb_universal_compaction_options_get_max_merge_width(rocksdb_universal_compaction_options_t*);`
+	private static final MethodHandle MH_GET_MAX_MERGE_WIDTH;
+	/// `void rocksdb_universal_compaction_options_set_max_size_amplification_percent(rocksdb_universal_compaction_options_t*, int);`
+	private static final MethodHandle MH_SET_MAX_SIZE_AMPLIFICATION_PERCENT;
+	/// `int rocksdb_universal_compaction_options_get_max_size_amplification_percent(rocksdb_universal_compaction_options_t*);`
+	private static final MethodHandle MH_GET_MAX_SIZE_AMPLIFICATION_PERCENT;
+	/// `void rocksdb_universal_compaction_options_set_compression_size_percent(rocksdb_universal_compaction_options_t*, int);`
+	private static final MethodHandle MH_SET_COMPRESSION_SIZE_PERCENT;
+	/// `int rocksdb_universal_compaction_options_get_compression_size_percent(rocksdb_universal_compaction_options_t*);`
+	private static final MethodHandle MH_GET_COMPRESSION_SIZE_PERCENT;
+	/// `void rocksdb_universal_compaction_options_set_stop_style(rocksdb_universal_compaction_options_t*, int);`
+	private static final MethodHandle MH_SET_STOP_STYLE;
+	/// `int rocksdb_universal_compaction_options_get_stop_style(rocksdb_universal_compaction_options_t*);`
+	private static final MethodHandle MH_GET_STOP_STYLE;
+
+	static {
+		MH_CREATE = NativeLibrary.lookup("rocksdb_universal_compaction_options_create",
+				FunctionDescriptor.of(ValueLayout.ADDRESS));
+
+		MH_DESTROY = NativeLibrary.lookup("rocksdb_universal_compaction_options_destroy",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+		MH_SET_SIZE_RATIO = NativeLibrary.lookup("rocksdb_universal_compaction_options_set_size_ratio",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_SIZE_RATIO = NativeLibrary.lookup("rocksdb_universal_compaction_options_get_size_ratio",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_MIN_MERGE_WIDTH = NativeLibrary.lookup("rocksdb_universal_compaction_options_set_min_merge_width",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_MIN_MERGE_WIDTH = NativeLibrary.lookup("rocksdb_universal_compaction_options_get_min_merge_width",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_MAX_MERGE_WIDTH = NativeLibrary.lookup("rocksdb_universal_compaction_options_set_max_merge_width",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_MAX_MERGE_WIDTH = NativeLibrary.lookup("rocksdb_universal_compaction_options_get_max_merge_width",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_MAX_SIZE_AMPLIFICATION_PERCENT = NativeLibrary.lookup(
+				"rocksdb_universal_compaction_options_set_max_size_amplification_percent",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_MAX_SIZE_AMPLIFICATION_PERCENT = NativeLibrary.lookup(
+				"rocksdb_universal_compaction_options_get_max_size_amplification_percent",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_COMPRESSION_SIZE_PERCENT = NativeLibrary.lookup(
+				"rocksdb_universal_compaction_options_set_compression_size_percent",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_COMPRESSION_SIZE_PERCENT = NativeLibrary.lookup(
+				"rocksdb_universal_compaction_options_get_compression_size_percent",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+		MH_SET_STOP_STYLE = NativeLibrary.lookup("rocksdb_universal_compaction_options_set_stop_style",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+
+		MH_GET_STOP_STYLE = NativeLibrary.lookup("rocksdb_universal_compaction_options_get_stop_style",
+				FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+	}
+
+	private UniversalCompactionOptions(MemorySegment ptr) {
+		super(ptr);
+	}
+
+	/// Creates universal compaction options with RocksDB defaults.
+	///
+	/// @return a new instance; caller must close it
+	public static UniversalCompactionOptions newUniversalCompactionOptions() {
+		try {
+			return new UniversalCompactionOptions((MemorySegment) MH_CREATE.invokeExact());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("universal_compaction_options create failed", t);
+		}
+	}
+
+	/// Percentage flexibility when merging files of different sizes: a candidate file is
+	/// considered "similar enough" to merge with the files already picked if its size is
+	/// within this percentage of their total. Larger values merge more aggressively. Default: 1.
+	///
+	/// @param percent size-similarity threshold, as a percentage
+	/// @return `this` for chaining
+	public UniversalCompactionOptions setSizeRatio(int percent) {
+		try {
+			MH_SET_SIZE_RATIO.invokeExact(ptr(), percent);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setSizeRatio failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured size-ratio percentage.
+	///
+	/// @return current size-ratio percentage
+	public int getSizeRatio() {
+		try {
+			return (int) MH_GET_SIZE_RATIO.invokeExact(ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getSizeRatio failed", t);
+		}
+	}
+
+	/// Minimum number of files a compaction run must merge together. Default: 2.
+	///
+	/// @param width minimum number of files per compaction run
+	/// @return `this` for chaining
+	public UniversalCompactionOptions setMinMergeWidth(int width) {
+		try {
+			MH_SET_MIN_MERGE_WIDTH.invokeExact(ptr(), width);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setMinMergeWidth failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured minimum merge width.
+	///
+	/// @return current minimum merge width
+	public int getMinMergeWidth() {
+		try {
+			return (int) MH_GET_MIN_MERGE_WIDTH.invokeExact(ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getMinMergeWidth failed", t);
+		}
+	}
+
+	/// Maximum number of files a single compaction run may merge together. The underlying
+	/// C++ field is `unsigned int`, defaulting to `UINT_MAX` (unbounded), but the C API's
+	/// setter/getter are a plain signed `int` -- reading this before ever setting it returns
+	/// `-1` (`UINT_MAX`'s bit pattern reinterpreted as signed), not a large positive number.
+	///
+	/// @param width maximum number of files per compaction run
+	/// @return `this` for chaining
+	public UniversalCompactionOptions setMaxMergeWidth(int width) {
+		try {
+			MH_SET_MAX_MERGE_WIDTH.invokeExact(ptr(), width);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setMaxMergeWidth failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured maximum merge width.
+	///
+	/// @return current maximum merge width
+	public int getMaxMergeWidth() {
+		try {
+			return (int) MH_GET_MAX_MERGE_WIDTH.invokeExact(ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getMaxMergeWidth failed", t);
+		}
+	}
+
+	/// Once the estimated space amplification (extra space used by non-bottommost data, as a
+	/// percentage of bottommost data size) exceeds this, a full compaction is triggered
+	/// regardless of [#setSizeRatio]/[#setMinMergeWidth]. Default: 200 (files can take up to
+	/// 3x the space of the useful data).
+	///
+	/// @param percent maximum tolerated space amplification, as a percentage
+	/// @return `this` for chaining
+	public UniversalCompactionOptions setMaxSizeAmplificationPercent(int percent) {
+		try {
+			MH_SET_MAX_SIZE_AMPLIFICATION_PERCENT.invokeExact(ptr(), percent);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setMaxSizeAmplificationPercent failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured maximum size amplification percentage.
+	///
+	/// @return current maximum size amplification percentage
+	public int getMaxSizeAmplificationPercent() {
+		try {
+			return (int) MH_GET_MAX_SIZE_AMPLIFICATION_PERCENT.invokeExact(ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getMaxSizeAmplificationPercent failed", t);
+		}
+	}
+
+	/// Percentage of the compaction size that is allowed to bypass the size-amplification
+	/// ratio check and use a cheaper compression level. Default: -1 (disabled: all compacted
+	/// data uses the same compression as everything else).
+	///
+	/// @param percent percentage of compaction size using a cheaper compression level
+	/// @return `this` for chaining
+	public UniversalCompactionOptions setCompressionSizePercent(int percent) {
+		try {
+			MH_SET_COMPRESSION_SIZE_PERCENT.invokeExact(ptr(), percent);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setCompressionSizePercent failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured compression size percentage.
+	///
+	/// @return current compression size percentage
+	public int getCompressionSizePercent() {
+		try {
+			return (int) MH_GET_COMPRESSION_SIZE_PERCENT.invokeExact(ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getCompressionSizePercent failed", t);
+		}
+	}
+
+	/// Sets when a compaction run stops adding more files. Default: [StopStyle#TOTAL_SIZE].
+	///
+	/// @param stopStyle the stop style to use
+	/// @return `this` for chaining
+	public UniversalCompactionOptions setStopStyle(StopStyle stopStyle) {
+		try {
+			MH_SET_STOP_STYLE.invokeExact(ptr(), stopStyle.value);
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setStopStyle failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured stop style.
+	///
+	/// @return current stop style
+	public StopStyle getStopStyle() {
+		try {
+			return StopStyle.fromValue((int) MH_GET_STOP_STYLE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getStopStyle failed", t);
+		}
+	}
+
+	@Override
+	protected void tryClose(MemorySegment ptr) throws Throwable {
+		MH_DESTROY.invokeExact(ptr);
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/FifoCompactionOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/FifoCompactionOptionsTest.java
@@ -1,0 +1,100 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FifoCompactionOptionsTest {
+
+	@Test
+	void fifoCompaction_allowsReadWrite(@TempDir Path dir) {
+		// Given
+		try (var fifo = FifoCompactionOptions.newFifoCompactionOptions()
+				     .setMaxTableFilesSize(MemorySize.ofMB(64))
+				     .setAllowCompaction(true);
+		     var opts = Options.newOptions()
+				     .setCreateIfMissing(true)
+				     .setCompactionStyle(Options.CompactionStyle.FIFO)
+				     .setFifoCompactionOptions(fifo);
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+
+			// When
+			var result = db.get("k".getBytes());
+
+			// Then
+			assertThat(result).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void setAllowCompaction_roundTrips() {
+		// Given
+		try (var fifo = FifoCompactionOptions.newFifoCompactionOptions().setAllowCompaction(true)) {
+
+			// When
+			var result = fifo.getAllowCompaction();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setMaxTableFilesSize_roundTrips() {
+		// Given
+		try (var fifo = FifoCompactionOptions.newFifoCompactionOptions()
+				     .setMaxTableFilesSize(MemorySize.ofMB(64))) {
+
+			// When
+			var result = fifo.getMaxTableFilesSize();
+
+			// Then
+			assertThat(result).isEqualTo(MemorySize.ofMB(64));
+		}
+	}
+
+	@Test
+	void setMaxDataFilesSize_roundTrips() {
+		// Given
+		try (var fifo = FifoCompactionOptions.newFifoCompactionOptions()
+				     .setMaxDataFilesSize(MemorySize.ofMB(32))) {
+
+			// When
+			var result = fifo.getMaxDataFilesSize();
+
+			// Then
+			assertThat(result).isEqualTo(MemorySize.ofMB(32));
+		}
+	}
+
+	@Test
+	void setUseKvRatioCompaction_roundTrips() {
+		// Given
+		try (var fifo = FifoCompactionOptions.newFifoCompactionOptions().setUseKvRatioCompaction(true)) {
+
+			// When
+			var result = fifo.getUseKvRatioCompaction();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setCompactionStyle_roundTrips() {
+		// Given
+		try (var opts = Options.newOptions().setCompactionStyle(Options.CompactionStyle.FIFO)) {
+
+			// When
+			var result = opts.getCompactionStyle();
+
+			// Then
+			assertThat(result).isEqualTo(Options.CompactionStyle.FIFO);
+		}
+	}
+}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/UniversalCompactionOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/UniversalCompactionOptionsTest.java
@@ -1,0 +1,131 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UniversalCompactionOptionsTest {
+
+	@Test
+	void universalCompaction_allowsReadWrite(@TempDir Path dir) {
+		// Given
+		try (var universal = UniversalCompactionOptions.newUniversalCompactionOptions()
+				     .setMinMergeWidth(2)
+				     .setMaxMergeWidth(20)
+				     .setMaxSizeAmplificationPercent(200)
+				     .setSizeRatio(1)
+				     .setCompressionSizePercent(-1)
+				     .setStopStyle(UniversalCompactionOptions.StopStyle.TOTAL_SIZE);
+		     var opts = Options.newOptions()
+				     .setCreateIfMissing(true)
+				     .setCompactionStyle(Options.CompactionStyle.UNIVERSAL)
+				     .setUniversalCompactionOptions(universal);
+		     var db = RocksDB.openReadWrite(opts, dir)) {
+
+			db.put("k".getBytes(), "v".getBytes());
+
+			// When
+			var result = db.get("k".getBytes());
+
+			// Then
+			assertThat(result).isEqualTo("v".getBytes());
+		}
+	}
+
+	@Test
+	void setSizeRatio_roundTrips() {
+		// Given
+		try (var universal = UniversalCompactionOptions.newUniversalCompactionOptions().setSizeRatio(5)) {
+
+			// When
+			var result = universal.getSizeRatio();
+
+			// Then
+			assertThat(result).isEqualTo(5);
+		}
+	}
+
+	@Test
+	void setMinMergeWidth_roundTrips() {
+		// Given
+		try (var universal = UniversalCompactionOptions.newUniversalCompactionOptions().setMinMergeWidth(3)) {
+
+			// When
+			var result = universal.getMinMergeWidth();
+
+			// Then
+			assertThat(result).isEqualTo(3);
+		}
+	}
+
+	@Test
+	void setMaxMergeWidth_roundTrips() {
+		// Given
+		try (var universal = UniversalCompactionOptions.newUniversalCompactionOptions().setMaxMergeWidth(10)) {
+
+			// When
+			var result = universal.getMaxMergeWidth();
+
+			// Then
+			assertThat(result).isEqualTo(10);
+		}
+	}
+
+	@Test
+	void setMaxSizeAmplificationPercent_roundTrips() {
+		// Given
+		try (var universal = UniversalCompactionOptions.newUniversalCompactionOptions()
+				     .setMaxSizeAmplificationPercent(150)) {
+
+			// When
+			var result = universal.getMaxSizeAmplificationPercent();
+
+			// Then
+			assertThat(result).isEqualTo(150);
+		}
+	}
+
+	@Test
+	void setCompressionSizePercent_roundTrips() {
+		// Given
+		try (var universal = UniversalCompactionOptions.newUniversalCompactionOptions()
+				     .setCompressionSizePercent(50)) {
+
+			// When
+			var result = universal.getCompressionSizePercent();
+
+			// Then
+			assertThat(result).isEqualTo(50);
+		}
+	}
+
+	@Test
+	void setStopStyle_roundTrips() {
+		// Given
+		try (var universal = UniversalCompactionOptions.newUniversalCompactionOptions()
+				     .setStopStyle(UniversalCompactionOptions.StopStyle.SIMILAR_SIZE)) {
+
+			// When
+			var result = universal.getStopStyle();
+
+			// Then
+			assertThat(result).isEqualTo(UniversalCompactionOptions.StopStyle.SIMILAR_SIZE);
+		}
+	}
+
+	@Test
+	void setCompactionStyle_roundTrips() {
+		// Given
+		try (var opts = Options.newOptions().setCompactionStyle(Options.CompactionStyle.UNIVERSAL)) {
+
+			// When
+			var result = opts.getCompactionStyle();
+
+			// Then
+			assertThat(result).isEqualTo(Options.CompactionStyle.UNIVERSAL);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two previously completely-unmapped compaction-style options classes, each its own commit:

**1. `FifoCompactionOptions`** (0 of 7 setters mapped before this) + the shared prerequisite both chunks need:
- New `Options.CompactionStyle` enum (`LEVEL`/`UNIVERSAL`/`FIFO`, mirrors `c.h`'s anonymous `rocksdb_*_compaction` enum) plus `Options#setCompactionStyle`/`getCompactionStyle` — without this, attaching FIFO/universal sub-options is inert, since RocksDB defaults to `LEVEL` compaction and ignores them
- `FifoCompactionOptions`: `setAllowCompaction`, `setMaxTableFilesSize`, `setMaxDataFilesSize`, `setUseKvRatioCompaction`, each with a getter
- `Options#setFifoCompactionOptions` — the attach point

**2. `UniversalCompactionOptions`** (0 of 10 setters mapped before this):
- `setSizeRatio`, `setMinMergeWidth`, `setMaxMergeWidth`, `setMaxSizeAmplificationPercent`, `setCompressionSizePercent`, each with a getter
- New `StopStyle` enum (`SIMILAR_SIZE`/`TOTAL_SIZE`, per `universal_compaction.h`'s `CompactionStopStyle`) for `setStopStyle`/`getStopStyle`
- `Options#setUniversalCompactionOptions` — the attach point
- Note on `setMaxMergeWidth`: the underlying C++ field is `unsigned int` defaulting to `UINT_MAX`, but the C API's setter/getter are a plain signed `int` — documented on the method since reading it before ever setting it returns `-1`, not a large positive number

**Ownership**: neither class needs `transferOwnership()` — confirmed via `db/c.cc` that both `rocksdb_options_set_fifo_compaction_options`/`_set_universal_compaction_options` copy the underlying struct *by value* into `Options`'s own field, unlike `FilterPolicy`/`SliceTransform`'s real `shared_ptr` ownership handoff. Both classes may be closed immediately after attaching, same as `BlockBasedTableOptions`.

## Test plan
- [x] `fifoCompaction_allowsReadWrite`, `universalCompaction_allowsReadWrite` — each opens a real DB with the compaction style + full option set configured and does a put/get
- [x] Round-trip tests for every setter/getter pair, plus `Options.CompactionStyle` round-trips in both test files
- [x] `./mvnw -pl core -am test` — 1040 tests, 0 failures, 0 errors
- [x] `./mvnw javadoc:javadoc -pl core` — zero output (verified both the FIFO-only intermediate state and the full combined state, since `CompactionStyle.UNIVERSAL`'s javadoc cross-references `UniversalCompactionOptions` added in the second commit)