### PR TITLE
feat: add EnvOptions, wire into SstFileWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (new `Options.CompactionStyle` enum) and `Options#setFifoCompactionOptions`.
 - `UniversalCompactionOptions`: new wrapper for universal compaction (new `StopStyle` enum),
   attached via `Options#setCompactionStyle` and `Options#setUniversalCompactionOptions`.
+- `EnvOptions`: new wrapper for `rocksdb_envoptions_t` (mmap/direct I/O, sync cadence, fallocate,
+  readahead, rate limiting), previously completely unmapped. Attached via a new
+  `SstFileWriter.newSstFileWriter(Options, EnvOptions)` overload; the existing single-arg
+  overload keeps using RocksDB's defaults internally.
 
 ## [0.10] — 2026-08-30
 

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/EnvOptions.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/EnvOptions.java
@@ -1,0 +1,470 @@
+package io.github.dfa1.rocksdbffm;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/// FFM wrapper for `rocksdb_envoptions_t`.
+///
+/// Tunes low-level file-I/O behavior (mmap vs. direct I/O, fsync cadence, readahead, ...) for
+/// a single [SstFileWriter] -- distinct from [Env], which selects the pluggable
+/// filesystem/threading environment itself. Attach via
+/// [SstFileWriter#newSstFileWriter(Options, EnvOptions)]. `EnvOptions` may be closed once
+/// passed to that call; RocksDB copies the underlying struct by value.
+///
+/// ```
+/// try (var envOpts = EnvOptions.newEnvOptions().setUseDirectWrites(true);
+///      var opts = Options.newOptions();
+///      var writer = SstFileWriter.newSstFileWriter(opts, envOpts)) {
+///     ...
+/// }
+/// ```
+public final class EnvOptions extends NativeObject {
+
+	/// `rocksdb_envoptions_t* rocksdb_envoptions_create(void);`
+	private static final MethodHandle MH_CREATE;
+	/// `void rocksdb_envoptions_destroy(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_DESTROY;
+	/// `void rocksdb_envoptions_set_use_mmap_reads(rocksdb_envoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_USE_MMAP_READS;
+	/// `unsigned char rocksdb_envoptions_get_use_mmap_reads(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_USE_MMAP_READS;
+	/// `void rocksdb_envoptions_set_use_mmap_writes(rocksdb_envoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_USE_MMAP_WRITES;
+	/// `unsigned char rocksdb_envoptions_get_use_mmap_writes(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_USE_MMAP_WRITES;
+	/// `void rocksdb_envoptions_set_use_direct_reads(rocksdb_envoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_USE_DIRECT_READS;
+	/// `unsigned char rocksdb_envoptions_get_use_direct_reads(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_USE_DIRECT_READS;
+	/// `void rocksdb_envoptions_set_use_direct_writes(rocksdb_envoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_USE_DIRECT_WRITES;
+	/// `unsigned char rocksdb_envoptions_get_use_direct_writes(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_USE_DIRECT_WRITES;
+	/// `void rocksdb_envoptions_set_allow_fallocate(rocksdb_envoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_ALLOW_FALLOCATE;
+	/// `unsigned char rocksdb_envoptions_get_allow_fallocate(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_ALLOW_FALLOCATE;
+	/// `void rocksdb_envoptions_set_fd_cloexec(rocksdb_envoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_FD_CLOEXEC;
+	/// `unsigned char rocksdb_envoptions_get_fd_cloexec(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_FD_CLOEXEC;
+	/// `void rocksdb_envoptions_set_bytes_per_sync(rocksdb_envoptions_t* opt, uint64_t v);`
+	private static final MethodHandle MH_SET_BYTES_PER_SYNC;
+	/// `uint64_t rocksdb_envoptions_get_bytes_per_sync(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_BYTES_PER_SYNC;
+	/// `void rocksdb_envoptions_set_strict_bytes_per_sync(rocksdb_envoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_STRICT_BYTES_PER_SYNC;
+	/// `unsigned char rocksdb_envoptions_get_strict_bytes_per_sync(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_STRICT_BYTES_PER_SYNC;
+	/// `void rocksdb_envoptions_set_fallocate_with_keep_size(rocksdb_envoptions_t* opt, unsigned char v);`
+	private static final MethodHandle MH_SET_FALLOCATE_WITH_KEEP_SIZE;
+	/// `unsigned char rocksdb_envoptions_get_fallocate_with_keep_size(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_FALLOCATE_WITH_KEEP_SIZE;
+	/// `void rocksdb_envoptions_set_compaction_readahead_size(rocksdb_envoptions_t* opt, size_t v);`
+	private static final MethodHandle MH_SET_COMPACTION_READAHEAD_SIZE;
+	/// `size_t rocksdb_envoptions_get_compaction_readahead_size(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_COMPACTION_READAHEAD_SIZE;
+	/// `void rocksdb_envoptions_set_writable_file_max_buffer_size(rocksdb_envoptions_t* opt, size_t v);`
+	private static final MethodHandle MH_SET_WRITABLE_FILE_MAX_BUFFER_SIZE;
+	/// `size_t rocksdb_envoptions_get_writable_file_max_buffer_size(rocksdb_envoptions_t* opt);`
+	private static final MethodHandle MH_GET_WRITABLE_FILE_MAX_BUFFER_SIZE;
+	/// `void rocksdb_envoptions_set_rate_limiter(rocksdb_envoptions_t* opt, rocksdb_ratelimiter_t* rate_limiter);`
+	private static final MethodHandle MH_SET_RATE_LIMITER;
+
+	static {
+		MH_CREATE = NativeLibrary.lookup("rocksdb_envoptions_create",
+				FunctionDescriptor.of(ValueLayout.ADDRESS));
+
+		MH_DESTROY = NativeLibrary.lookup("rocksdb_envoptions_destroy",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+		MH_SET_USE_MMAP_READS = NativeLibrary.lookup("rocksdb_envoptions_set_use_mmap_reads",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_USE_MMAP_READS = NativeLibrary.lookup("rocksdb_envoptions_get_use_mmap_reads",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_USE_MMAP_WRITES = NativeLibrary.lookup("rocksdb_envoptions_set_use_mmap_writes",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_USE_MMAP_WRITES = NativeLibrary.lookup("rocksdb_envoptions_get_use_mmap_writes",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_USE_DIRECT_READS = NativeLibrary.lookup("rocksdb_envoptions_set_use_direct_reads",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_USE_DIRECT_READS = NativeLibrary.lookup("rocksdb_envoptions_get_use_direct_reads",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_USE_DIRECT_WRITES = NativeLibrary.lookup("rocksdb_envoptions_set_use_direct_writes",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_USE_DIRECT_WRITES = NativeLibrary.lookup("rocksdb_envoptions_get_use_direct_writes",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_ALLOW_FALLOCATE = NativeLibrary.lookup("rocksdb_envoptions_set_allow_fallocate",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_ALLOW_FALLOCATE = NativeLibrary.lookup("rocksdb_envoptions_get_allow_fallocate",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_FD_CLOEXEC = NativeLibrary.lookup("rocksdb_envoptions_set_fd_cloexec",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_FD_CLOEXEC = NativeLibrary.lookup("rocksdb_envoptions_get_fd_cloexec",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_BYTES_PER_SYNC = NativeLibrary.lookup("rocksdb_envoptions_set_bytes_per_sync",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_BYTES_PER_SYNC = NativeLibrary.lookup("rocksdb_envoptions_get_bytes_per_sync",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_STRICT_BYTES_PER_SYNC = NativeLibrary.lookup("rocksdb_envoptions_set_strict_bytes_per_sync",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_STRICT_BYTES_PER_SYNC = NativeLibrary.lookup("rocksdb_envoptions_get_strict_bytes_per_sync",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_FALLOCATE_WITH_KEEP_SIZE = NativeLibrary.lookup("rocksdb_envoptions_set_fallocate_with_keep_size",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_BYTE));
+
+		MH_GET_FALLOCATE_WITH_KEEP_SIZE = NativeLibrary.lookup("rocksdb_envoptions_get_fallocate_with_keep_size",
+				FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS));
+
+		MH_SET_COMPACTION_READAHEAD_SIZE = NativeLibrary.lookup(
+				"rocksdb_envoptions_set_compaction_readahead_size",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_COMPACTION_READAHEAD_SIZE = NativeLibrary.lookup(
+				"rocksdb_envoptions_get_compaction_readahead_size",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_WRITABLE_FILE_MAX_BUFFER_SIZE = NativeLibrary.lookup(
+				"rocksdb_envoptions_set_writable_file_max_buffer_size",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+		MH_GET_WRITABLE_FILE_MAX_BUFFER_SIZE = NativeLibrary.lookup(
+				"rocksdb_envoptions_get_writable_file_max_buffer_size",
+				FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+
+		MH_SET_RATE_LIMITER = NativeLibrary.lookup("rocksdb_envoptions_set_rate_limiter",
+				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	}
+
+	private EnvOptions(MemorySegment ptr) {
+		super(ptr);
+	}
+
+	/// Creates env options with RocksDB defaults.
+	///
+	/// @return a new instance; caller must close it
+	public static EnvOptions newEnvOptions() {
+		try {
+			return new EnvOptions((MemorySegment) MH_CREATE.invokeExact());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("envoptions create failed", t);
+		}
+	}
+
+	/// If true, reads go through `mmap` instead of `pread`. Default: platform-dependent
+	/// (`true` on most POSIX platforms). Unlike a regular read, a page fault on an `mmap`-ed
+	/// region past the end of a file that has since been truncated or deleted crashes the
+	/// process instead of returning an I/O error -- prefer direct/buffered reads unless you
+	/// specifically need `mmap`'s zero-copy behavior and control every reader's lifetime.
+	///
+	/// @param value `true` to use `mmap` for reads
+	/// @return `this` for chaining
+	public EnvOptions setUseMmapReads(boolean value) {
+		try {
+			MH_SET_USE_MMAP_READS.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setUseMmapReads failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether reads go through `mmap`.
+	///
+	/// @return `true` if reads go through `mmap`
+	public boolean getUseMmapReads() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_USE_MMAP_READS.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getUseMmapReads failed", t);
+		}
+	}
+
+	/// If true, writes go through `mmap` instead of regular `write` calls. Default: `false`.
+	///
+	/// @param value `true` to use `mmap` for writes
+	/// @return `this` for chaining
+	public EnvOptions setUseMmapWrites(boolean value) {
+		try {
+			MH_SET_USE_MMAP_WRITES.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setUseMmapWrites failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether writes go through `mmap`.
+	///
+	/// @return `true` if writes go through `mmap`
+	public boolean getUseMmapWrites() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_USE_MMAP_WRITES.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getUseMmapWrites failed", t);
+		}
+	}
+
+	/// If true, uses direct I/O (`O_DIRECT`) for reads, bypassing the OS page cache. Avoids
+	/// double-caching the same data in both RocksDB's block cache and the OS page cache, at
+	/// the cost of RocksDB itself now being responsible for readahead the OS would otherwise
+	/// provide. Default: `false`.
+	///
+	/// @param value `true` to use direct I/O for reads
+	/// @return `this` for chaining
+	public EnvOptions setUseDirectReads(boolean value) {
+		try {
+			MH_SET_USE_DIRECT_READS.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setUseDirectReads failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether direct I/O is used for reads.
+	///
+	/// @return `true` if direct I/O is used for reads
+	public boolean getUseDirectReads() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_USE_DIRECT_READS.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getUseDirectReads failed", t);
+		}
+	}
+
+	/// If true, uses direct I/O (`O_DIRECT`) for writes, bypassing the OS page cache. Default:
+	/// `false`.
+	///
+	/// @param value `true` to use direct I/O for writes
+	/// @return `this` for chaining
+	public EnvOptions setUseDirectWrites(boolean value) {
+		try {
+			MH_SET_USE_DIRECT_WRITES.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setUseDirectWrites failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether direct I/O is used for writes.
+	///
+	/// @return `true` if direct I/O is used for writes
+	public boolean getUseDirectWrites() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_USE_DIRECT_WRITES.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getUseDirectWrites failed", t);
+		}
+	}
+
+	/// If true, allows `fallocate` to preallocate disk space for a file before writing to it,
+	/// reducing fragmentation on some filesystems. Default: `true`.
+	///
+	/// @param value `true` to allow `fallocate`
+	/// @return `this` for chaining
+	public EnvOptions setAllowFallocate(boolean value) {
+		try {
+			MH_SET_ALLOW_FALLOCATE.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setAllowFallocate failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether `fallocate` is allowed.
+	///
+	/// @return `true` if `fallocate` is allowed
+	public boolean getAllowFallocate() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_ALLOW_FALLOCATE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getAllowFallocate failed", t);
+		}
+	}
+
+	/// If true, sets the close-on-exec flag on file descriptors RocksDB opens, so they don't
+	/// leak into subprocesses spawned via `fork`/`exec`. Default: `true`.
+	///
+	/// @param value `true` to set close-on-exec on opened file descriptors
+	/// @return `this` for chaining
+	public EnvOptions setFdCloexec(boolean value) {
+		try {
+			MH_SET_FD_CLOEXEC.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setFdCloexec failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether close-on-exec is set on opened file descriptors.
+	///
+	/// @return `true` if close-on-exec is set on opened file descriptors
+	public boolean getFdCloexec() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_FD_CLOEXEC.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getFdCloexec failed", t);
+		}
+	}
+
+	/// Issues a periodic `sync` (via `sync_file_range` on Linux) after every this-many bytes
+	/// written to a single file, smoothing out write latency by avoiding a large buildup of
+	/// dirty pages that would otherwise all get flushed at once. Default: `0` (disabled).
+	///
+	/// @param size number of bytes between periodic syncs
+	/// @return `this` for chaining
+	public EnvOptions setBytesPerSync(MemorySize size) {
+		try {
+			MH_SET_BYTES_PER_SYNC.invokeExact(ptr(), size.toBytes());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setBytesPerSync failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured bytes-per-sync interval.
+	///
+	/// @return current bytes-per-sync interval
+	public MemorySize getBytesPerSync() {
+		try {
+			return MemorySize.ofBytes((long) MH_GET_BYTES_PER_SYNC.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getBytesPerSync failed", t);
+		}
+	}
+
+	/// If true, the periodic sync triggered by [#setBytesPerSync] blocks until the sync
+	/// actually completes instead of merely being requested. Default: `false`.
+	///
+	/// @param value `true` to block until each periodic sync completes
+	/// @return `this` for chaining
+	public EnvOptions setStrictBytesPerSync(boolean value) {
+		try {
+			MH_SET_STRICT_BYTES_PER_SYNC.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setStrictBytesPerSync failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether periodic syncs block until completion.
+	///
+	/// @return `true` if periodic syncs block until completion
+	public boolean getStrictBytesPerSync() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_STRICT_BYTES_PER_SYNC.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getStrictBytesPerSync failed", t);
+		}
+	}
+
+	/// If true, `fallocate` preallocates space without changing the file's reported size
+	/// (`FALLOC_FL_KEEP_SIZE` on Linux). Default: `true`.
+	///
+	/// @param value `true` to keep the reported file size unchanged when preallocating
+	/// @return `this` for chaining
+	public EnvOptions setFallocateWithKeepSize(boolean value) {
+		try {
+			MH_SET_FALLOCATE_WITH_KEEP_SIZE.invokeExact(ptr(), RocksDB.toByte(value));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setFallocateWithKeepSize failed", t);
+		}
+		return this;
+	}
+
+	/// Returns whether `fallocate` keeps the reported file size unchanged.
+	///
+	/// @return `true` if `fallocate` keeps the reported file size unchanged
+	public boolean getFallocateWithKeepSize() {
+		try {
+			return RocksDB.fromByte((byte) MH_GET_FALLOCATE_WITH_KEEP_SIZE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getFallocateWithKeepSize failed", t);
+		}
+	}
+
+	/// Readahead size used specifically for compaction reads (as opposed to regular reads).
+	/// Default: `0` (use the OS's own readahead heuristics).
+	///
+	/// @param size compaction readahead size
+	/// @return `this` for chaining
+	public EnvOptions setCompactionReadaheadSize(MemorySize size) {
+		try {
+			MH_SET_COMPACTION_READAHEAD_SIZE.invokeExact(ptr(), size.toBytes());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setCompactionReadaheadSize failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured compaction readahead size.
+	///
+	/// @return current compaction readahead size
+	public MemorySize getCompactionReadaheadSize() {
+		try {
+			return MemorySize.ofBytes((long) MH_GET_COMPACTION_READAHEAD_SIZE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getCompactionReadaheadSize failed", t);
+		}
+	}
+
+	/// Maximum buffer size used for writing to a single file before flushing to disk. Default:
+	/// `1 MB`.
+	///
+	/// @param size maximum write buffer size
+	/// @return `this` for chaining
+	public EnvOptions setWritableFileMaxBufferSize(MemorySize size) {
+		try {
+			MH_SET_WRITABLE_FILE_MAX_BUFFER_SIZE.invokeExact(ptr(), size.toBytes());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setWritableFileMaxBufferSize failed", t);
+		}
+		return this;
+	}
+
+	/// Returns the configured maximum write buffer size.
+	///
+	/// @return current maximum write buffer size
+	public MemorySize getWritableFileMaxBufferSize() {
+		try {
+			return MemorySize.ofBytes((long) MH_GET_WRITABLE_FILE_MAX_BUFFER_SIZE.invokeExact(ptr()));
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("getWritableFileMaxBufferSize failed", t);
+		}
+	}
+
+	/// Attaches a [RateLimiter] to throttle this file's I/O. `rateLimiter` remains owned by
+	/// the caller and can be shared across multiple `EnvOptions`/`Options`.
+	///
+	/// @param rateLimiter rate limiter to use; caller retains ownership
+	/// @return `this` for chaining
+	public EnvOptions setRateLimiter(RateLimiter rateLimiter) {
+		try {
+			MH_SET_RATE_LIMITER.invokeExact(ptr(), rateLimiter.ptr());
+		} catch (Throwable t) {
+			throw RocksDB.wrapInvokeFailure("setRateLimiter failed", t);
+		}
+		return this;
+	}
+
+	@Override
+	protected void tryClose(MemorySegment ptr) throws Throwable {
+		MH_DESTROY.invokeExact(ptr);
+	}
+}

--- a/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileWriter.java
+++ b/core/src/main/java/io/github/dfa1/rocksdbffm/SstFileWriter.java
@@ -28,10 +28,6 @@ import java.nio.file.Path;
 /// ```
 public final class SstFileWriter extends NativeObject {
 
-	/// `rocksdb_envoptions_t* rocksdb_envoptions_create(void);`
-	private static final MethodHandle MH_ENVOPTIONS_CREATE;
-	/// `void rocksdb_envoptions_destroy(rocksdb_envoptions_t* opt);`
-	private static final MethodHandle MH_ENVOPTIONS_DESTROY;
 	/// `rocksdb_sstfilewriter_t* rocksdb_sstfilewriter_create(const rocksdb_envoptions_t* env, const rocksdb_options_t* io_options);`
 	private static final MethodHandle MH_CREATE;
 	/// `void rocksdb_sstfilewriter_destroy(rocksdb_sstfilewriter_t* writer);`
@@ -50,12 +46,6 @@ public final class SstFileWriter extends NativeObject {
 	private static final MethodHandle MH_FILE_SIZE;
 
 	static {
-		MH_ENVOPTIONS_CREATE = NativeLibrary.lookup("rocksdb_envoptions_create",
-				FunctionDescriptor.of(ValueLayout.ADDRESS));
-
-		MH_ENVOPTIONS_DESTROY = NativeLibrary.lookup("rocksdb_envoptions_destroy",
-				FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
-
 		MH_CREATE = NativeLibrary.lookup("rocksdb_sstfilewriter_create",
 				FunctionDescriptor.of(ValueLayout.ADDRESS,
 						ValueLayout.ADDRESS, ValueLayout.ADDRESS));
@@ -98,18 +88,27 @@ public final class SstFileWriter extends NativeObject {
 		super(ptr);
 	}
 
-	/// Creates an SST file writer using the given DB options (comparator, compression, etc.).
+	/// Creates an SST file writer using the given DB options (comparator, compression, etc.)
+	/// and default file-I/O behavior.
 	///
 	/// @param options DB options that control comparator and compression for the SST file
 	/// @return a new [SstFileWriter]; caller must close it
 	public static SstFileWriter newSstFileWriter(Options options) {
+		try (EnvOptions envOptions = EnvOptions.newEnvOptions()) {
+			return newSstFileWriter(options, envOptions);
+		}
+	}
+
+	/// Creates an SST file writer using the given DB options (comparator, compression, etc.)
+	/// and file-I/O behavior. RocksDB copies `envOptions` internally; it may be closed after
+	/// this call.
+	///
+	/// @param options    DB options that control comparator and compression for the SST file
+	/// @param envOptions low-level file-I/O behavior (mmap/direct I/O, sync cadence, ...)
+	/// @return a new [SstFileWriter]; caller must close it
+	public static SstFileWriter newSstFileWriter(Options options, EnvOptions envOptions) {
 		try {
-			MemorySegment envOpts = (MemorySegment) MH_ENVOPTIONS_CREATE.invokeExact();
-			try {
-				return new SstFileWriter((MemorySegment) MH_CREATE.invokeExact(envOpts, options.ptr()));
-			} finally {
-				MH_ENVOPTIONS_DESTROY.invokeExact(envOpts);
-			}
+			return new SstFileWriter((MemorySegment) MH_CREATE.invokeExact(envOptions.ptr(), options.ptr()));
 		} catch (Throwable t) {
 			throw RocksDB.wrapInvokeFailure("sstfilewriter create failed", t);
 		}

--- a/core/src/test/java/io/github/dfa1/rocksdbffm/EnvOptionsTest.java
+++ b/core/src/test/java/io/github/dfa1/rocksdbffm/EnvOptionsTest.java
@@ -1,0 +1,198 @@
+package io.github.dfa1.rocksdbffm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnvOptionsTest {
+
+	@Test
+	void envOptions_allowsSstFileWriterReadWrite(@TempDir Path dir) {
+		// Given
+		Path sstPath = dir.resolve("data.sst");
+		try (var envOptions = EnvOptions.newEnvOptions()
+				     .setUseDirectWrites(false)
+				     .setAllowFallocate(true)
+				     .setBytesPerSync(MemorySize.ofMB(1))
+				     .setCompactionReadaheadSize(MemorySize.ofKB(64))
+				     .setWritableFileMaxBufferSize(MemorySize.ofMB(1));
+		     var opts = Options.newOptions();
+		     var writer = SstFileWriter.newSstFileWriter(opts, envOptions)) {
+			writer.open(sstPath);
+			writer.put("aaa".getBytes(), "val1".getBytes());
+			writer.finish();
+		}
+
+		// When
+		try (var db = RocksDB.openReadWrite(dir.resolve("db"))) {
+			db.ingestExternalFile(List.of(sstPath));
+			var result = db.get("aaa".getBytes());
+
+			// Then
+			assertThat(result).isEqualTo("val1".getBytes());
+		}
+	}
+
+	@Test
+	void setUseMmapReads_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setUseMmapReads(true)) {
+
+			// When
+			var result = envOptions.getUseMmapReads();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setUseMmapWrites_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setUseMmapWrites(true)) {
+
+			// When
+			var result = envOptions.getUseMmapWrites();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setUseDirectReads_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setUseDirectReads(true)) {
+
+			// When
+			var result = envOptions.getUseDirectReads();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setUseDirectWrites_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setUseDirectWrites(true)) {
+
+			// When
+			var result = envOptions.getUseDirectWrites();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setAllowFallocate_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setAllowFallocate(false)) {
+
+			// When
+			var result = envOptions.getAllowFallocate();
+
+			// Then
+			assertThat(result).isFalse();
+		}
+	}
+
+	@Test
+	void setFdCloexec_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setFdCloexec(false)) {
+
+			// When
+			var result = envOptions.getFdCloexec();
+
+			// Then
+			assertThat(result).isFalse();
+		}
+	}
+
+	@Test
+	void setBytesPerSync_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setBytesPerSync(MemorySize.ofMB(1))) {
+
+			// When
+			var result = envOptions.getBytesPerSync();
+
+			// Then
+			assertThat(result).isEqualTo(MemorySize.ofMB(1));
+		}
+	}
+
+	@Test
+	void setStrictBytesPerSync_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setStrictBytesPerSync(true)) {
+
+			// When
+			var result = envOptions.getStrictBytesPerSync();
+
+			// Then
+			assertThat(result).isTrue();
+		}
+	}
+
+	@Test
+	void setFallocateWithKeepSize_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setFallocateWithKeepSize(false)) {
+
+			// When
+			var result = envOptions.getFallocateWithKeepSize();
+
+			// Then
+			assertThat(result).isFalse();
+		}
+	}
+
+	@Test
+	void setCompactionReadaheadSize_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setCompactionReadaheadSize(MemorySize.ofKB(64))) {
+
+			// When
+			var result = envOptions.getCompactionReadaheadSize();
+
+			// Then
+			assertThat(result).isEqualTo(MemorySize.ofKB(64));
+		}
+	}
+
+	@Test
+	void setWritableFileMaxBufferSize_roundTrips() {
+		// Given
+		try (var envOptions = EnvOptions.newEnvOptions().setWritableFileMaxBufferSize(MemorySize.ofMB(2))) {
+
+			// When
+			var result = envOptions.getWritableFileMaxBufferSize();
+
+			// Then
+			assertThat(result).isEqualTo(MemorySize.ofMB(2));
+		}
+	}
+
+	@Test
+	void setRateLimiter_doesNotThrowAndCallerRetainsOwnership(@TempDir Path dir) {
+		// Given
+		try (var rateLimiter = RateLimiter.create(MemorySize.ofMB(10));
+		     var envOptions = EnvOptions.newEnvOptions().setRateLimiter(rateLimiter);
+		     var opts = Options.newOptions();
+		     var writer = SstFileWriter.newSstFileWriter(opts, envOptions)) {
+			writer.open(dir.resolve("rl.sst"));
+			writer.put("k".getBytes(), "v".getBytes());
+			writer.finish();
+
+			// When / Then -- rateLimiter is still open and usable after being shared here
+			assertThat(rateLimiter.ptr()).isNotNull();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

New wrapper for `rocksdb_envoptions_t`, previously completely unmapped (0 of 12 setters) despite already being used *internally* — `SstFileWriter` created a default `rocksdb_envoptions_t` via `rocksdb_envoptions_create()`/`_destroy()` purely as plumbing, with none of its tunables exposed.

Maps all 12: `useMmapReads`/`useMmapWrites`, `useDirectReads`/`useDirectWrites`, `allowFallocate`, `fdCloexec`, `bytesPerSync`/`strictBytesPerSync`, `fallocateWithKeepSize`, `compactionReadaheadSize`, `writableFileMaxBufferSize` (each with a getter except `rateLimiter`, setter-only in `c.h`).

**Ownership**: confirmed via `db/c.cc` that `rocksdb_sstfilewriter_create`'s C++ constructor takes `EnvOptions` by value — no `transferOwnership()` needed, same model as `Fifo`/`UniversalCompactionOptions` from #157. `setRateLimiter` mirrors `Options.setRateLimiter`'s existing shared-ownership pattern (a `shared_ptr` copy, not a handoff) — the caller keeps owning the `RateLimiter`.

**Reachability**: wired in via a new `SstFileWriter.newSstFileWriter(Options, EnvOptions)` overload, so this is actually usable end-to-end rather than mapped-but-unreachable — the existing single-arg overload still creates its own default `EnvOptions` internally, now via the new wrapper instead of raw `MethodHandle` calls duplicating the create/destroy plumbing.

Worth noting: `use_mmap_reads` specifically is the exact `EnvOptions` field behind the SIGBUS repro that led to #140/#144 earlier this session — this isn't a purely hypothetical gap.

## Test plan
- [x] `envOptions_allowsSstFileWriterReadWrite` — writes an SST via the new overload with several options configured, ingests it, reads back
- [x] Round-trip tests for every setter/getter pair
- [x] `setRateLimiter_doesNotThrowAndCallerRetainsOwnership` — confirms the shared-ownership model
- [x] Existing `SstFileWriterTest` (18 tests) still passes unchanged, confirming the single-arg overload's behavior didn't regress
- [x] `./mvnw -pl core -am test` — 1053 tests, 0 failures, 0 errors
- [x] `./mvnw javadoc:javadoc -pl core` — zero output