### PR TITLE
DO NOT MERGE: bisect surefire 3.6.0-M1 for Windows fork crash (#163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
+        # TEMPORARY: windows-only while bisecting dfa1/rocksdb-ffm#163; restore full matrix after.
+        os: [windows-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -51,3 +52,17 @@ jobs:
 
       - name: Build and test
         run: mvn --batch-mode verify -Pall-natives
+
+      # TEMPORARY: bisecting the surefire 3.5.6 -> 3.6.0 Windows fork crash
+      # (dfa1/rocksdb-ffm#163) against the 3.6.0-M1 milestone. Remove once diagnosed.
+      - name: Upload crash artifacts
+        if: always() && matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-crash-artifacts
+          path: |
+            **/hs_err_pid*.log
+            **/target/surefire-reports/*.dump*
+            **/target/surefire-reports/*.dumpstream
+          if-no-files-found: warn
+          retention-days: 3

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.6.0</version>
+					<version>3.6.0-M1</version>
 					<configuration>
 						<!-- @{argLine} expands to the JaCoCo agent arguments set by jacoco:prepare-agent
 						     when the coverage profile is active; empty otherwise. -->

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.5.6</version>
+					<version>3.6.0</version>
 					<configuration>
 						<!-- @{argLine} expands to the JaCoCo agent arguments set by jacoco:prepare-agent
 						     when the coverage profile is active; empty otherwise. -->


### PR DESCRIPTION
Temporary bisection PR: does the Windows fork crash from #163 already reproduce on maven-surefire-plugin 3.6.0-M1 (the only milestone between 3.5.6 and 3.6.0), or only in the final 3.6.0 release?

Will close once the result is captured. Not for merging.